### PR TITLE
Get RSS `pubDate` from mtimes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,11 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Restore mtimes from git history
+          command: |
+            sudo apt-get install git-restore-mtime
+            git restore-mtime
+      - run:
           name: setup environment
           command: |
             pip install --upgrade pip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
       - run:
           name: Restore mtimes from git history
           command: |
+            sudo apt-get update
             sudo apt-get install git-restore-mtime
             git restore-mtime
       - run:

--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -16,6 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch_depth: 0
+
+      - name: Restore mtimes from git history
+        run: |
+          sudo apt-get install git-restore-mtime
+          git restore-mtime
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/_ext/rss.py
+++ b/_ext/rss.py
@@ -33,14 +33,25 @@ class RSSItem:
     def from_meta(cls, page_name: str, meta: dict, app: "Sphinx") -> "RSSItem":
         """Create from a page's metadata"""
         url = urljoin(app.config.html_baseurl, app.builder.get_target_uri(page_name))
+
         # purposely don't use `get` here because we want to error if these fields are absent
         return RSSItem(
             title=meta[":og:title"],
             description=meta[":og:description"],
-            date=datetime.fromisoformat(meta["date"]),
+            date=cls.get_date_updated(page_name, meta, app),
             author=meta.get(":og:author", "pyOpenSci"),
             url=url,
         )
+
+    @staticmethod
+    def get_date_updated(page_name: str, meta: dict, app: "Sphinx") -> datetime:
+        """if the page has an explicit date_updated, use that, otherwise get mtime"""
+        if 'date_updated' in meta:
+            return datetime.fromisoformat(meta['date_updated'])
+        else:
+            page_path = app.srcdir / (page_name + ".md")
+            mtime = page_path.stat().st_mtime
+            return datetime.fromtimestamp(mtime)
 
     def render(self) -> str:
         return f"""\

--- a/_ext/rss.py
+++ b/_ext/rss.py
@@ -72,7 +72,7 @@ class RSSFeed:
     title: str = "pyOpenSci Tutorials"
     link: str = "https://www.pyopensci.org/python-package-guide/tutorials/intro.html"
     self_link: str = "https://www.pyopensci.org/python-package-guide/tutorials.rss"
-    description: str = "Tutorials for learning python i guess!!!"
+    description: str = "A tutorial feed that lists metadata for the pyOpenSci Python packaging tutorials so we can automatically list them on our website."
     language: str = "en"
 
     def render(self) -> str:

--- a/tutorials/add-license-coc.md
+++ b/tutorials/add-license-coc.md
@@ -1,7 +1,6 @@
 ---
 :og:description: Learn how to add a LICENSE and CODE_OF_CONDUCT file to your Python package. This lesson covers choosing a permissive license, placing key files for visibility on GitHub and PyPI, and adopting the Contributor Covenant to support an inclusive community.
 :og:title: Add a License and Code of Conduct to your python package
-date: 1970-01-02
 ---
 
 # Add a `LICENSE` & `CODE_OF_CONDUCT` to your Python package

--- a/tutorials/add-readme.md
+++ b/tutorials/add-readme.md
@@ -1,7 +1,6 @@
 ---
 :og:description: Learn how to create a clear, effective README file for your Python package. This lesson covers what to include, why each section matters, and how a well-structured README improves usability and discoverability on GitHub and PyPI.
 :og:title: Add a README file to your Python package
-date: 1970-01-03
 ---
 
 # Add a README file to your Python package

--- a/tutorials/command-line-reference.md
+++ b/tutorials/command-line-reference.md
@@ -1,7 +1,6 @@
 ---
 :og:description: Learn how to add a command-line interface (CLI) to your Python package using the argparse library. This lesson walks you through creating a CLI entry point so users can run your package directly from the terminal.
 :og:title: Command Line Reference Guide
-date: 1970-01-04
 ---
 
 # Command Line Reference Guide

--- a/tutorials/get-to-know-hatch.md
+++ b/tutorials/get-to-know-hatch.md
@@ -1,7 +1,6 @@
 ---
 :og:description: Get started with Hatch, a modern Python packaging tool. This lesson introduces Hatch’s features and shows how it simplifies environment management, project scaffolding, and building your package.
 :og:title: Get to Know Hatch
-date: 1970-01-05
 ---
 
 # Get to Know Hatch

--- a/tutorials/installable-code.md
+++ b/tutorials/installable-code.md
@@ -1,7 +1,6 @@
 ---
 :og:description: Learn how to make your code installable as a Python package using Hatch. This lesson walks you through structuring your code and configuring pyproject.toml so others can easily install and use your package.
 :og:title: Make your Python code installable so it can be used across projects
-date: 1970-01-01
 ---
 
 # Make your Python code installable

--- a/tutorials/intro.md
+++ b/tutorials/intro.md
@@ -1,7 +1,6 @@
 ---
 :og:description: This page outlines the key steps to create, document, and share a high-quality scientific Python package. Here you will also get an overview of the pyOpenSci packaging guide and what you’ll learn.
 :og:title: Python packaging 101
-date: 1970-01-05
 ---
 
 (packaging-101)=

--- a/tutorials/publish-conda-forge.md
+++ b/tutorials/publish-conda-forge.md
@@ -1,7 +1,6 @@
 ---
 :og:description: Learn how to publish your Python package on conda-forge to make it easily installable with conda. This lesson covers the submission process, metadata requirements, and maintaining your feedstock.
 :og:title: Publish your Python package that is on PyPI to conda-forge
-date: 1970-01-06
 ---
 
 # Publish your Python package that is on PyPI to conda-forge

--- a/tutorials/publish-pypi.md
+++ b/tutorials/publish-pypi.md
@@ -1,7 +1,6 @@
 ---
 :og:description: Learn how to publish your Python package on PyPI so others can install it using pip. This lesson covers building your package, creating a PyPI account, and uploading your distribution files.
 :og:title: Publish your Python package to PyPI
-date: 1970-01-07
 ---
 
 # Publish your Python package to PyPI

--- a/tutorials/pyproject-toml.md
+++ b/tutorials/pyproject-toml.md
@@ -1,7 +1,6 @@
 ---
 :og:description: The pyproject.toml file is the central configuration file for building and packaging Python projects. This lesson explains key sections like name, version, dependencies, and how they support packaging and distribution. You’ll learn how to set up this file to ensure your package is ready for publishing.
 :og:title: Make your Python package PyPI ready - pyproject.toml
-date: 1970-01-08
 ---
 
 # Make your Python package PyPI ready - pyproject.toml

--- a/tutorials/setup-py-to-pyproject-toml.md
+++ b/tutorials/setup-py-to-pyproject-toml.md
@@ -1,7 +1,6 @@
 ---
 :og:description: If you’re creating a pure Python project, pyproject.toml is preferred over setup.py for packaging and configuration. Learn how to migrate from the older setup.py format to the modern pyproject.toml file. This lesson walks you through updating your package metadata and build settings to align with current Python packaging standards.
 :og:title: Using Hatch to Migrate setup.py to a pyproject.toml
-date: 1970-01-09
 ---
 
 # Using Hatch to Migrate setup.py to a pyproject.toml


### PR DESCRIPTION
Fixes: #507 

Taking the idea from @stefmolin , here we get the `pubDate` from the mtime of the file. In CI we restore those from the commit history.

There is a minor bit of semantic mismatch between the RSS feed/RSS spec and what we might want for the site - the RSS field is `pubDate`, or the date that the item was *published.* I don't think the spec is prescriptive about what that means, e.g. updating a file could be re-publishing it (that's how we treat it here). Usually it's good to treat the original publication date and the update date separately when displaying: e.g. "Originally published: 2020-01-01, updated: 2025-06-04" since both of those are independently meaningful for a reader. Currently we don't display the date on the site, but i renamed the parameter to `date_updated` in case we want to add that in the future.

You'll notice that all the dates for the tutorials are shortly before right now, since that's the last time they were changed (to remove the dates). That may or may not be desirable... so i also made it possible to explicitly assign those dates if we wanted to backdate the existing tutorials, for example.