### PR TITLE
Remove option to reuse virtual-env for nox sessions

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -3,7 +3,6 @@ import pathlib
 import shutil
 import nox
 
-nox.options.reuse_existing_virtualenvs = True
 
 ## Sphinx related options
 


### PR DESCRIPTION
Fixes #419 

Removes the option to reuse the virtual environments for nox sessions from noxfile.py