### PR TITLE
Description/Author formatting in `tutorials/pyproject-toml.md`

### DIFF
--- a/tutorials/pyproject-toml.md
+++ b/tutorials/pyproject-toml.md
@@ -176,7 +176,7 @@ The `description` is just a string like the other values you've set:
 # you can use """ for multiline strings like in python!
 
 description = """
-Tools that update the pyOpenSci contributor and review metadata 
+Tools that update the pyOpenSci contributor and review metadata
 that is posted on our website
 """
 ```
@@ -202,7 +202,7 @@ There is a quirk with PyPI for authors that have names but not emails in the pyp
 
 ```toml
 maintainers = [
-    { name = "Firstname lastname", email = "email@pyopensci.org" }, 
+    { name = "Firstname lastname", email = "email@pyopensci.org" },
     { name = "Firstname lastname" }
 ]
 ```
@@ -211,7 +211,7 @@ Then we suggest that you only provide names in your list of names to ensure that
 
 ```toml
 maintainers = [
-    { name = "Firstname lastname"}, 
+    { name = "Firstname lastname"},
     { name = "Firstname lastname" }
 ]
 ```
@@ -232,7 +232,7 @@ build-backend = "hatchling.build"
 name = "pyospackage"
 version = "0.1.0"
 description = """
-Tools that update the pyOpenSci contributor and review metadata 
+Tools that update the pyOpenSci contributor and review metadata
 that is posted on our website
 """
 authors = [
@@ -280,7 +280,7 @@ build-backend = "hatchling.build"
 name = "pyospackage"
 version = "0.1.0"
 description = """
-Tools that update the pyOpenSci contributor and review metadata 
+Tools that update the pyOpenSci contributor and review metadata
 that is posted on our website
 """
 authors = [
@@ -309,7 +309,7 @@ build-backend = "hatchling.build"
 name = "pyospackage"
 version = "0.1.0"
 description = """
-Tools that update the pyOpenSci contributor and review metadata 
+Tools that update the pyOpenSci contributor and review metadata
 that is posted on our website
 """
 authors = [
@@ -347,7 +347,7 @@ build-backend = "hatchling.build"
 name = "pyospackage"
 version = "0.1.0"
 description = """
-Tools that update the pyOpenSci contributor and review metadata 
+Tools that update the pyOpenSci contributor and review metadata
 that is posted on our website
 """
 authors = [
@@ -423,7 +423,7 @@ build-backend = "hatchling.build"
 name = "pyospackage"
 version = "0.1.0"
 description = """
-Tools that update the pyOpenSci contributor and review metadata 
+Tools that update the pyOpenSci contributor and review metadata
 that is posted on our website
 """
 authors = [
@@ -473,7 +473,7 @@ build-backend = "hatchling.build"
 name = "pyospackage"
 version = "0.1.0"
 description = """
-Tools that update the pyOpenSci contributor and review metadata 
+Tools that update the pyOpenSci contributor and review metadata
 that is posted on our website
 """
 authors = [
@@ -524,7 +524,7 @@ build-backend = "hatchling.build"
 name = "pyospackage"
 version = "0.1.0"
 description = """
-Tools that update the pyOpenSci contributor and review metadata 
+Tools that update the pyOpenSci contributor and review metadata
 that is posted on our website
 """
 authors = [


### PR DESCRIPTION
Currently, putting the author and maintainer all on one line makes it hard to read, and spill of the page even with the page maximized on my laptop - the example of the quirk is not visible :(

<img width="892" alt="Screenshot 2024-03-01 at 2 15 22 PM" src="https://github.com/lwasser/python-package-guide/assets/12961499/857e6510-5175-438b-9c9c-e8e02332e2c7">

<img width="884" alt="Screenshot 2024-03-01 at 2 15 39 PM" src="https://github.com/lwasser/python-package-guide/assets/12961499/2992ffcb-092e-47c0-818d-e04f7d950e8c">

Reformatted the author and description throughout so that it looks like this:
<img width="895" alt="Screenshot 2024-03-01 at 2 17 42 PM" src="https://github.com/lwasser/python-package-guide/assets/12961499/0fd5d48d-58e9-4346-adc3-9bbd9132499e">

I also
- Added a note on a "description" - there is already a nice note on the relationship between the TOML tables and arrays and python data objects, so I previewed that by saying "multiline strings are also the same" and otherwise the description doesn't get introduced
- Modified the authors and maintainers to illustrate the concept - two initial authors, but then one of them drops out and then we gain a new friend. I think them being the same is a lil confusing


