### PR TITLE
Fix issues in update-language nox session caused by translation stats

### DIFF
--- a/_ext/translation_graph.py
+++ b/_ext/translation_graph.py
@@ -1,13 +1,14 @@
-from pathlib import Path
 import json
-from typing import TYPE_CHECKING, TypeAlias, TypedDict, Annotated as A
+from pathlib import Path
+from typing import TYPE_CHECKING, TypeAlias, TypedDict
+from typing import Annotated as A
 
+import numpy as np
+import plotly.graph_objects as go
 from babel.messages import pofile
 from docutils import nodes
 from docutils.parsers.rst import Directive
-import plotly.graph_objects as go
 from plotly.offline import plot
-import numpy as np
 
 if TYPE_CHECKING:
     from sphinx.application import Sphinx
@@ -17,6 +18,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent  # Repository base directory
 LOCALES_DIR = BASE_DIR / "locales"  # Locales directory
 STATIC_DIR = BASE_DIR / "_static"  # Static directory
 
+
 class ModuleStats(TypedDict):
     total: int
     translated: int
@@ -24,7 +26,10 @@ class ModuleStats(TypedDict):
     untranslated: int
     percentage: float
 
-TranslationStats: TypeAlias = dict[A[str, "locale"], dict[A[str, "module"], ModuleStats]]
+
+TranslationStats: TypeAlias = dict[
+    A[str, "locale"], dict[A[str, "module"], ModuleStats]
+]
 
 
 class TranslationGraph(Directive):
@@ -42,19 +47,39 @@ class TranslationGraph(Directive):
     Total: %{customdata.total}<br>
     Completed: %{customdata.percentage}%
     """
+
     def run(self):
         data = get_translation_stats()
 
         # Sort data by locale and module
-        data = {locale: dict(sorted(loc_stats.items())) for locale, loc_stats in sorted(data.items())}
+        data = {
+            locale: dict(sorted(loc_stats.items()))
+            for locale, loc_stats in sorted(data.items())
+        }
 
         # prepend english, everything set to 100%
-        en = {module: ModuleStats(total=stats['total'], translated=stats['total'], fuzzy=stats['total'], untranslated=0, percentage=100) for module, stats in next(iter(data.values())).items()}
-        data = {'en': en} | data
+        en = {
+            module: ModuleStats(
+                total=stats["total"],
+                translated=stats["total"],
+                fuzzy=stats["total"],
+                untranslated=0,
+                percentage=100,
+            )
+            for module, stats in next(iter(data.values())).items()
+        }
+        data = {"en": en} | data
 
         # Calculate average completion percentage for each locale and sort locales
-        locale_completion = {locale: np.mean([stats['percentage'] for stats in loc_stats.values()]) for locale, loc_stats in data.items()}
-        sorted_locales = sorted(locale_completion.keys(), key=lambda locale: locale_completion[locale], reverse=True)
+        locale_completion = {
+            locale: np.mean([stats["percentage"] for stats in loc_stats.values()])
+            for locale, loc_stats in data.items()
+        }
+        sorted_locales = sorted(
+            locale_completion.keys(),
+            key=lambda locale: locale_completion[locale],
+            reverse=True,
+        )
 
         # Reorder data based on sorted locales
         data = {locale: data[locale] for locale in sorted_locales}
@@ -64,11 +89,20 @@ class TranslationGraph(Directive):
         modules = list(next(iter(data.values())).keys())
 
         # Extract data to plot
-        values = [[stats['percentage'] for stats in loc_stats.values()] for loc_stats in data.values()]
-        hoverdata = [[{'module': module} | stats for module, stats in loc_stats.items()] for loc_stats in data.values()]
+        values = [
+            [stats["percentage"] for stats in loc_stats.values()]
+            for loc_stats in data.values()
+        ]
+        hoverdata = [
+            [{"module": module} | stats for module, stats in loc_stats.items()]
+            for loc_stats in data.values()
+        ]
 
         # Add text to display percentages directly in the heatmap boxes
-        text = [[f"{int(stats['percentage'])}%" for stats in loc_stats.values()] for loc_stats in data.values()]
+        text = [
+            [f"{int(stats['percentage'])}%" for stats in loc_stats.values()]
+            for loc_stats in data.values()
+        ]
 
         heatmap = go.Heatmap(
             x=modules,
@@ -83,23 +117,28 @@ class TranslationGraph(Directive):
             hovertemplate=self.HOVER_TEMPLATE,
             name="",  # Set the trace name to an empty string to remove "trace 0" from hoverbox
             colorbar={
-                'orientation': 'h',
-                'y': 0,
+                "orientation": "h",
+                "y": 0,
                 "yanchor": "bottom",
                 "yref": "container",
                 "title": "Completion %",
                 "thickness": 10,
                 "tickvals": [12.5, 50, 87.5, 100],  # Midpoints for each category
-                "ticktext": ["0-25%", "25-75%", "75-<100%", "100%"],  # Labels for categories
+                "ticktext": [
+                    "0-25%",
+                    "25-75%",
+                    "75-<100%",
+                    "100%",
+                ],  # Labels for categories
             },
             colorscale=[
-                [0.0,  "rgb(254, 255, 231)"],   # 0-25%
+                [0.0, "rgb(254, 255, 231)"],  # 0-25%
                 [0.25, "rgb(254, 255, 231)"],
-                [0.25, "rgb(187, 130, 176)"],   # 25-75%
+                [0.25, "rgb(187, 130, 176)"],  # 25-75%
                 [0.75, "rgb(187, 130, 176)"],
-                [0.75, "rgb(129, 192, 170)"],   # 75-<100%
+                [0.75, "rgb(129, 192, 170)"],  # 75-<100%
                 [0.99, "rgb(129, 192, 170)"],
-                [1.0,  "rgb(78,  112, 100)"],   # 100%
+                [1.0, "rgb(78,  112, 100)"],  # 100%
             ],
         )
         # Create figure
@@ -112,7 +151,7 @@ class TranslationGraph(Directive):
             xaxis_showgrid=False,
             xaxis_side="top",
             xaxis_tickangle=-45,
-            xaxis_tickfont = {
+            xaxis_tickfont={
                 "family": "var(--bs-font-monospace)",
             },
             yaxis_showgrid=False,
@@ -127,7 +166,8 @@ class TranslationGraph(Directive):
         )
         return [nodes.raw("", div, format="html")]
 
-def calculate_translation_percentage(po_path : Path, locale : str) -> ModuleStats:
+
+def calculate_translation_percentage(po_path: Path, locale: str) -> ModuleStats:
     """
     Calculate the translation percentage for a given .po file.
 
@@ -170,7 +210,7 @@ def calculate_translation_percentage(po_path : Path, locale : str) -> ModuleStat
         "translated": translated,
         "fuzzy": fuzzy,
         "untranslated": total - translated - fuzzy,
-        "percentage": round(percentage, 2)
+        "percentage": round(percentage, 2),
     }
 
 
@@ -218,9 +258,15 @@ def get_translation_stats() -> TranslationStats:
 
     return results
 
+
 def write_translation_stats(app: "Sphinx", exception: Exception | None) -> None:
     from sphinx.util import logging
+
     logger = logging.getLogger("_ext.translation_graph")
+
+    if app.builder.name != "html":
+        logger.info("Skipping translation stats for non-HTML build")
+        return
 
     stats = get_translation_stats()
     out_path = app.outdir / "_static" / "translation_stats.json"

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,9 +1,10 @@
 import os
 import pathlib
 import shutil
-import nox
-import sys
 import subprocess
+import sys
+
+import nox
 
 # for some reason necessary to correctly import conf from cwd
 sys.path.insert(0, str(pathlib.Path(__file__).parent.absolute()))
@@ -15,7 +16,7 @@ nox.options.default_venv_backend = "uv|virtualenv"
 ## Sphinx related options
 
 # Sphinx output and source directories
-BUILD_DIR = '_build'
+BUILD_DIR = "_build"
 OUTPUT_DIR = pathlib.Path(BUILD_DIR, "html")
 SOURCE_DIR = pathlib.Path(".")
 
@@ -31,7 +32,7 @@ SPHINX_AUTO_BUILD = "sphinx-autobuild"
 BUILD_PARAMETERS = ["-b", "html"]
 
 # Sphinx parameters used to test the build of the guide
-TEST_PARAMETERS = ['--keep-going', '-E', '-a']
+TEST_PARAMETERS = ["--keep-going", "-E", "-a"]
 
 # Sphinx parameters to generate translation templates
 TRANSLATION_TEMPLATE_PARAMETERS = ["-b", "gettext"]
@@ -43,9 +44,7 @@ AUTOBUILD_IGNORE = [
     "build_assets",
     "tmp",
 ]
-AUTOBUILD_INCLUDE = [
-    pathlib.Path("_static", "pyos.css")
-]
+AUTOBUILD_INCLUDE = [pathlib.Path("_static", "pyos.css")]
 
 ## Localization options (translations)
 
@@ -56,14 +55,17 @@ LANGUAGES = conf.languages
 RELEASE_LANGUAGES = conf.release_languages
 
 # allowable values of `SPHINX_ENV`
-SPHINX_ENVS = ('production', 'development')
+SPHINX_ENVS = ("production", "development")
+
 
 @nox.session
 def docs(session):
     """Build the packaging guide."""
     session.install("-e", ".")
     sphinx_env = _sphinx_env(session)
-    session.run(SPHINX_BUILD, *BUILD_PARAMETERS, SOURCE_DIR, OUTPUT_DIR, *session.posargs)
+    session.run(
+        SPHINX_BUILD, *BUILD_PARAMETERS, SOURCE_DIR, OUTPUT_DIR, *session.posargs
+    )
     # When building the guide, also build the translations in RELEASE_LANGUAGES
     session.notify("build-release-languages", session.posargs)
 
@@ -76,14 +78,30 @@ def docs_test(session):
     Note: this is the session used in CI/CD to release the guide.
     """
     session.install("-e", ".")
-    session.run(SPHINX_BUILD, *BUILD_PARAMETERS, *TEST_PARAMETERS, SOURCE_DIR, OUTPUT_DIR, *session.posargs,
-                env={'SPHINX_ENV': 'production'})
+    session.run(
+        SPHINX_BUILD,
+        *BUILD_PARAMETERS,
+        *TEST_PARAMETERS,
+        SOURCE_DIR,
+        OUTPUT_DIR,
+        *session.posargs,
+        env={"SPHINX_ENV": "production"},
+    )
     # When building the guide with additional parameters, also build the translations in RELEASE_LANGUAGES
     # with those same parameters.
-    session.notify("build-release-languages", ["production", *TEST_PARAMETERS, *session.posargs])
+    session.notify(
+        "build-release-languages", ["production", *TEST_PARAMETERS, *session.posargs]
+    )
 
-def _autobuild_cmd(posargs: list[str], output_dir = OUTPUT_DIR) -> list[str]:
-    cmd = [SPHINX_AUTO_BUILD, *BUILD_PARAMETERS, str(SOURCE_DIR), str(output_dir), *posargs]
+
+def _autobuild_cmd(posargs: list[str], output_dir=OUTPUT_DIR) -> list[str]:
+    cmd = [
+        SPHINX_AUTO_BUILD,
+        *BUILD_PARAMETERS,
+        str(SOURCE_DIR),
+        str(output_dir),
+        *posargs,
+    ]
     for folder in AUTOBUILD_IGNORE:
         cmd.extend(["--ignore", f'"{folder}"'])
     return cmd
@@ -109,7 +127,7 @@ def docs_live(session):
     # This part was commented in the previous version of the nox file, keeping the same here
     # for folder in AUTOBUILD_INCLUDE:
     #     cmd.extend(["--watch", folder])
-    session.run(*cmd, env={'SPHINX_ENV': "development"})
+    session.run(*cmd, env={"SPHINX_ENV": "development"})
 
 
 @nox.session(name="docs-live-lang")
@@ -135,13 +153,14 @@ def docs_live_lang(session):
     lang = session.posargs[0]
     if lang in LANGUAGES:
         session.posargs.pop(0)
-        session.notify("docs-live", ('-D', f"language={lang}", *session.posargs))
+        session.notify("docs-live", ("-D", f"language={lang}", *session.posargs))
     else:
         session.error(
             f"[{lang}] locale is not available. Try using:\n\n      "
             "nox -s docs-live-lang -- LANG\n\n      "
             f"where LANG is one of: {LANGUAGES}"
         )
+
 
 @nox.session(name="docs-live-langs")
 def docs_live_langs(session):
@@ -151,37 +170,61 @@ def docs_live_langs(session):
     Requires concurrently to run (npm install -g concurrently)
     """
     try:
-        subprocess.check_call(['concurrently'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        subprocess.check_call(
+            ["concurrently"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+        )
     except subprocess.CalledProcessError:
         # handle errors in the called executable
         # (aka, was found)
         pass
     except OSError:
-        session.error('docs-live-langs requires concurrently (npm install -g concurrently)')
+        session.error(
+            "docs-live-langs requires concurrently (npm install -g concurrently)"
+        )
 
     session.install("-e", ".")
 
-    cmds = ['"' + " ".join(["SPHINX_ENV=development"] + _autobuild_cmd(session.posargs) + ['--open-browser']) + '"']
+    cmds = [
+        '"'
+        + " ".join(
+            ["SPHINX_ENV=development"]
+            + _autobuild_cmd(session.posargs)
+            + ["--open-browser"]
+        )
+        + '"'
+    ]
     for language in LANGUAGES:
         cmds.append(
-            '"' + " ".join(
-                [f"SPHINX_LANG={language}", "SPHINX_ENV=development"] +
-                _autobuild_cmd(
+            '"'
+            + " ".join(
+                [f"SPHINX_LANG={language}", "SPHINX_ENV=development"]
+                + _autobuild_cmd(
                     session.posargs + ["-D", f"language={language}"],
-                    output_dir=OUTPUT_DIR / language
-                ) + ["--port=0"]
-            ) + '"'
+                    output_dir=OUTPUT_DIR / language,
+                )
+                + ["--port=0"]
+            )
+            + '"'
         )
-    cmd = ['concurrently', '--kill-others', '-n', ','.join(["en"] + LANGUAGES), '-c', 'auto', *cmds]
+    cmd = [
+        "concurrently",
+        "--kill-others",
+        "-n",
+        ",".join(["en"] + LANGUAGES),
+        "-c",
+        "auto",
+        *cmds,
+    ]
     session.run(*cmd)
+
 
 @nox.session(name="docs-clean")
 def clean_dir(session):
     """Clean out the docs directory used in the live build."""
     session.warn(f"Cleaning out {OUTPUT_DIR}")
-    dir_contents = OUTPUT_DIR.glob('*')
+    dir_contents = OUTPUT_DIR.glob("*")
     for content in dir_contents:
-        session.log(f'removing {content}')
+        session.log(f"removing {content}")
         if content.is_dir():
             shutil.rmtree(content)
         else:
@@ -200,10 +243,18 @@ def update_release_languages(session):
         session.install("-e", ".")
         session.install("sphinx-intl")
         session.log("Updating templates (.pot)")
-        session.run(SPHINX_BUILD, *TRANSLATION_TEMPLATE_PARAMETERS, SOURCE_DIR, TRANSLATION_TEMPLATE_DIR, *session.posargs)
+        session.run(
+            SPHINX_BUILD,
+            *TRANSLATION_TEMPLATE_PARAMETERS,
+            SOURCE_DIR,
+            TRANSLATION_TEMPLATE_DIR,
+            *session.posargs,
+        )
         for lang in RELEASE_LANGUAGES:
             session.log(f"Updating .po files for [{lang}] translation")
-            session.run("sphinx-intl", "update", "-p", TRANSLATION_TEMPLATE_DIR, "-l", lang)
+            session.run(
+                "sphinx-intl", "update", "-p", TRANSLATION_TEMPLATE_DIR, "-l", lang
+            )
     else:
         session.warn("No release languages defined in RELEASE_LANGUAGES")
 
@@ -221,9 +272,17 @@ def update_language(session):
             session.install("-e", ".")
             session.install("sphinx-intl")
             session.log("Updating templates (.pot)")
-            session.run(SPHINX_BUILD, *TRANSLATION_TEMPLATE_PARAMETERS, SOURCE_DIR, TRANSLATION_TEMPLATE_DIR, *session.posargs)
+            session.run(
+                SPHINX_BUILD,
+                *TRANSLATION_TEMPLATE_PARAMETERS,
+                SOURCE_DIR,
+                TRANSLATION_TEMPLATE_DIR,
+                *session.posargs,
+            )
             session.log(f"Updating .po files for [{lang}] translation")
-            session.run("sphinx-intl", "update", "-p", TRANSLATION_TEMPLATE_DIR, "-l", lang)
+            session.run(
+                "sphinx-intl", "update", "-p", TRANSLATION_TEMPLATE_DIR, "-l", lang
+            )
         else:
             f"[{lang}] locale is not available. Try using:\n\n      "
             "nox -s docs-live-lang -- LANG\n\n      "
@@ -234,12 +293,6 @@ def update_language(session):
             "nox -s update-language -- LANG\n\n     "
             f" where LANG is one of: {LANGUAGES}"
         )
-    if not session.posargs:
-        session.error("Please provide the list of languages to build the translation for")
-
-    sphinx_env = _sphinx_env(session)
-
-    languages_to_build = session.posargs.pop(0)
 
 
 @nox.session(name="build-language")
@@ -253,7 +306,15 @@ def build_language(session):
         if lang in LANGUAGES:
             session.install("-e", ".")
             session.log(f"Building [{lang}] guide")
-            session.run(SPHINX_BUILD, *BUILD_PARAMETERS, "-D", f"language={lang}", ".", OUTPUT_DIR / lang, *session.posargs)
+            session.run(
+                SPHINX_BUILD,
+                *BUILD_PARAMETERS,
+                "-D",
+                f"language={lang}",
+                ".",
+                OUTPUT_DIR / lang,
+                *session.posargs,
+            )
         else:
             session.error(f"Language {lang} is not in LANGUAGES list.")
     else:
@@ -276,13 +337,22 @@ def build_release_languages(session):
     session.install("-e", ".")
     for lang in RELEASE_LANGUAGES:
         session.log(f"Building [{lang}] guide")
-        if lang == 'en':
+        if lang == "en":
             out_dir = OUTPUT_DIR
         else:
             out_dir = OUTPUT_DIR / lang
-        session.run(SPHINX_BUILD, *BUILD_PARAMETERS, "-D", f"language={lang}", ".", out_dir, *session.posargs,
-                    env={"SPHINX_LANG": lang, "SPHINX_ENV": sphinx_env})
+        session.run(
+            SPHINX_BUILD,
+            *BUILD_PARAMETERS,
+            "-D",
+            f"language={lang}",
+            ".",
+            out_dir,
+            *session.posargs,
+            env={"SPHINX_LANG": lang, "SPHINX_ENV": sphinx_env},
+        )
     session.log(f"Translations built for {RELEASE_LANGUAGES}")
+
 
 @nox.session(name="build-all-languages")
 def build_all_languages(session):
@@ -295,21 +365,35 @@ def build_all_languages(session):
     session.install("-e", ".")
     for lang in LANGUAGES:
         session.log(f"Building [{lang}] guide")
-        session.run(SPHINX_BUILD, *BUILD_PARAMETERS, "-D", f"language={lang}", ".", OUTPUT_DIR / lang, *session.posargs)
+        session.run(
+            SPHINX_BUILD,
+            *BUILD_PARAMETERS,
+            "-D",
+            f"language={lang}",
+            ".",
+            OUTPUT_DIR / lang,
+            *session.posargs,
+        )
     session.log(f"Translations built for {LANGUAGES}")
     sphinx_env = _sphinx_env(session)
 
     # if running from the docs or docs-test sessions, build only release languages
     BUILD_LANGUAGES = RELEASE_LANGUAGES if sphinx_env == "production" else LANGUAGES
     # only build languages that have a locale folder
-    BUILD_LANGUAGES = [lang for lang in BUILD_LANGUAGES if (TRANSLATION_LOCALES_DIR / lang).exists()]
+    BUILD_LANGUAGES = [
+        lang for lang in BUILD_LANGUAGES if (TRANSLATION_LOCALES_DIR / lang).exists()
+    ]
     session.log(f"Declared languages: {LANGUAGES}")
     session.log(f"Release languages: {RELEASE_LANGUAGES}")
-    session.log(f"Building languages{' for release' if sphinx_env == 'production' else ''}: {BUILD_LANGUAGES}")
+    session.log(
+        f"Building languages{' for release' if sphinx_env == 'production' else ''}: {BUILD_LANGUAGES}"
+    )
     if not BUILD_LANGUAGES:
         session.warn("No translations to build")
     else:
-        session.notify("build-languages", [sphinx_env, BUILD_LANGUAGES, *session.posargs])
+        session.notify(
+            "build-languages", [sphinx_env, BUILD_LANGUAGES, *session.posargs]
+        )
 
 
 @nox.session(name="build-all-languages-test")
@@ -332,6 +416,6 @@ def _sphinx_env(session) -> str:
         env = session.posargs.pop(0)
         session.log(f"Using SPHINX_ENV={env} from posargs")
     else:
-        env = os.environ.get('SPHINX_ENV', 'development')
+        env = os.environ.get("SPHINX_ENV", "development")
         session.log(f"Using SPHINX_ENV={env} from os.environ")
     return env


### PR DESCRIPTION
The update we merged recently to update the translation stats (#521) introduced a bug that caused the update translation sessions to fail (it assumes the build directory is /html, but when running the gettext sphinx builder that is not true. I added a check to only compute stats when using the html builder.

I also clean up some old code that was at the end of the update language session function that was causing the session to fail but it was no longer needed.