### PR TITLE
fix(ci): docs-test should be docs_test

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -42,7 +42,7 @@ jobs:
       run: python3 -m pip install nox
 
     - name: Build book
-      run: nox -s docs-test
+      run: nox -s docs_test
 
     # Save html as artifact
     - name: Save book html as artifact for viewing


### PR DESCRIPTION
Currently numerous pr's are failing because of a ci step that calls nox -s docs-test. it should actually be docs_test if you look at the noxfile in this repo. this should fix the current issues but let's see if CI runs or fails!