### PR TITLE
Include missed update step pyproject.toml

### DIFF
--- a/tutorials/installable-code.md
+++ b/tutorials/installable-code.md
@@ -416,6 +416,7 @@ However, if you wish, you can clean it up a bit.
 To begin:
 
 * Remove support for Python 3.8
+* Within the `[project]` table, update `requires-python = ">3.8"` to `requires-python = ">3.9"`
 
 Since you are creating a pure Python package in this lesson,
 you can remove the following classifiers:


### PR DESCRIPTION
When users remove python versions from the classifiers table, they should update the requires-python language to reflect the python versions supported.