### PR TITLE
Fix: missing link to publish pypi lesson in  current landing page

### DIFF
--- a/index.md
+++ b/index.md
@@ -73,6 +73,7 @@ by the community now! Join our community review process or watch development of 
 
 * [What is a Python package?](/tutorials/intro)
 * [Make your code installable](/tutorials/1-installable-code)
+* [Publish your package to (test) PyPi](/tutorials/publish-pypi)
 * *How to add a README and LICENSE to support publication (coming next!)*
 * *How to add metadata to a pyproject.toml file for publication to PyPI.*
 


### PR DESCRIPTION
I missed adding the navigation link for the enw tutorial on the landing page in the already merged pr. this fixes that!