### PR TITLE
docs: fix the Unicode apostrophe issue in markdown files

### DIFF
--- a/package-structure-code/python-package-distribution-files-sdist-wheel.md
+++ b/package-structure-code/python-package-distribution-files-sdist-wheel.md
@@ -78,7 +78,7 @@ Project metadata used to be stored in either a setup.py file or a setup.cfg file
 
 ### An example - xclim
 
-When you publish to PyPI, you will notice that each package has metadata listed. Let’s have a look at [xclim](https://pypi.org/project/xclim/), one of our [pyOpenSci packages](https://www.pyopensci.org/python-packages.html). Notice that on the PyPI landing page you see some metadata about the package including python, maintainer information and more. PyPI is able to populate this metadata because it was defined using correct syntax and classifiers by Xclim's maintainers, [pyproject.toml file](https://github.com/Ouranosinc/xclim/blob/master/pyproject.toml). This metadata when the xclim package is built, is translated into a distribution file that allows PyPI to read the metadata and print it out on their website.
+When you publish to PyPI, you will notice that each package has metadata listed. Let's have a look at [xclim](https://pypi.org/project/xclim/), one of our [pyOpenSci packages](https://www.pyopensci.org/python-packages.html). Notice that on the PyPI landing page you see some metadata about the package including python, maintainer information and more. PyPI is able to populate this metadata because it was defined using correct syntax and classifiers by Xclim's maintainers, [pyproject.toml file](https://github.com/Ouranosinc/xclim/blob/master/pyproject.toml). This metadata when the xclim package is built, is translated into a distribution file that allows PyPI to read the metadata and print it out on their website.
 
 ```{figure} ../images/python-build-package/pypi-metadata-classifiers.png
 :scale: 50 %

--- a/tutorials/installable-code.md
+++ b/tutorials/installable-code.md
@@ -80,7 +80,7 @@ To make your Python code installable you need to create a specific directory str
 - Some code.
 - An `__init__.py` file in your code directory.
 
-The directory structure you’ll create in this lesson will look like this:
+The directory structure you'll create in this lesson will look like this:
 
 ```bash
 pyospackage/  # Your project directory
@@ -118,7 +118,7 @@ import pyospackage
 
 The **pyproject.toml** file is:
 
-- Where you define your project’s metadata (including its name, authors, license, etc)
+- Where you define your project's metadata (including its name, authors, license, etc)
 - Where you define dependencies (the packages that it depends on)
 - Used to specify and configure what build backend you want to use to [build your package](../package-structure-code/python-package-distribution-files-sdist-wheel).
 
@@ -279,7 +279,7 @@ Python can support many different docstrings formats depending on the documentat
 
 **pyOpenSci recommends using the NumPy Docstring convention.**
 
-If you aren’t familiar with docstrings or typing yet, that is ok. You can review [this page in the pyOpenSci packaging guide](https://www.pyopensci.org/python-package-guide/documentation/write-user-documentation/document-your-code-api-docstrings.html) for an overview of both topics.
+If you aren't familiar with docstrings or typing yet, that is ok. You can review [this page in the pyOpenSci packaging guide](https://www.pyopensci.org/python-package-guide/documentation/write-user-documentation/document-your-code-api-docstrings.html) for an overview of both topics.
 
 ```python
 def add_num(a: int, b: int) -> int:
@@ -480,7 +480,7 @@ Source = "https://github.com/unknown/pyospackage"
 The core information that you need in a `pyproject.toml` file in order to publish on PyPI is your **package's name**  and the **version**. However, we suggest that you flesh out your metadata early on in the `pyproject.toml` file.
 
 Once you have your project metadata in the pyproject.toml file, you will
-rarely update it. In the next lesson you’ll add more metadata and structure to this file.
+rarely update it. In the next lesson you'll add more metadata and structure to this file.
 :::
 
 ## Step 5: Install your package locally

--- a/tutorials/pyproject-toml.md
+++ b/tutorials/pyproject-toml.md
@@ -40,7 +40,7 @@ When creating your pyproject.toml file, consider the following:
     * **name=**
     * **version=**
 3. You should add more metadata to the `[project]` table as it will make it easier for users to find your project on PyPI. And it will also make it easier for installers to understand how to install your package.
-3. When you are adding classifiers to the **[project]** table, only use valid values from [PyPI’s classifier page](https://PyPI.org/classifiers/). An invalid value here will raise an error when you build and publish your package on PyPI.
+3. When you are adding classifiers to the **[project]** table, only use valid values from [PyPI's classifier page](https://PyPI.org/classifiers/). An invalid value here will raise an error when you build and publish your package on PyPI.
 4. There is no specific order for tables in the `pyproject.toml` file. However, fields need to be placed within the correct tables. For example `requires =` always need to be in the **[build-system]** table.
 5. We suggest that you include your **[build-system]** table at the top of your `pyproject.toml` file.
 :::


### PR DESCRIPTION
The use of Unicode should be avoided unless necessary.