### PR TITLE
fix: pass env to language session

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -95,10 +95,11 @@ favicons = [
     {"href": "https://www.pyopensci.org/images/favicon.ico"},
 ]
 
-html_baseurl = "/python-package-guide/"
+html_baseurl = "https://www.pyopensci.org/python-package-guide/"
+lang_selector_baseurl = "/python-package-guide/"
 if not sphinx_env == "production":
     # for links in language selector when developing locally
-    html_baseurl = "/"
+    lang_selector_baseurl = "/"
 
 html_theme_options = {
     "announcement": "<p><a href='https://www.pyopensci.org/about-peer-review/index.html'>We run peer review of scientific Python software. Learn more.</a></p>",
@@ -148,7 +149,7 @@ html_context = {
     "github_version": "main",
     "language": language,
     "languages": build_languages,
-    "baseurl": html_baseurl,
+    "baseurl": lang_selector_baseurl,
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/conf.py
+++ b/conf.py
@@ -95,7 +95,7 @@ favicons = [
     {"href": "https://www.pyopensci.org/images/favicon.ico"},
 ]
 
-html_baseurl = "https://www.pyopensci.org/python-package-guide/"
+html_baseurl = "/python-package-guide/"
 if not sphinx_env == "production":
     # for links in language selector when developing locally
     html_baseurl = "/"

--- a/noxfile.py
+++ b/noxfile.py
@@ -78,7 +78,7 @@ def docs_test(session):
                 env={'SPHINX_ENV': 'production'})
     # When building the guide with additional parameters, also build the translations in RELEASE_LANGUAGES
     # with those same parameters.
-    session.notify("build-release-languages", [*TEST_PARAMETERS, *session.posargs])
+    session.notify("build-release-languages", ["production", *TEST_PARAMETERS, *session.posargs])
 
 def _autobuild_cmd(posargs: list[str], output_dir = OUTPUT_DIR) -> list[str]:
     cmd = [SPHINX_AUTO_BUILD, *BUILD_PARAMETERS, str(SOURCE_DIR), str(output_dir), *posargs]
@@ -274,7 +274,6 @@ def build_release_languages(session):
     session.install("-e", ".")
     for lang in RELEASE_LANGUAGES:
         session.log(f"Building [{lang}] guide")
-        session.run(SPHINX_BUILD, *BUILD_PARAMETERS, "-D", f"language={lang}", ".", OUTPUT_DIR / lang, *session.posargs)
         if lang == 'en':
             out_dir = OUTPUT_DIR
         else:
@@ -328,6 +327,9 @@ def _sphinx_env(session) -> str:
     ``SPHINX_ENV`` environment variable, defaulting to "development"
     """
     if session.posargs and session.posargs[0] in SPHINX_ENVS:
-        return session.posargs.pop(0)
+        env = session.posargs.pop(0)
+        session.log(f"Using SPHINX_ENV={env} from posargs")
     else:
-        return os.environ.get('SPHINX_ENV', 'development')
+        env = os.environ.get('SPHINX_ENV', 'development')
+        session.log(f"Using SPHINX_ENV={env} from os.environ")
+    return env


### PR DESCRIPTION
Fix: #476 

simple enough - just passing the production env to the language building step.

<details>
<summary>edit: no longer true</summary>
changes the production baseurl to be the absolute path rather than the full URL - should be same behavior when deployed, but when testing locally it otherwise would have sent you to the live site rather than the local version.

since this session is intended for deployment, and in deployment we are under the `python-package-guide/` path, when previewing this you would need to move the build output from `_build/html` to `_build/html/python-package-guide` (if you are e.g. launching `http-server` from `_build/html`). this shoudln't be a problem in practice since you shouldn't need to directly preview the production build all that often, and the `docs-live-lang`/`s` envs are for development.
</details>

Since sphinx uses `html_baseurl` and we were overloading it, split out the lang selector base path in to a different variable.