### PR TITLE
correctly ignore `_build` directory

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -83,7 +83,7 @@ def docs_test(session):
 def _autobuild_cmd(posargs: list[str], output_dir = OUTPUT_DIR) -> list[str]:
     cmd = [SPHINX_AUTO_BUILD, *BUILD_PARAMETERS, str(SOURCE_DIR), str(output_dir), *posargs]
     for folder in AUTOBUILD_IGNORE:
-        cmd.extend(["--ignore", f"*/{folder}/*"])
+        cmd.extend(["--ignore", f'"{folder}"'])
     return cmd
 
 


### PR DESCRIPTION
Fixes: https://github.com/pyOpenSci/python-package-guide/issues/523

previously the `_build` directory was not being correctly ignored by sphinx-autobuild because the glob `*`'s being added to the front and back of the ignored directory aren't compatible with how sphinx-autobuild does filtration. this prevents infinite builds and correctly ignores the whole `_build` directory. 