### PR TITLE
fix: styles in light mode in tables are white

### DIFF
--- a/_static/pyos.css
+++ b/_static/pyos.css
@@ -179,7 +179,7 @@ ugly scrollbar to show all the time
 
 html[data-theme="light"] {
   --pst-color-primary: var(--pyos-color-primary);
-  --pst-color-primary-text: #fff;
+  --pst-color-primary-text: #272424;
   --pst-color-primary-highlight: #053f49;
   --sd-color-primary: var(--pst-color-primary);
   --sd-color-primary-text: var(--pst-color-primary-text);
@@ -405,7 +405,7 @@ aside.footnote {
 /* Make the first column in a table a "header" like thing */
 
 /* Dark mode fix for tables */
-@media (prefers-color-scheme: dark) {
+@media (data-theme="dark") {
   td:not(.row-header):nth-child(1) {
     background-color: var(--pst-color-tbl-row); /* Adjust the dark mode color */
     color: #ffffff; /* Adjust the text color for better contrast */


### PR DESCRIPTION
This fixes the table on tools to be more readable in light mode
<img width="936" alt="Screenshot 2025-05-19 at 3 06 49 PM" src="https://github.com/user-attachments/assets/fa93296b-b922-4bea-a269-9619f25cd664" />


<img width="695" alt="Screenshot 2025-05-19 at 3 06 18 PM" src="https://github.com/user-attachments/assets/db51c4b7-72c3-472b-9130-167703280026" />
