### PR TITLE
Update conf.py file to reduce the number of items in the top header of our guide - fix for safari.

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -79,7 +79,7 @@ html_theme_options = {
         "image_light": "logo-light-mode.png",
         "alt_text": "pyOpenSci Python Package Guide. The pyOpenSci logo is a purple flower with pyOpenSci under it. The o in open sci is the center of the flower",
     },
-    "header_links_before_dropdown": 4,
+    "header_links_before_dropdown": 3,
     "use_edit_page_button": True,
     "show_toc_level": 1,
     # "navbar_align": "left",  # [left, content, right] For testing that the navbar items align properly


### PR DESCRIPTION
Move the the pyOpenSci home page link into the "More" dropdown