### PR TITLE
docs: Small clarification to avoid confusion

### DIFF
--- a/package-structure-code/intro.md
+++ b/package-structure-code/intro.md
@@ -115,7 +115,7 @@ In this section of our Python packaging guide, we:
 - Suggest tools and approaches that both meet your needs and also support
   existing standards.
 - Suggest tools and approaches that will allow you to expand upon a workflow
-  that may begin as a pure Python tool and evolve into a tool that requires
+  that may begin as a pure Python code and evolve into code that requires
   addition layers of complexity in the packaging build.
 - Align our suggestions with the most current, accepted
   [PEPs (Python Enhancement Protocols)](https://peps.python.org/pep-0000/)

--- a/package-structure-code/intro.md
+++ b/package-structure-code/intro.md
@@ -111,7 +111,7 @@ and for anyone who is just getting started with creating a Python package.
 In this section of our Python packaging guide, we:
 
 - Provide an overview of the options available to you when packaging your
-  tool.
+  code.
 - Suggest tools and approaches that both meet your needs and also support
   existing standards.
 - Suggest tools and approaches that will allow you to expand upon a workflow


### PR DESCRIPTION
Rephrase two sentences to avoid confusion with the use of the word tool: tool as the software that will be in the package and tool as the packaging tool that will be used to make the package.