### PR TITLE
enh: adding a ``translation_stats.py`` file

### DIFF
--- a/_static/translation_stats.json
+++ b/_static/translation_stats.json
@@ -1,118 +1,118 @@
 {
-    "es": {
-        "continuous-integration": {
-            "total": 38,
-            "translated": 0,
-            "fuzzy": 0,
-            "untranslated": 38,
-            "percentage": 0.0
-        },
-        "CONTRIBUTING": {
-            "total": 124,
-            "translated": 0,
-            "fuzzy": 0,
-            "untranslated": 124,
-            "percentage": 0.0
-        },
-        "documentation": {
-            "total": 9,
-            "translated": 8,
-            "fuzzy": 1,
-            "untranslated": 0,
-            "percentage": 88.89
-        },
-        "index": {
-            "total": 14,
-            "translated": 11,
-            "fuzzy": 1,
-            "untranslated": 2,
-            "percentage": 78.57
-        },
-        "package-structure-code": {
-            "total": 131,
-            "translated": 126,
-            "fuzzy": 1,
-            "untranslated": 4,
-            "percentage": 96.18
-        },
-        "tests": {
-            "total": 1,
-            "translated": 0,
-            "fuzzy": 1,
-            "untranslated": 0,
-            "percentage": 0.0
-        },
-        "TRANSLATING": {
-            "total": 108,
-            "translated": 0,
-            "fuzzy": 0,
-            "untranslated": 108,
-            "percentage": 0.0
-        },
-        "tutorials": {
-            "total": 12,
-            "translated": 11,
-            "fuzzy": 1,
-            "untranslated": 0,
-            "percentage": 91.67
-        }
+  "es": {
+    "continuous-integration": {
+      "total": 38,
+      "translated": 0,
+      "fuzzy": 0,
+      "untranslated": 38,
+      "percentage": 0.0
     },
-    "ja": {
-        "continuous-integration": {
-            "total": 38,
-            "translated": 38,
-            "fuzzy": 0,
-            "untranslated": 0,
-            "percentage": 100.0
-        },
-        "CONTRIBUTING": {
-            "total": 124,
-            "translated": 124,
-            "fuzzy": 0,
-            "untranslated": 0,
-            "percentage": 100.0
-        },
-        "documentation": {
-            "total": 468,
-            "translated": 467,
-            "fuzzy": 1,
-            "untranslated": 0,
-            "percentage": 99.79
-        },
-        "index": {
-            "total": 14,
-            "translated": 11,
-            "fuzzy": 1,
-            "untranslated": 2,
-            "percentage": 78.57
-        },
-        "package-structure-code": {
-            "total": 87,
-            "translated": 86,
-            "fuzzy": 1,
-            "untranslated": 0,
-            "percentage": 98.85
-        },
-        "tests": {
-            "total": 1,
-            "translated": 0,
-            "fuzzy": 1,
-            "untranslated": 0,
-            "percentage": 0.0
-        },
-        "TRANSLATING": {
-            "total": 25,
-            "translated": 24,
-            "fuzzy": 1,
-            "untranslated": 0,
-            "percentage": 96.0
-        },
-        "tutorials": {
-            "total": 12,
-            "translated": 11,
-            "fuzzy": 1,
-            "untranslated": 0,
-            "percentage": 91.67
-        }
+    "CONTRIBUTING": {
+      "total": 124,
+      "translated": 0,
+      "fuzzy": 0,
+      "untranslated": 124,
+      "percentage": 0.0
+    },
+    "documentation": {
+      "total": 9,
+      "translated": 8,
+      "fuzzy": 1,
+      "untranslated": 0,
+      "percentage": 88.89
+    },
+    "index": {
+      "total": 14,
+      "translated": 11,
+      "fuzzy": 1,
+      "untranslated": 2,
+      "percentage": 78.57
+    },
+    "package-structure-code": {
+      "total": 131,
+      "translated": 126,
+      "fuzzy": 1,
+      "untranslated": 4,
+      "percentage": 96.18
+    },
+    "tests": {
+      "total": 1,
+      "translated": 0,
+      "fuzzy": 1,
+      "untranslated": 0,
+      "percentage": 0.0
+    },
+    "TRANSLATING": {
+      "total": 108,
+      "translated": 0,
+      "fuzzy": 0,
+      "untranslated": 108,
+      "percentage": 0.0
+    },
+    "tutorials": {
+      "total": 12,
+      "translated": 11,
+      "fuzzy": 1,
+      "untranslated": 0,
+      "percentage": 91.67
     }
+  },
+  "ja": {
+    "continuous-integration": {
+      "total": 38,
+      "translated": 38,
+      "fuzzy": 0,
+      "untranslated": 0,
+      "percentage": 100.0
+    },
+    "CONTRIBUTING": {
+      "total": 124,
+      "translated": 124,
+      "fuzzy": 0,
+      "untranslated": 0,
+      "percentage": 100.0
+    },
+    "documentation": {
+      "total": 468,
+      "translated": 467,
+      "fuzzy": 1,
+      "untranslated": 0,
+      "percentage": 99.79
+    },
+    "index": {
+      "total": 14,
+      "translated": 11,
+      "fuzzy": 1,
+      "untranslated": 2,
+      "percentage": 78.57
+    },
+    "package-structure-code": {
+      "total": 87,
+      "translated": 86,
+      "fuzzy": 1,
+      "untranslated": 0,
+      "percentage": 98.85
+    },
+    "tests": {
+      "total": 1,
+      "translated": 0,
+      "fuzzy": 1,
+      "untranslated": 0,
+      "percentage": 0.0
+    },
+    "TRANSLATING": {
+      "total": 25,
+      "translated": 24,
+      "fuzzy": 1,
+      "untranslated": 0,
+      "percentage": 96.0
+    },
+    "tutorials": {
+      "total": 12,
+      "translated": 11,
+      "fuzzy": 1,
+      "untranslated": 0,
+      "percentage": 91.67
+    }
+  }
 }

--- a/scripts/translation_stats.py
+++ b/scripts/translation_stats.py
@@ -57,7 +57,7 @@ def calculate_translation_percentage(po_path : Path, locale : str) -> dict:
 def main():
     # Get all .po files in the locales directory
     po_files = list(LOCALES_DIR.rglob("*.po"))
-    
+
     # Let's use a dictionary to store the results
     #
     # We will store the info as
@@ -83,20 +83,20 @@ def main():
     #        ...
     # }
     results = {}
-    
+
     # Calculate translation percentages for each file
     for po_file in po_files:
         # Get the locale from the file path
         locale = po_file.parent.parent.name
         stats = calculate_translation_percentage(po_file, locale)
         print(f"({po_file.stem}): {stats['percentage']}% translated ({stats['translated']} of {stats['total']})")
-        
+
         # Store the results in the dictionary
         if locale not in results:
             results[locale] = {}
-        
+
         results[locale][po_file.stem] = stats
-    
+
     # Dump the results to a JSON file
     with open(STATIC_DIR / "translation_stats.json", "w") as f:
         import json


### PR DESCRIPTION
Part of https://github.com/pyOpenSci/python-package-guide/issues/493

Setting up the script to extract the data and storing it in a JSON file for further postprocessing.