### PR TITLE
Update text to reflect modern Hatch

### DIFF
--- a/package-structure-code/python-package-build-tools.md
+++ b/package-structure-code/python-package-build-tools.md
@@ -224,7 +224,7 @@ More than one maintainer? (bus factor)|✖|✖| ✖| ✅
 
 Notes:
 
-- _Hatch plans to support using other back-ends and dependency management in the future_
+- _Hatch plans to support dependency management in the future_
 - Poetry supports semantic versioning. Thus, it will support version bumping following commit messages if you use a tool such as Python Semantic Release
 
 ## PDM

--- a/package-structure-code/python-package-build-tools.md
+++ b/package-structure-code/python-package-build-tools.md
@@ -344,7 +344,7 @@ as building your documentation locally. This means that you could potentially dr
 :widths: 20,5,50
 :delim: "|"
 
-Use Other Build Backends|✅ | Switching out build back-ends is not currently an option with Hatch. However, this feature is planned for a future release.
+Use Other Build Backends|✅ |
 Dependency management|✖| Currently you have to add dependencies manually with Hatch. However a feature to support dependencies management may be added in a future release.
 Environment Management |✅ | Hatch supports Python virtual environments. If you wish to use other types of environments such as Conda, you will need to [install a plugin such as hatch-conda for conda support](https://github.com/OldGrumpyViking/hatch-conda).
 Publish to PyPI and test PyPI|✅|Hatch supports publishing to both test PyPI and PyPI

--- a/package-structure-code/python-package-build-tools.md
+++ b/package-structure-code/python-package-build-tools.md
@@ -224,7 +224,7 @@ More than one maintainer? (bus factor)|✖|✖| ✖| ✅
 
 Notes:
 
-- _Hatch plans to support dependency management in the future_
+- _Hatch plans to support using other back-ends and dependency management in the future_
 - Poetry supports semantic versioning. Thus, it will support version bumping following commit messages if you use a tool such as Python Semantic Release
 
 ## PDM
@@ -344,7 +344,7 @@ as building your documentation locally. This means that you could potentially dr
 :widths: 20,5,50
 :delim: "|"
 
-Use Other Build Backends|✅ |
+Use Other Build Backends|✅ | Switching out build back-ends is not currently an option with Hatch. However, this feature is planned for a future release.
 Dependency management|✖| Currently you have to add dependencies manually with Hatch. However a feature to support dependencies management may be added in a future release.
 Environment Management |✅ | Hatch supports Python virtual environments. If you wish to use other types of environments such as Conda, you will need to [install a plugin such as hatch-conda for conda support](https://github.com/OldGrumpyViking/hatch-conda).
 Publish to PyPI and test PyPI|✅|Hatch supports publishing to both test PyPI and PyPI


### PR DESCRIPTION
Support for building using other backends happened toward the end of 2023