### PR TITLE
Fix format of Spanish documentation.po file

### DIFF
--- a/locales/es/LC_MESSAGES/documentation.po
+++ b/locales/es/LC_MESSAGES/documentation.po
@@ -95,7 +95,7 @@ msgstr ""
 "nativa para Sphinx. rST ha sido la sintaxis por defecto para documentación "
 "durante muchos años. Sin embargo, recientemente myST ha aumentado en popularidad "
 "para convertirse en la herramienta favorita para documentación gracias a su
-flexibilidad."
+"flexibilidad."
 
 #: ../../documentation/hosting-tools/myst-markdown-rst-doc-syntax.md:9
 msgid ""


### PR DESCRIPTION
Fix missing double quote in Spanish version of documentation.po file.