### PR TITLE
Update github actions versions to current

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -46,7 +46,7 @@ jobs:
 
     # Save html as artifact
     - name: Save book html as artifact for viewing
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: book-html
         path: |

--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -15,10 +15,10 @@ jobs:
   build-test-book:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4q
 
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.9'
 

--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -31,7 +31,7 @@ jobs:
       run: echo "::set-output name=dir::$(pip cache dir)"
 
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}

--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -15,7 +15,7 @@ jobs:
   build-test-book:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Setup Python
       uses: actions/setup-python@v2

--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -15,7 +15,7 @@ jobs:
   build-test-book:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4q
+    - uses: actions/checkout@v4
 
     - name: Setup Python
       uses: actions/setup-python@v5


### PR DESCRIPTION
This PR fixes #237 and includes actions version updates for:

- upload-artifact
- cache
- setup-python
- checkout

They were done as separate commits and should be easy to pickoff if not all of them are needed or wanted.