### PR TITLE
Fix: update link to coc

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -83,8 +83,8 @@ html_theme_options = {
             "name": "Peer Review Guide",
         },
         {
-            "url": "https://pyopensci.org/governance",
-            "name": "Governance",
+            "url": "https://pyopensci.org/handbook",
+            "name": "Handbook",
         },
     ],
     "icon_links": [


### PR DESCRIPTION
We have updated our governance link so it now lives at handbook/governance. This updates the link to be handbook rather than governance