### PR TITLE
Fix: update project name and make year automated

### DIFF
--- a/_static/pyos.css
+++ b/_static/pyos.css
@@ -21,6 +21,13 @@
 /* anything related to the dark theme */
 html[data-theme="dark"] {
     --pst-color-info-bg: #400f59!important;
+    --pst-color-tbl-row: #2E2E2E!important;
+}
+
+/* anything related to the light theme */
+html[data-theme="light"] {
+    --pst-color-tbl-row: #f5f1ff!important;
+}
 }
 
 
@@ -330,4 +337,47 @@ aside.footnote {
     &:target {
       background-color: var(--pst-color-target);
     }
+  }
+
+
+.fa-circle-check {
+    color: #7BCDBA;
+}
+
+/* pyOpenSci table styles */
+
+.pyos-table {
+    & th.head, .pyos-table th.head.stub {
+    background-color: #33205C!important;
+
+    & p {
+        color: #fff
+    }
+}
+    & th.stub {
+        background-color: var(--pst-color-tbl-row);
+        font-weight: 500;
+      }
+    & td {
+        vertical-align: middle;
+        text-align: center;
+    }
+}
+
+
+/* Make the first column in a table a "header" like thing */
+
+
+/* Dark mode fix for tables */
+@media (prefers-color-scheme: dark) {
+    td:not(.row-header):nth-child(1) {
+      background-color: var(--pst-color-tbl-row); /* Adjust the dark mode color */
+      color: #ffffff; /* Adjust the text color for better contrast */
+      font-weight: 500;
+    }
+  }
+
+td, th {
+    border: 1px solid #ccc; /* Light gray border */
+    padding: 8px; /* Add some padding for better readability */
   }

--- a/conf.py
+++ b/conf.py
@@ -13,12 +13,17 @@
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
+from datetime import datetime
+
+current_year = datetime.now().year
+organization_name = "pyOpenSci"
+
 
 
 # -- Project information -----------------------------------------------------
 
-project = "python-package-guide"
-copyright = "2024, pyOpenSci"
+project = "pyOpenSci Python Package Guide"
+copyright = f"{current_year}, {organization_name}"
 author = "pyOpenSci Community"
 
 # The full version, including alpha/beta/rc tags

--- a/conf.py
+++ b/conf.py
@@ -14,6 +14,7 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 from datetime import datetime
+import subprocess
 
 current_year = datetime.now().year
 organization_name = "pyOpenSci"
@@ -26,8 +27,15 @@ project = "pyOpenSci Python Package Guide"
 copyright = f"{current_year}, {organization_name}"
 author = "pyOpenSci Community"
 
-# The full version, including alpha/beta/rc tags
-release = "0.1"
+# Get the latest Git tag - there might be a prettier way to do this but...
+try:
+    release_value = subprocess.check_output(["git", "describe", "--tags"]).decode("utf-8").strip()
+    release_value = release_value[:4]
+except subprocess.CalledProcessError:
+    release_value = "0.1"  # Default value in case there's no tag
+
+# Update the release value
+release = release_value
 
 # -- General configuration ---------------------------------------------------
 

--- a/tutorials/1-installable-code.md
+++ b/tutorials/1-installable-code.md
@@ -52,7 +52,11 @@ environment and shell on your computer.
 You are welcome to use any Python environment manager that you choose.
 If you are using Windows or are not familiar with Shell, you may want to check out the Carpentries shell lesson[^shell-lesson]. Windows users will likely need to configure a tool for any Shell and git related steps.
 
+:::{todo}
+When this lesson is published, unlink
 * [If you need guidance creating a Python environment, review this lesson](extras/1-create-environment.md) which walks you through creating an environment using both `venv` and `conda`.
+:::
+
 * If you aren't sure which environment manager to use and
 you are a scientist, we suggest that you use `conda`, particularly if you are working with spatial data.
 
@@ -292,8 +296,12 @@ For instance, a `build-system` table most often holds two (2) variables:
 2. `build-backend = `, which is used to define the specific build-backend name, (in this example we are using `hatchling.build`).
 
 TOML organizes data structures, defining relationships within a configuration
-file. You will learn more about the `pyproject.toml` format in the
+file.
+
+:::{todo}
+You will learn more about the `pyproject.toml` format in the
 [next lesson when you add additional metadata / information to this file.](5-pyproject-toml.md)
+:::
 
 ```toml
 # An example of the build-system table which contains two variables - requires and build-backend


### PR DESCRIPTION
This is a tiny pr that

* Creates a more reader friendly project name (ends up in the meta tags and social previews)
* Creates the copyright via an f-string so the year is always up to date.
* Grabs the release value from git tags. 

question - will that approach work in ci to get the tags that way? will we need to increase the fetch depth to ensure we already get a tag? Because we don't release often. 