### PR TITLE
A11y: Use PyData Theme's Sphinx Design Components to fix dark mode contrast

### DIFF
--- a/index.md
+++ b/index.md
@@ -69,7 +69,6 @@ Learn about our open peer review process
 :::{grid-item-card}
 :link: documentation/index
 :link-type: doc
-:class-header: bg-light
 
 ✨ Documentation Criteria & Recommendations ✨
 ^^^
@@ -83,7 +82,6 @@ commonly used in the scientific Python community.
 :::{grid-item-card}
 :link: package-structure-code/intro
 :link-type: doc
-:class-header: bg-light
 
 ✨ Python packaging tools & structure ✨
 ^^^
@@ -93,7 +91,6 @@ All of the modern tools discussed in this guide will help you build an efficient
 :::{grid-item-card}
 :link: CONTRIBUTING
 :link-type: doc
-:class-header: bg-light
 
 ✨ Want to contribute? ✨
 ^^^


### PR DESCRIPTION
In light mode, the card titles at https://www.pyopensci.org/python-package-guide/ has dark grey text on a light grey background:

<img width="922" alt="image" src="https://user-images.githubusercontent.com/1324225/227022629-9214eb6e-1341-4db4-8a78-e7d59fd34586.png">

The contrast is good, meeting both of [WCAG's AA and AAA accessibility guidelines](https://webaim.org/standards/wcag/):

<img width="230" alt="image" src="https://user-images.githubusercontent.com/1324225/227023195-24b1c736-aec2-4e31-a366-bfda5dc8800b.png">

However, in dark mode, we get a light grey text on a light grey background, making it hard to read:

<img width="930" alt="image" src="https://user-images.githubusercontent.com/1324225/227023858-bd79a29c-e2b0-407c-ac2c-fefd2ca690d8.png">

It has very low contrast, meeting neither level:

<img width="228" alt="image" src="https://user-images.githubusercontent.com/1324225/227024215-e1ac4250-50c4-47c9-90bc-0df1f9cec6d5.png">

In both cases, we're using Bootstrap's `bg-light` class for the background.

One fix would be to use a darker background in dark mode.

But the cards at https://pydata-sphinx-theme.readthedocs.io/en/latest/user_guide/web-components.html#cards don't have any special background colour for the panel titles, so shall we follow suit?

<img width="748" alt="image" src="https://user-images.githubusercontent.com/1324225/227024827-d95a0e67-2346-49fa-bc47-1eb2ae73197b.png">

<img width="733" alt="image" src="https://user-images.githubusercontent.com/1324225/227024791-a24658e0-a0e5-4467-814b-405856a41514.png">

If so, we get this:

<img width="934" alt="image" src="https://user-images.githubusercontent.com/1324225/227024710-0351441d-dd2b-428c-928b-e45b4f78fe76.png">

And:

<img width="936" alt="image" src="https://user-images.githubusercontent.com/1324225/227024886-136457b5-e368-4b4c-b696-3f245c14f969.png">
