### PR TITLE
Update version references in tutorial: 0.1.0 -> 0.1

### DIFF
--- a/tutorials/publish-pypi.md
+++ b/tutorials/publish-pypi.md
@@ -160,9 +160,9 @@ To build your package run `hatch build`:
 ```bash
 ➜ hatch build
 ──────────────── sdist ─────────────────
-dist/pyospackage-0.1.0.tar.gz
+dist/pyospackage-0.1.tar.gz
 ──────────────── wheel ─────────────────
-dist/pyospackage-0.1.0-py3-none-any.whl
+dist/pyospackage-0.1-py3-none-any.whl
 
 ```
 
@@ -178,9 +178,9 @@ your package to conda-forge](publish-conda-forge). You will learn about this in 
 :::{todo}
 ➜ hatch build
 ────────────────────────────────────── sdist ──────────────────────────────────────
-dist/pyospackage-0.1.0.tar.gz
+dist/pyospackage-0.1.tar.gz
 ────────────────────────────────────── wheel ──────────────────────────────────────
-dist/pyospackage-0.1.0-py3-none-any.whl
+dist/pyospackage-0.1-py3-none-any.whl
 :::
 
 ### <i class="fa-solid fa-wand-magic-sparkles"></i> Congratulations - you've created your Python package distribution files <i class="fa-solid fa-wand-magic-sparkles"></i>
@@ -269,8 +269,8 @@ TestPyPI.
 ❯ hatch publish -r test
 Enter your username: __token__
 Enter your credentials: <paste-your-token-value-here>
-dist/pyospackage-0.1.0-py3-none-any.whl ... already exists
-dist/pyospackage-0.1.0.tar.gz ... already exists
+dist/pyospackage-0.1-py3-none-any.whl ... already exists
+dist/pyospackage-0.1.tar.gz ... already exists
 
 ```
 

--- a/tutorials/publish-pypi.md
+++ b/tutorials/publish-pypi.md
@@ -113,7 +113,7 @@ Package         Version      Editable project location
 numpy           1.26.3
 pandas          2.1.4
 pip             23.3.1
-pyosPackage     0.1.0        /path/to/your/project/here/pyosPackage
+pyosPackage     0.1          /path/to/your/project/here/pyosPackage
 python-dateutil 2.8.2
 pytz            2023.3.post1
 six             1.16.0

--- a/tutorials/pyproject-toml.md
+++ b/tutorials/pyproject-toml.md
@@ -688,7 +688,7 @@ You are now ready to publish a new version of your Python package to (test) PyPI
 Try to republish now.
 
 First, update the version of your package in your pyproject toml file. Below version is updated from
-`0.1` to `0.2`.
+`0.1` to `0.1.1`.
 
 ```TOML
 [build-system]
@@ -697,7 +697,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyospackage"
-version = "0.2"
+version = "0.1.1"
 ```
 
 Now use hatch to publish the new version of your package to test.PyPI.org.

--- a/tutorials/pyproject-toml.md
+++ b/tutorials/pyproject-toml.md
@@ -697,7 +697,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyospackage"
-version = "0.1.1"
+version = "0.2"
 ```
 
 Now use hatch to publish the new version of your package to test.PyPI.org.

--- a/tutorials/pyproject-toml.md
+++ b/tutorials/pyproject-toml.md
@@ -78,7 +78,7 @@ The pyproject.toml file tells your build tool:
 
 - What build backend to use to build your package (we are using `hatchling` in this tutorial but there are [many others to choose from](/package-structure-code/python-package-build-tools)).
 - How and where to retrieve your package's version:
-    - **statically** where you declare the version `version = "0.1.0"` or
+    - **statically** where you declare the version `version = "0.1"` or
     - **dynamically** where the tool looks to the most recent tag in your history to determine the current version.
 - What dependencies your package needs
 - What versions of Python your package supports (important for your users).
@@ -139,7 +139,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyospackage"
-version = "0.1.0"
+version = "0.1"
 ```
 
 Your next step is to add additional recommended metadata fields that will both
@@ -161,7 +161,7 @@ After completing the [installable code tutorial](installable-code), you should h
 ```toml
 [project]
 name = "pyospackage"
-version = "0.1.0"
+version = "0.1"
 ```
 
 Add the following to your table:
@@ -230,7 +230,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyospackage"
-version = "0.1.0"
+version = "0.1"
 description = """
 Tools that update the pyOpenSci contributor and review metadata
 that is posted on our website
@@ -278,7 +278,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyospackage"
-version = "0.1.0"
+version = "0.1"
 description = """
 Tools that update the pyOpenSci contributor and review metadata
 that is posted on our website
@@ -310,7 +310,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyospackage"
-version = "0.1.0"
+version = "0.1"
 description = """
 Tools that update the pyOpenSci contributor and review metadata
 that is posted on our website
@@ -382,7 +382,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyospackage"
-version = "0.1.0"
+version = "0.1"
 description = """
 Tools that update the pyOpenSci contributor and review metadata
 that is posted on our website
@@ -457,7 +457,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyospackage"
-version = "0.1.0"
+version = "0.1"
 description = """
 Tools that update the pyOpenSci contributor and review metadata
 that is posted on our website
@@ -507,7 +507,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyospackage"
-version = "0.1.0"
+version = "0.1"
 description = """
 Tools that update the pyOpenSci contributor and review metadata
 that is posted on our website
@@ -558,7 +558,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyospackage"
-version = "0.1.0"
+version = "0.1"
 description = """
 Tools that update the pyOpenSci contributor and review metadata
 that is posted on our website
@@ -614,7 +614,7 @@ build-backend = "hatchling.build"
 [project]
 name = "pyospackage"
 # dynamic = ["version"] # you will learn how to dynamically set the version in a future lesson
-version = "0.1.0" # manually assign version (not preferred)
+version = "0.1" # manually assign version (not preferred)
 description = "Tools that update the pyOpenSci contributor and review metadata that is posted on our website"
 authors = [{ name = "Firstname lastname", email = "email@pyopensci.org" }]
 
@@ -688,7 +688,7 @@ You are now ready to publish a new version of your Python package to (test) PyPI
 Try to republish now.
 
 First, update the version of your package in your pyproject toml file. Below version is updated from
-`0.1.0` to `0.1.1`.
+`0.1` to `0.2`.
 
 ```TOML
 [build-system]


### PR DESCRIPTION
Updated _most_ remaining references to version from three number to two number versions:
- `0.1.0` -> `0.1`
- `0.1.1` -> `0.2`

I did not touch the following. Let me know if that is desired:
1) References to version in example shell output because I'm not 100% sure if that would change; I suspect it would , but would like to confirm. e.g. `dist/pyospackage-0.1.0.tar.gz` etc. in `publish-pypi.md`
2) Reference inside an image alt text, where I suspect the alt text should correctly describe the image (also in `publish-pypi.md`)
3) References outside of `tutorials/`

(Continuation of #257)