### PR TITLE
Fix: catch 404s but ignore time out errors

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -68,4 +68,4 @@ jobs:
           directory: "_build/html"
           arguments: |
             --ignore-files "/.+\/_static\/.+/,/genindex.html/"
-            --ignore-status-codes "404, 403, 429, 503"
+            --ignore-status-codes "0, 403, 429, 503"


### PR DESCRIPTION
I think we should be catching 404s but ignoring timeout errors in CI. let's see if that helps