### PR TITLE
PyPI source URL for conda recipes needs to use underscores instead of hyphens

### DIFF
--- a/tutorials/publish-conda-forge.md
+++ b/tutorials/publish-conda-forge.md
@@ -244,7 +244,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pyospackage-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name.replace('-', '_') }}/pyospackage-{{ version }}.tar.gz
   sha256: 43ec82da3a10752a5dbf2f0ef742e357803a3ddb400005f87e86534685bfb8a7
 
 build:

--- a/tutorials/publish-conda-forge.md
+++ b/tutorials/publish-conda-forge.md
@@ -244,7 +244,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name.replace('-', '_') }}/pyospackage-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
   sha256: 43ec82da3a10752a5dbf2f0ef742e357803a3ddb400005f87e86534685bfb8a7
 
 build:
@@ -397,7 +397,7 @@ If you want to learn more about static libraries, then [this overview](https://p
 
 ```bash
 source:
- url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pyospackage-{{ version }}.tar.gz
+ url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
  sha256: 01e31f5521973710d0d91b15a94491d4f8f8f54566322110098c0f2381dd09ab
 
 build:
@@ -411,7 +411,7 @@ build:
 **Translation:** Here conda wants you to provide a link to the source distribution on PyPI rather than a link to your GitHub repository distribution. Notice above in the Source section of your recipe there is a `url:` section that provides a PyPI url that ends in tar.gz. That is a link to your source distribution that conda-forge will use.
 
 ```yaml
-url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pyospackage-{{ version }}.tar.gz
+url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
 ```
 
 > - [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.


### PR DESCRIPTION
I had issues a while back publishing a package to conda forge with the distribution named `data-morph-ai`. It turned out that the PyPI source URL needed to be

```
https://pypi.org/packages/source/d/data-morph-ai/data_morph_ai-{{ version }}.tar.gz
```

instead of 

```
https://pypi.org/packages/source/d/data-morph-ai/data-morph-ai-{{ version }}.tar.gz
```