### PR TITLE
Replace usage of "Anaconda Cloud" in various contexts

### DIFF
--- a/documentation/repository-files/readme-file-best-practices.md
+++ b/documentation/repository-files/readme-file-best-practices.md
@@ -6,7 +6,7 @@ sees before they install your package.
 
 The README.md file is the landing page of:
 
-* Your package as it appears on a repository site such as PyPI or Anaconda
+* Your package as it appears on a repository site such as PyPI or Anaconda.org
 * Your package's GitHub repository
 
 Your README.md file is also used as a measure of package and community
@@ -68,7 +68,7 @@ README file for others to quickly browse.
 
 Some badges that you might consider adding to your README file include:
 
-* Current version of the package on PyPI / Anaconda Cloud
+* Current version of the package on PyPI / Anaconda.org
 
 Example: [![PyPI version shields.io](https://img.shields.io/pypi/v/pandera.svg)](https://pypi.org/project/pandera/)
 
@@ -114,7 +114,7 @@ file.
 ### ✔️ Installation instructions
 
 Include instructions for installing your package. If you have published
-the package on both PyPI and Anaconda Cloud be sure to include instructions for both.
+the package on both PyPI and Anaconda.org, be sure to include instructions for both.
 
 ### ✔️ Document any additional setup required
 

--- a/package-structure-code/publish-python-package-pypi-conda.md
+++ b/package-structure-code/publish-python-package-pypi-conda.md
@@ -4,7 +4,7 @@
 
 pyOpenSci requires that your package has an distribution that can be installed
 from a public community repository such as PyPI or a conda channel such as
-`bioconda` or `conda-forge` in the Anaconda.org.
+`bioconda` or `conda-forge` on Anaconda.org.
 
 Below you will learn more about the various publishing options for your Python
 package.

--- a/package-structure-code/publish-python-package-pypi-conda.md
+++ b/package-structure-code/publish-python-package-pypi-conda.md
@@ -1,10 +1,10 @@
-# Publishing Your Package In A Community Repository: PyPI or Anaconda Cloud
+# Publishing Your Package In A Community Repository: PyPI or Anaconda.org
 
 <!--todo: add as resource https://docs.conda.io/projects/conda/en/latest/glossary.html -->
 
 pyOpenSci requires that your package has an distribution that can be installed
 from a public community repository such as PyPI or a conda channel such as
-`bioconda` or `conda-forge` in the Anaconda cloud.
+`bioconda` or `conda-forge` in the Anaconda.org.
 
 Below you will learn more about the various publishing options for your Python
 package.
@@ -13,7 +13,7 @@ package.
 
 * Installing packages in the same environment using both pip and conda can
 lead to package conflicts.
-* To minimize conflicts for users who may be using conda (or pip) to manage local environments, consider publishing your package to both PyPI and the conda-forge channel of the Anaconda Cloud.
+* To minimize conflicts for users who may be using conda (or pip) to manage local environments, consider publishing your package to both PyPI and the conda-forge channel on Anaconda.org.
 
 Below you will learn more specifics about the differences between PyPI and conda publishing of your Python package.
 :::
@@ -57,13 +57,13 @@ your package.
 :::
 
 (about-conda)=
-## What is Anaconda Cloud and conda?
+## What is conda and Anaconda.org?
 
 conda is an open source package and environment management tool.
-conda can be used to install tools from the [Anaconda Cloud
+conda can be used to install tools from the [Anaconda
 repository](https://repo.anaconda.com/).
 
-Anaconda cloud (anaconda.org) contains public and private repositories for
+Anaconda.org contains public and private repositories for
 packages. These repositories are known as channels (discussed below).
 
 :::{admonition} A brief history of conda's evolution
@@ -95,12 +95,12 @@ channels. The conda package manager can install packages from different channels
 There are several core public channels that most people use to install
 packages using conda, including:
 
-- **defaults:** this is a channel managed by Anaconda. It is the version of the Python packages that you will install if you install the Anaconda Distribution. Anaconda decides what packages live on the default channel.
+- **defaults:** this is a channel managed by Anaconda. It is the version of the Python packages that you will install if you install the Anaconda Distribution. Anaconda (the company) decides what packages live on the `defaults` channel.
 - [**conda-forge:**](https://anaconda.org/conda-forge) this is a community-driven channel that focuses on scientific packages. This channel is ideal for tools that support geospatial data. Anyone can publish a package to this channel.
 - [**bioconda**](https://anaconda.org/bioconda): this channel focuses on biomedical tools.
 
 **conda-forge** emerged as many of the scientific packages did not
-exist in the default Anaconda cloud channel.
+exist in the `defaults` Anaconda channel.
 
 :::{figure-md} pypi-conda-channels
 

--- a/package-structure-code/python-package-structure.md
+++ b/package-structure-code/python-package-structure.md
@@ -147,7 +147,7 @@ If your package tests require data, we suggest that you do NOT include that
 data within your package structure. We will discuss this in more detail in a
 tutorial. Include data in your package structure increases the size of your
 distribution files. This places a maintenance toll on repositories like PyPI and
-anaconda cloud that have to deal with thousands of package uploads.
+Anaconda.org that have to deal with thousands of package uploads.
 ```
 
 ## About the flat Python package layout

--- a/tutorials/publish-conda-forge.md
+++ b/tutorials/publish-conda-forge.md
@@ -38,9 +38,9 @@ Once you have published both package distributions (the source distribution and 
 ## What is conda-forge?
 
 conda is an open source package and environment management tool that
-can be used to install tools from the different channels within the Anaconda Cloud repository.
+can be used to install tools from the different channels on Anaconda.org.
 
-You can think about a channel as a specific location where a group of packages are stored and can be installed from using a command such as `conda install packagename`. In the case of the Anaconda cloud channels, some of these channels such as the default channel, is managed by Anaconda (the company). Only Anaconda can decide what packages are available in the default channel. However, the conda-forge (and bioconda) channel are community-managed channels.
+You can think about a channel as a specific location where a group of packages are stored and can be installed from using a command such as `conda install packagename`. In the case of conda channels, some of these channels such as the `defaults` channel, is managed by Anaconda (the company). Only Anaconda can decide what packages are available in the `defaults` channel. However, the conda-forge (and bioconda) channel are community-managed channels.
 Anyone can submit a package to these channels however they must pass a technical review in the [staged-recipes GitHub repository](https://github.com/conda-forge/staged-recipes) to be published.
 
 [Learn more about conda channels here.](#about-conda)


### PR DESCRIPTION
The site that hosts community-built packages/channels (e.g., conda-forge & bioconda) packages is officially called "anaconda.org", not "Anaconda Cloud".  (The latter is a different Anaconda Inc product.)