### PR TITLE
Always use `python -m` with pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To build, follow these steps:
 1. Install `nox`
 
    ```console
-   $ pip install nox
+   $ python -m pip install nox
    ```
 2. Build the documentation:
 

--- a/package-structure-code/code-style-linting-format.md
+++ b/package-structure-code/code-style-linting-format.md
@@ -315,7 +315,7 @@ To setup pre-commit locally, you need to do 3 things:
 1. Install pre-commit (and include it as a development requirement in your repository)
 
 ```sh
-pip install pre-commit
+python -m pip install pre-commit
 
 # or
 

--- a/package-structure-code/declare-dependencies.md
+++ b/package-structure-code/declare-dependencies.md
@@ -336,11 +336,11 @@ If you want to support conda users, you may want to also maintain a conda enviro
 ```{admonition} A note for conda users
 :class: tip
 
-If you use a conda environment for developing your tool, keep in mind that when you install your package using `pip install -e .` (or using pip in general), dependencies will be installed from PyPI rather than conda.
+If you use a conda environment for developing your tool, keep in mind that when you install your package using `python -m pip install -e .` (or using pip in general), dependencies will be installed from PyPI rather than conda.
 
 Thus, if you are running a conda environment, installing your package in "editable" mode risks dependency conflicts. This is particularly important if you have a spatial package that requires geospatial system libraries like GDAL or another system-level dependency.
 
-Alternatively, you can install your package using `pip install -e . --no-deps` to only install the package. And install the rest of your dependencies using a conda environment file.
+Alternatively, you can install your package using `python -m pip install -e . --no-deps` to only install the package. And install the rest of your dependencies using a conda environment file.
 ```
 
 ## Dependencies in Read the Docs

--- a/package-structure-code/pyproject-toml-python-package-metadata.md
+++ b/package-structure-code/pyproject-toml-python-package-metadata.md
@@ -168,7 +168,7 @@ what dependencies your package requires.
 
 - **dependencies:** dependencies are optional but we strongly suggest you include them in your pyproject.toml. Dependencies will be installed by pip when your project is installed creating a better user-experience.
 
-- **`[project.optional-dependencies]`:** the optional or development dependencies will be installed if someone runs `pip install projectname[dev]`. This is a nice way to include your development dependencies for users who may wish to contribute to your project.
+- **`[project.optional-dependencies]`:** the optional or development dependencies will be installed if someone runs `python -m pip install projectname[dev]`. This is a nice way to include your development dependencies for users who may wish to contribute to your project.
 
 - **keywords:** These are the keywords that will appear on your PyPI landing page. Think of them as words that people might use to search for your package.
 - **classifiers:** The classifiers section of your metadata is also important for the landing page of your package in PyPI and for filtering of packages in PyPI. A list of [all options for classifiers can be found her](https://PyPI.org/classifiers/)e. Some of the classifiers that you should consider including
@@ -201,13 +201,13 @@ Then specify dependency groups as follows:
 
 Following the above example, you install dependencies like this:
 
-- `pip install -e .[tests]`
+- `python -m pip install -e .[tests]`
 
 The above will install both your package in editable mode and all of the dependencies declared in the tests section of your `[project.optional-dependencies]` table.
 
 To install all dependencies and also your package, you'd use:
 
-`pip install -e .[tests,lint,docs]`
+`python -m pip install -e .[tests,lint,docs]`
 
 :::{admonition} Recursive dependencies
 :class: tip

--- a/package-structure-code/python-package-build-tools.md
+++ b/package-structure-code/python-package-build-tools.md
@@ -308,7 +308,7 @@ Install your package in editable mode|✅| Flit supports installing your package
 Build your sdist and wheel distributions|✅| Flit can be used to build your packages sdist and wheel distributions.
 ```
 
-NOTE: _If you are using the most current version of pip, it supports both a symlink approach `flit install -s` and `pip install -e .`_
+NOTE: _If you are using the most current version of pip, it supports both a symlink approach `flit install -s` and `python -m pip install -e .`_
 
 ```{admonition} Learn more about flit
 * [Why use flit?](https://flit.pypa.io/en/stable/rationale.html)
@@ -351,7 +351,7 @@ Publish to PyPI and test PyPI|✅|Hatch supports publishing to both test PyPI an
 Version Control based versioning|✅ | Hatch offers `hatch_vcs` which is a plugin that uses setuptools_scm to support versioning using git tags. The workflow with `hatch_vcs` is the same as that with `setuptools_scm`.
 Version bumping| ✅ | Hatch supports you bumping the version of your package using standard semantic version terms patch; minor; major
 Follows current packaging standards|✅|Hatch supports current packaging standards for adding metadata to the **pyproject.toml** file.
-Install your package in editable mode|✅| Hatch will install your package into any of its environments by default in editable mode. You can install your package in editable mode manually using `pip install -e .` Hatch mentions [editable installs](https://hatch.pypa.io/latest/config/build/#dev-mode) but refers to pip in its documentation.
+Install your package in editable mode|✅| Hatch will install your package into any of its environments by default in editable mode. You can install your package in editable mode manually using `python -m pip install -e .` Hatch mentions [editable installs](https://hatch.pypa.io/latest/config/build/#dev-mode) but refers to pip in its documentation.
 Build your sdist and wheel distributions|✅| Hatch will build the sdist and wheel distributions
 ✨Matrix environment creation to support testing across Python versions✨|✅| The matrix environment creation is a feature that is unique to Hatch in the packaging ecosystem. This feature is useful if you wish to test your package locally across Python versions (instead of using a tool such as tox).
 ✨[Nox / MAKEFILE like functionality](https://hatch.pypa.io/latest/environment/#selection)✨| ✅| This feature is also unique to Hatch. This functionality allows you to create workflows in the **pyproject.toml** configuration to do things like serve docs locally and clean your package build directory. This means you may have one less tool in your build workflow.

--- a/tutorials/add-readme.md
+++ b/tutorials/add-readme.md
@@ -89,7 +89,7 @@ Remember that the more people understand what your package does, the more people
 Next, add instructions that tell users how to install your package.
 
 For example, can they use pip to install your package?
-`pip install packagename`
+`python -m pip install packagename`
 
 or conda?
 
@@ -202,7 +202,7 @@ Short description here using non-technical language that describes what your pac
 
 To install this package run:
 
-`pip install pyosPackage`
+`python -m pip install pyosPackage`
 
 ## OPTIONAL - if you have additional setup instructions add them here. if not, skip this section.
 

--- a/tutorials/installable-code.md
+++ b/tutorials/installable-code.md
@@ -140,7 +140,7 @@ If you try to pip install a package with no `pyproject.toml` you will get the fo
 
 ```bash
 GitHub/pyospackage/testme
-➜ pip install .
+➜ python -m pip install .
 ERROR: Directory '.' is not installable.
 Neither 'setup.py' nor 'pyproject.toml' found.
 ```
@@ -527,12 +527,12 @@ Obtaining file:///Users/leahawasser/Documents/GitHub/pyos/pyosPackage
 # use pip list instead of conda list here if you are working in an venv environment rather than a conda envt
 ```
 
-:::{admonition}  What does `pip install -e .` do?
+:::{admonition}  What does `python -m pip install -e .` do?
 :class: tip
 
-Let's break down `pip install -e .`
+Let's break down `python -m pip install -e .`
 
-`pip install -e .` installs your package into the current active
+`python -m pip install -e .` installs your package into the current active
 Python environment in **editable mode** (`-e`). Installing your package in
 editable mode, allows you to work on your code and then test the updates
 interactively in your favorite Python interface. One important caveat of editable mode is that every time you update your code, you may need to restart Python.
@@ -606,7 +606,7 @@ If you wish to share your code without publishing to PyPI you can
 always install packages directly from GitHub using the syntax:
 
 ```bash
-pip install git+https://github.com/user/repo.git@branch_or_tag
+python -m pip install git+https://github.com/user/repo.git@branch_or_tag
 ```
 
 To make your package GitHub installable, you can:
@@ -618,7 +618,7 @@ To make your package GitHub installable, you can:
 For instance below you install the pyospackage from the main branch of the
 pyOpenSci repository.
 
-`pip install git+https://github.com/user/repo.git@branch_or_tag`
+`python -m pip install git+https://github.com/user/repo.git@branch_or_tag`
 
 :::
 

--- a/tutorials/publish-conda-forge.md
+++ b/tutorials/publish-conda-forge.md
@@ -110,7 +110,7 @@ Note - this is a tutorial aimed to help you get your package onto conda-forge. T
 First, [install grayskull](https://conda.github.io/grayskull/user_guide.html). You can install it using either pip:
 
 ```bash
-> pip install grayskull
+> python -m pip install grayskull
 ```
 
 or conda

--- a/tutorials/publish-pypi.md
+++ b/tutorials/publish-pypi.md
@@ -142,7 +142,7 @@ by default it uses venv[^venv] which is the default environment management tool 
 Hatch will:
 
 1. Create a new virtualenv (venv) that is located on your computer.
-2. Install your package into the environment in editable mode (similar to `pip install -e`). This means it installs both your project and your project's dependencies as declared in your pyproject.toml file.
+2. Install your package into the environment in editable mode (similar to `python -m pip install -e`). This means it installs both your project and your project's dependencies as declared in your pyproject.toml file.
 
 ## Step 2: Build your package's sdist and wheel distributions
 
@@ -308,7 +308,7 @@ As an example, [check out our pyOpenSci pyosPackage landing page on TestPyPI](ht
 the page has information about the current package version and also
 installation instructions as follows:
 
-`pip install -i https://test.pypi.org/simple/ pyosPackage`
+`python -m pip install -i https://test.pypi.org/simple/ pyosPackage`
 
 :::{important} Publishing to TestPyPI vs PyPI
 While you can install from TestPyPI it's not recommended that you publish to


### PR DESCRIPTION
I noticed some inconsistencies around how `pip` is invoked in the package guide, so I've gone through and made sure all pip commands are invoked with `python -m pip ...` as recommended in the guide here:
https://www.pyopensci.org/python-package-guide/package-structure-code/declare-dependencies.html#install-dependency-groups
![image](https://github.com/pyOpenSci/python-package-guide/assets/7882693/59f1f2f7-f1e0-47bb-b9ec-753666242f84)
