### PR TITLE
Enh: add glossary

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -1,0 +1,12 @@
+# Glossary
+
+A glossary of common terms used throughout Jupyter Book.
+
+```{glossary}
+
+[sdist](#python-source-distribution)
+    A distribution that is cool.
+[wheel](#python-wheel)
+    A distribution that is cool.
+
+```

--- a/glossary.md
+++ b/glossary.md
@@ -3,7 +3,8 @@
 A glossary of common terms used throughout Jupyter Book.
 
 ```{glossary}
-
+[badges](#github-badges)
+    placeholder
 [sdist](#python-source-distribution)
     A distribution that is cool.
 [wheel](#python-wheel)

--- a/tutorials/1-installable-code.md
+++ b/tutorials/1-installable-code.md
@@ -3,6 +3,9 @@
 :og:title: Make your Python code installable so it can be used across projects
 ---
 
+How you call the glossary:
+{term}`sdist`
+
 # Make your Python code installable
 
 :::{admonition} What we previously covered
@@ -501,6 +504,8 @@ This is the content with links once the links are live we can uncomment this and
 * [Learn how to build your package distribution](6-publish-pypi.md) files (**sdist** and **wheel**) and publish to **test PyPI**.
 * Finally you will learn how to publish to **conda-forge** from **PyPI**.
 :::
+
+
 
 ## Footnotes
 


### PR DESCRIPTION
@kierisi it turns out that a glossary isn't an additional infra it's just a directive. 

To make sure terms highlight and link to the glossary you can use this syntax:

How you call the glossary:

{term}`sdist`

i had thought it might automagically pick up the terms each time we add one but that is not the case. we will have to add references to the thing defined in the glossary! but this should get us started! and you are welcome to submit a fresh PR if adding to this one feels like more work!! i didn't really do much here but figure out how work :) 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206399753784684