### PR TITLE
Fix: inconsistent headings

### DIFF
--- a/tutorials/1-installable-code.md
+++ b/tutorials/1-installable-code.md
@@ -258,7 +258,7 @@ pyospackage/
        ├── add_numbers.py
 ```
 
-## Step 3. Add code to your `add_numbers.py` module
+## Step 3: Add code to your `add_numbers.py` module
 
 If you are following along and making a Python package from scratch then you can add the code below to your `add_numbers.py` module. The function below adds two integers together and returns the result. Notice that the code below has a few features that we will review in future tutorials:
 
@@ -298,7 +298,7 @@ def add_num(a: int, b: int) -> int:
     return a + b
 ```
 
-## Step 4. Modify metadata in your `pyproject.toml` file
+## Step 4: Modify metadata in your `pyproject.toml` file
 
 Next, you will modify some of the metadata (information) that
 Hatch adds to your `pyproject.toml` file. You are
@@ -404,7 +404,7 @@ You will learn how to automate defining a package
 version using git tags in the version and release your package lesson.
 :::
 
-### Step 3: Adjust your project classifiers
+### Adjust project classifiers
 
 Hatch by default provides a list of classifiers that define what
 Python versions your package supports. While this won't impact your package build, let's remove some of them that you likely don't need.
@@ -464,7 +464,7 @@ Once you have your project metadata in the pyproject.toml file, you will
 rarely update it. In the next lesson you’ll add more metadata and structure to this file.
 :::
 
-## Step 5. Install your package locally
+## Step 5: Install your package locally
 
 At this point you should have:
 
@@ -564,7 +564,7 @@ pyosPackage                   0.1.0          /Users/yourusername/path/here/pyosP
 ...
 ```
 
-## 6. Test out your new package
+## Step 6: Test out your new package
 
 After installing your package, type “python” at the command prompt in your chosen terminal to start
 a Python session in your active Python environment.


### PR DESCRIPTION
This is a tiny pr that fixes headings in installable module tutorial to be consistent. 