### PR TITLE
Fix: Issue 201 - conda-forge tutorial learning objectives

### DIFF
--- a/tutorials/publish-conda-forge.md
+++ b/tutorials/publish-conda-forge.md
@@ -17,11 +17,10 @@ publish your package on conda-forge.
 
 In this lesson you will learn how to:
 
-- Pubishing your PyPI published repository to conda-forge
-- Fork and clone the conda-forge staged-recipes repository
-- Create conda-forge recipe for your package
-- Submit a pull request to the staged-recipes repository
-- Maintain your conda-forge feedstock
+- Create a conda-forge yaml recipe for your package using Grayskull
+- Submit the recipe (yaml file) to the conda-forge staged recipes repository as a pull request
+- Maintain your conda-forge package by creating new releases for your package on PyPI
+
 
 Once your package is on PyPI you can then easily publish it to conda-forge
 using the [grayskull](https://conda.github.io/grayskull/) tool. You do not need to build the package specifically

--- a/tutorials/publish-conda-forge.md
+++ b/tutorials/publish-conda-forge.md
@@ -17,9 +17,11 @@ publish your package on conda-forge.
 
 In this lesson you will learn how to:
 
-- How to build your package's sdist and wheel distributions
-- Setup an account on testPyPI (the process is similar for the real PyPI)
-- Publish your package to PyPI
+- Pubishing your PyPI published repository to conda-forge
+- Fork and clone the conda-forge staged-recipes repository
+- Create conda-forge recipe for your package
+- Submit a pull request to the staged-recipes repository
+- Maintain your conda-forge feedstock
 
 Once your package is on PyPI you can then easily publish it to conda-forge
 using the [grayskull](https://conda.github.io/grayskull/) tool. You do not need to build the package specifically


### PR DESCRIPTION
Addresses Issue 201 by updating the learning objectives of the publishing to conda-forge tutorial in `tutorials/publish-conda-forge.md`