### PR TITLE
Increase dark mode contrast to meet WCAG requirements and other dark mode things

### DIFF
--- a/_static/pyos.css
+++ b/_static/pyos.css
@@ -1,3 +1,16 @@
+/* PyOS-specific vars :) */
+:root {
+    --pyos-color-primary: #703c87;
+    --pyos-color-secondary: #8045e5;
+    --pyos-color-secondary-highlight: #591bc2;
+    --pyos-color-tertiary: #A66C98;
+    --pyos-color-dark: #542568;
+    --pyos-color-light: #DAABCF;
+
+    /* Darkmode Adjustments*/
+    --pyos-dm-color-primary: #C483E0;
+}
+
 html, body {
     font-size: 1.0rem;
 }
@@ -37,8 +50,8 @@ h2, h3, h4 {
 h1 {
     margin-top: 10px;
     margin-bottom: 40px;
-    font-family: 'Itim'!important;
-    color: #542568;
+    font-family: 'Itim' !important;
+    color: var(--pyos-h1-color);
 }
 h2 {
     margin-top: 80px;
@@ -66,6 +79,16 @@ figcaption {
     font-size: .9em;
 }
 
+/* Navbar */
+/* 
+Don't fill all vertical space beneath TOC, which causes 
+readthedocs version selector to fall off the page and the
+ugly scrollbar to show all the time
+*/
+.bd-sidebar-primary .sidebar-primary-items__end {
+  margin-bottom: unset;
+  margin-top: unset;
+}
 
 /* Tutorial block page */
 .left-div {
@@ -139,7 +162,7 @@ figcaption {
 
 
 html[data-theme=light] {
-    --pst-color-primary: #703c87;
+    --pst-color-primary: var(--pyos-color-primary);
     --pst-color-primary-text: #fff;
     --pst-color-primary-highlight: #053f49;
     --sd-color-primary: var(--pst-color-primary);
@@ -147,9 +170,9 @@ html[data-theme=light] {
     --sd-color-primary-highlight: var(--pst-color-primary-highlight);
     --sd-color-primary-bg: #d0ecf1;
     --sd-color-primary-bg-text: #14181e;
-    --pst-color-secondary: #8045e5;
+    --pst-color-secondary: var(--pyos-color-secondary);
     --pst-color-secondary-text: #fff;
-    --pst-color-secondary-highlight: #591bc2;
+    --pst-color-secondary-highlight: var(--pyos-color-secondary-highlight);
     --sd-color-secondary: var(--pst-color-secondary);
     --sd-color-secondary-text: var(--pst-color-secondary-text);
     --sd-color-secondary-highlight: var(--pst-color-secondary-highlight);
@@ -165,5 +188,13 @@ html[data-theme=light] {
     --sd-color-success-bg-text: #14181e;
     --pst-color-info: #A66C98; /* general admonition */
     --pst-color-info-bg: #eac8e2;
-    --pst-heading-color: #542568;
+    --pst-heading-color: var(--pyos-color-dark);
+    --pyos-h1-color: var(--pyos-color-dark);
+}
+
+html[data-theme=dark] {
+    --pst-color-primary: var(--pyos-dm-color-primary);
+    --pst-color-link: var(--pyos-color-light);
+    --pst-color-link-hover: var(--pyos-dm-color-primary);
+    --pyos-h1-color: var(--pyos-color-light);
 }

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,7 +5,8 @@ import nox
 
 nox.options.reuse_existing_virtualenvs = True
 
-build_command = ["-b", "html", ".", "_build/html"]
+OUTPUT_DIR = "_build"
+build_command = ["-b", "html", ".", "/".join([OUTPUT_DIR, "/html"])]
 
 @nox.session
 def docs(session):
@@ -24,10 +25,30 @@ def docs_live(session):
         "build_assets",
         "tmp",
     ]
+    # Explicitly include custom CSS in each build since
+    # sphinx doesn't think _static files should change since,
+    # well, they're static.
+    # Include these as the final `filenames` argument
+    AUTOBUILD_INCLUDE = [
+        "_static/pyos.css"
+    ]
+
+    # ----------------
+    # Assemble command
     cmd = ["sphinx-autobuild"]
     for folder in AUTOBUILD_IGNORE:
         cmd.extend(["--ignore", f"*/{folder}/*"])
-    cmd.extend(build_command + session.posargs)
+    
+    cmd.extend(build_command)
+
+    # use positional arguments if we have them
+    if len(session.posargs) > 0:
+        cmd.extend(session.posargs)
+    # otherwise use default output and include directory
+    else:
+        cmd.extend(AUTOBUILD_INCLUDE)
+
+    # ----------------
     session.run(*cmd)
 
 docs_dir = os.path.join("_build", "html")


### PR DESCRIPTION
## Main Stuff

The light mode of the packaging guide has a lovely, consistent, white and purple theme. The dark mode leaves a lot of default variables in place, and importantly doesn't switch the H1 color which is a very dark purple (which looks lovely in light mode!) This PR nudges us towards a more consistent style across light and dark modes by extracting some of the colors used elsewhere in the custom css file and creating a set of pyos css variables to use as a palette, and then uses those in the dark mode! 

Currently the page looks like this:
<img width="1266" alt="Screen Shot 2023-12-05 at 7 58 48 PM" src="https://github.com/pyOpenSci/python-package-guide/assets/12961499/60fbc250-8764-4319-a72b-e4a4ca947eb7">

which is not great for accessibility since the contrast is so low, and the teal color is pretty grating against the purples. The contrast is beneath WCAG
<img width="966" alt="Screen Shot 2023-12-05 at 8 01 58 PM" src="https://github.com/pyOpenSci/python-package-guide/assets/12961499/a9081593-3e57-4911-8f8e-6678831b8add" alt="Foreground color #542568 and background color 13181e have a contrast ratio of 1.56:1">

So the after shot is like this: 

<img width="1270" alt="Screen Shot 2023-12-05 at 8 00 19 PM" src="https://github.com/pyOpenSci/python-package-guide/assets/12961499/b01fa8db-5408-4da5-86df-031c9b466641">

which is not perfect but is a step in the right direction.

<img width="968" alt="Screen Shot 2023-12-05 at 8 02 30 PM" src="https://github.com/pyOpenSci/python-package-guide/assets/12961499/9dea3724-9b3e-4503-a457-39c42d8d7b91"  alt="Foreground color #DAABCF and background color 13181e have a contrast ratio of 9.08:1">

---

## Other Stuff

### Navbar

There's a big pointless block beneath the navbar stuff, not sure what it it's supposed to do, but at the moment what it does is make a scrollbar always appear and makes the readthedocs version box slide off the page. So I set that things margin to "unset"

Before:
<img width="537" alt="Screen Shot 2023-12-05 at 8 09 22 PM" src="https://github.com/pyOpenSci/python-package-guide/assets/12961499/412c357d-eb56-4f11-95e9-c5c248d0c08f">

after:
<img width="393" alt="Screen Shot 2023-12-05 at 8 09 33 PM" src="https://github.com/pyOpenSci/python-package-guide/assets/12961499/c09f00ac-0802-40f1-bc3b-a3abc0a801dc">


### Nox Build

The sphinx-autobuild command doesn't copy static files unless you tell it to (same as sphinx), which was super annoying to work on the CSS with, so i added a section there to allow us to explicitly specify files, and then did that (which is overridable by passing positional arguments)


