### PR TITLE
docs: set Bot configuration `contributorsSortAlphabetically` True

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -5,6 +5,7 @@
   "imageSize": 100,
   "commit": false,
   "commitConvention": "angular",
+  "contributorsSortAlphabetically": true,
   "contributors": [
     {
       "login": "eriknw",


### PR DESCRIPTION
It is better to show contributors name alphabetically.

- [Bot Configuration](https://allcontributors.org/docs/en/bot/configuration)