### PR TITLE
docs: fix wrong word in section about conda repositories

### DIFF
--- a/package-structure-code/publish-python-package-pypi-conda.md
+++ b/package-structure-code/publish-python-package-pypi-conda.md
@@ -141,7 +141,7 @@ package repository. Thus environments that contain packages
 installed from both pip and conda are more likely to yield
 dependency conflicts.
 
-Similarly installing packages from the default anaconda package mixed with the conda-forge channel can also lead to dependency conflicts.
+Similarly installing packages from the default anaconda channel mixed with the conda-forge channel can also lead to dependency conflicts.
 
 Many install packages directly from conda `defaults` channel. However, because
 this channel is managed by Anaconda, the packages available on it are


### PR DESCRIPTION
Looks like this sentence should say "channel" instead of "package" in the section about conda and pip.