### PR TITLE
docs: fix typo in documentation from Github to GitHub

### DIFF
--- a/documentation/repository-files/intro.md
+++ b/documentation/repository-files/intro.md
@@ -6,7 +6,7 @@ at a minimum have the following files:
 
 The files mentions above (README, Code of Conduct, license
 file, etc) are used as a measure of package community health
-on many online platforms. Below, you can see an example how Github
+on many online platforms. Below, you can see an example how GitHub
 evaluates community health. This community health link is available for
 all GitHub repositories.
 
@@ -21,7 +21,7 @@ GitHub community health looks for a readme file among other elements when it eva
 
 [Snyk](https://snyk.io/advisor/python) is another well-known company that
 keeps tabs on package health. Below you can see a similar evaluation of files
-in the Github repo as a measure of community health.
+in the GitHub repo as a measure of community health.
 
 ```{figure} /images/moving-pandas-python-package-snyk-health.png
 ---

--- a/index.md
+++ b/index.md
@@ -58,7 +58,7 @@ Publish your docs
 ```
 ## _new_ Tutorial Series: Create a Python Package
 
-The first round of our community-developed, how to create a Python package tutorial series for scientists is complete! Join our community review process or watch development of future tutorials in our [Github repo here](https://github.com/pyOpenSci/python-package-guide).
+The first round of our community-developed, how to create a Python package tutorial series for scientists is complete! Join our community review process or watch development of future tutorials in our [GitHub repo here](https://github.com/pyOpenSci/python-package-guide).
 
 
 :::::{grid} 1 1 2 2
@@ -187,7 +187,7 @@ Learn about best practices for:
 * [How to publish your docs](/documentation/hosting-tools/intro)
 * [Using Sphinx](/documentation/hosting-tools/intro)
 * [Markdown, MyST, and ReST](/documentation/hosting-tools/myst-markdown-rst-doc-syntax)
-* [Host your docs on Read The Docs or Github Pages](/documentation/hosting-tools/publish-documentation-online)
+* [Host your docs on Read The Docs or GitHub Pages](/documentation/hosting-tools/publish-documentation-online)
 :::
 ::::
 

--- a/tutorials/publish-pypi.md
+++ b/tutorials/publish-pypi.md
@@ -218,7 +218,7 @@ Example: `pyosPackage_yourNameHere`.
 
 #### Recommended
 
-- Update the Github repository name to align with the new package name
+- Update the GitHub repository name to align with the new package name
 - Update your local project folder to match the new package name (e.g. `pyospackage_yourNameHere/src`)
 - Update mentions of your repository name in other files (e.g. `README.md`)
 :::


### PR DESCRIPTION
Fix typo in documentation from Github to GitHub.