### PR TITLE
Fix broken stuff 2 (and keep stuff unbroken)

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -42,7 +42,7 @@ jobs:
       run: python3 -m pip install nox
 
     - name: Build book
-      run: nox -s docs
+      run: nox -s docs-test
 
     # Save html as artifact
     - name: Save book html as artifact for viewing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,6 @@
+---
+orphan: true
+---
 # Contributing Guide for the Python open source software packaging book
 
 This is a community resource. We welcome contributions in the form of issues and/or pull requests to this guide.

--- a/conf.py
+++ b/conf.py
@@ -61,6 +61,7 @@ myst_enable_extensions = [
     "attrs_block",
 ]
 myst_heading_anchors = 3
+myst_footnote_transition = False
 
 # Sphinx_favicon is used now in favor of built in support
 # https://pypi.org/project/sphinx-favicon/

--- a/noxfile.py
+++ b/noxfile.py
@@ -16,6 +16,17 @@ def docs(session):
     cmd.extend(build_command + session.posargs)
     session.run(*cmd)
 
+@nox.session(name="docs-test")
+def docs_test(session):
+    """
+    Same as `docs`, but rebuild everything and fail on warnings for testing
+    """
+    session.install("-r", "requirements.txt")
+    cmd = ["sphinx-build"]
+    cmd.extend(['-W', '--keep-going', '-E', '-a'])
+    cmd.extend(build_command + session.posargs)
+    session.run(*cmd)
+
 
 @nox.session(name="docs-live")
 def docs_live(session):

--- a/tutorials/add-license-coc.md
+++ b/tutorials/add-license-coc.md
@@ -170,11 +170,11 @@ The `CODE_OF_CONDUCT.md` should be placed at the root of your project directory,
 That's it - you've now added a code of conduct to your package directory.
 
 :::{admonition} Additional Code of Conduct resources
+:class: note
 
 - [<i class="fa-brands fa-github"></i> Guide: `CODE_OF_CONDUCT.md` files](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-code-of-conduct-to-your-project)
 - [pyOpenSci package guide `CODE_OF_CONDUCT.md` overview](https://www.pyopensci.org/python-package-guide/documentation/repository-files/code-of-conduct-file.html)
 :::
-
 
 ## <i class="fa-solid fa-hands-bubbles"></i> Wrap up
 

--- a/tutorials/add-license-coc.md
+++ b/tutorials/add-license-coc.md
@@ -170,12 +170,11 @@ The `CODE_OF_CONDUCT.md` should be placed at the root of your project directory,
 That's it - you've now added a code of conduct to your package directory.
 
 :::{admonition} Additional Code of Conduct resources
-:class: note
 
 - [<i class="fa-brands fa-github"></i> Guide: `CODE_OF_CONDUCT.md` files](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-code-of-conduct-to-your-project)
 - [pyOpenSci package guide `CODE_OF_CONDUCT.md` overview](https://www.pyopensci.org/python-package-guide/documentation/repository-files/code-of-conduct-file.html)
-
 :::
+
 
 ## <i class="fa-solid fa-hands-bubbles"></i> Wrap up
 

--- a/tutorials/installable-code.md
+++ b/tutorials/installable-code.md
@@ -587,7 +587,9 @@ Type "help", "copyright", "credits" or "license" for more information.
 3
 ```
 
+
 :::{admonition} Installing packages from GitHub
+
 If you wish to share your code without publishing to PyPI you can
 always install packages directly from GitHub using the syntax:
 

--- a/tutorials/installable-code.md
+++ b/tutorials/installable-code.md
@@ -587,9 +587,7 @@ Type "help", "copyright", "credits" or "license" for more information.
 3
 ```
 
-
 :::{admonition} Installing packages from GitHub
-
 If you wish to share your code without publishing to PyPI you can
 always install packages directly from GitHub using the syntax:
 

--- a/tutorials/publish-conda-forge.md
+++ b/tutorials/publish-conda-forge.md
@@ -44,7 +44,7 @@ Anyone can submit a package to these channels however they must pass a technical
 
 [Learn more about conda channels here.](#about-conda)
 
-:::{figure-md} pypi-conda-channels
+:::{figure-md} pypi-conda-channels-2
 
 <img src="../images/python-pypi-conda-channels.png" alt="Graphic with the title Python package repositories. Below it says anything hosted on PyPI can be installed using pip install. Packaging hosted on a conda channel can be installed using conda install. Below that there are two rows. The top row says conda channels. Next to it are three boxes one with conda-forge, community maintained; bioconda and then default - managed by the Anaconda team. Below that there is a row that says PyPI servers. PyPI - anyone can publish to PyPI and test PyPI (a testbed server for you to practice)." width="700px">
 
@@ -228,7 +228,7 @@ where it saved the recipe file.
 
 Open the meta.yaml file. The finished `meta.yaml` file that grayskull creates should look like the example below:
 
-```yaml
+```yaml+jinja
 {% set name = "pyospackage" %}
 {% set version = "0.1.8" %}
 
@@ -421,7 +421,7 @@ This is also why we don't suggest you publish to conda-forge as a practice run.
 
 Once you create your pull request, a suite of CI actions will run that build and test the build of your package. A conda-forge maintainer will work with you to get your recipe in good shape and merged.
 
-:::{figure-md} pypi-conda-channels
+:::{figure-md} conda-forge-pr-build
 
 <img src="../images/conda-forge-staged-recipes-ci.png" alt="Image showing the 5 CI tasks that will run against your package in the GitHub interface after you'ce created a pull request. " width="700px">
 


### PR DESCRIPTION
previously, on fix broken stuff: https://github.com/pyOpenSci/python-package-guide/pull/192

on this episode: we add a `docs-test` nox command that fails on errors so we can keep stuff from getting broken <3.

the existing HTML checker is good for something, but it misses stuff like duplicate targets, lexer errors, etc.
