### PR TITLE
Fix mirror of the `prettier` npm package for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,8 +40,8 @@ repos:
     hooks:
       - id: vale
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.3.3
     hooks:
       - id: prettier
         types_or: [yaml, html, css, scss, javascript, json, toml]


### PR DESCRIPTION
Use https://github.com/rbubley/mirrors-prettier instead of https://github.com/pre-commit/mirrors-prettier in .pre-commit-config.yaml.

- https://learn.scientific-python.org/development/guides/style#PC180