### PR TITLE
fix: incorrect license specification

### DIFF
--- a/package-structure-code/pyproject-toml-python-package-metadata.md
+++ b/package-structure-code/pyproject-toml-python-package-metadata.md
@@ -44,14 +44,19 @@ build-back-end = "pdm.backend"
 [project]
 name = "examplePy"
 authors = [
-    {name = "Some Maintainer", email = "some-email@pyopensci.org"}
+    {name = "Some Maintainer", email = "some-email@pyopensci.org"},
 ]
-maintainers = [{name = "All the contributors"}]
-license = {text = "BSD 3-Clause"}
+maintainers = [
+    {name = "All the contributors"},
+]
 description = "An example Python package used to support Python packaging tutorials"
 keywords = ["pyOpenSci", "python packaging"]
 readme = "README.md"
-
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: OS Independent",
+]
 dependencies = [
     "dependency-package-name-1",
     "dependency-package-name-2",
@@ -85,14 +90,19 @@ build-back-end = "setuptools.build_meta"
 [project]
 name = "examplePy"
 authors = [
-    {name = "Some Maintainer", email = "some-email@pyopensci.org"}
+    {name = "Some Maintainer", email = "some-email@pyopensci.org"},
 ]
-maintainers = [{name = "All the contributors"}]
-license = {text = "BSD 3-Clause"}
+maintainers = [
+    {name = "All the contributors"},
+]
 description = "An example Python package used to support Python packaging tutorials"
 keywords = ["pyOpenSci", "python packaging"]
 readme = "README.md"
-
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: OS Independent",
+]
 dependencies = [
     "dependency-package-name-1",
     "dependency-package-name-2",


### PR DESCRIPTION
The `license` field is only for unusual licenses or noting modifications. The correct way to set the license is via Trove classifiers. Some backends (like flit-core) completely ignore the license field. This might change eventually (see [PEP 639](https://peps.python.org/pep-0639/)), but for now, the canonical place for license metadata is the trove classifiers (one and only way to do things, supports multiple licenses, etc).