### PR TITLE
[Proposal] Remove Google Tag

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -35,7 +35,6 @@ extensions = [
     "sphinx_copybutton",
     "sphinx.ext.intersphinx",
     "sphinx_sitemap",
-    "sphinxcontrib.gtagjs",
     "sphinxext.opengraph",
 ]
 
@@ -98,20 +97,11 @@ html_theme_options = {
     "footer_items": ["copyright"],
 }
 
-html_theme_options["analytics"] = {
-    "google_analytics_id": "UA-141260825-1",
-}
-
 html_context = {
     "github_user": "pyopensci",
     "github_repo": "python-package-guide",
     "github_version": "main",
 }
-
-# Add analytics to furo theme
-gtagjs_ids = [
-    "UA-141260825-1",
-]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,3 @@ sphinx-sitemap
 # Support for social / adds meta tags
 sphinxext-opengraph
 sphinx-inline-tabs
-# Support for GA
-sphinxcontrib-gtagjs


### PR DESCRIPTION
Currently the site embeds google analytics (twice actually, [once for the gtagjs extension](https://github.com/pyOpenSci/python-package-guide/blob/0f33652c7df5fb7c6711c156cdcd7efb3b74d8d2/conf.py#L112-L115) and [another for the pydata theme](https://github.com/pyOpenSci/python-package-guide/blob/0f33652c7df5fb7c6711c156cdcd7efb3b74d8d2/conf.py#L101)).

Elsewhere, we give a rather stringent standard for opt-in data collection: https://www.pyopensci.org/software-peer-review/about/package-scope.html#telemetry-user-informed-consent

I think we could stand to do the same on our websites, no?

There is another tracker, matomo, that still attempts to embed itself in the page: https://github.com/pyOpenSci/python-package-guide/blob/main/_static/matomo.js
so analytics needs managed, hopefully?

Making this PR as a proposal, let's lead the way out of the darkness of surveillance web <3