### PR TITLE
Fix links

### DIFF
--- a/tests/index.md
+++ b/tests/index.md
@@ -38,7 +38,7 @@ package: unit tests, integration tests and end-to-end (or functional) tests. Lea
 
 ::::{grid-item}
 :::{card} ✨ Run tests locally ✨
-:link: test-types
+:link: run-tests
 :link-type: doc
 :class-card: left-aligned
 
@@ -49,7 +49,7 @@ of Python, then using an automation tool such as nox to run your tests is useful
 
 ::::{grid-item}
 :::{card} ✨ Run tests online (using CI) ✨
-:link: test-types
+:link: tests-ci
 :link-type: doc
 :class-card: left-aligned
 


### PR DESCRIPTION
Some of the info box links at https://www.pyopensci.org/python-package-guide/tests/index.html point to the same page.

The menu links look right.

(I've not tested this.)