### PR TITLE
Update Japanese translation files

### DIFF
--- a/locales/ja/LC_MESSAGES/TRANSLATING.po
+++ b/locales/ja/LC_MESSAGES/TRANSLATING.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pyOpenSci Python Package Guide\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-20 11:32+0900\n"
+"POT-Creation-Date: 2025-07-12 11:17+0200\n"
 "PO-Revision-Date: 2025-04-14 18:12+0000\n"
 "Last-Translator: Tetsuo Koyama <tkoyama010@gmail.com>, 2025\n"
 "Language: ja\n"
@@ -41,10 +41,14 @@ msgid ""
 msgstr "ガイドの翻訳に貢献するプロセスは、ガイドのソースファイルに直接取り組むのではなく、翻訳ファイルに取り組むという点を除けば、ガイドそのものに貢献するプロセスと似ています。"
 
 #: ../../TRANSLATING.md:11
+msgid "Translation Status"
+msgstr ""
+
+#: ../../TRANSLATING.md:16
 msgid "Overview of the Translation Process"
 msgstr "翻訳プロセスの概要"
 
-#: ../../TRANSLATING.md:13
+#: ../../TRANSLATING.md:18
 msgid ""
 "The process of adapting software to different languages is called "
 "internationalization, or i18n for short. Internationalization makes sure "
@@ -54,50 +58,50 @@ msgstr ""
 "ソフトウェアを異なる言語に適応させるプロセスは国際化、略してi18nと呼ばれます。 "
 "国際化はソースコード、私たちの場合はガイドのオリジナルの英語のソースファイルを修正することなく翻訳が行われるようにします。"
 
-#: ../../TRANSLATING.md:15
+#: ../../TRANSLATING.md:20
 msgid ""
 "Sphinx, the documentation engine we use to build the Python Package "
 "Guide, has built-in support for internationalization, so the workflow is "
 "very straightforward."
 msgstr "Pythonパッケージガイドをビルドするために使っているドキュメントエンジンであるSphinxは、国際化をビルトインでサポートしているので、ワークフローはとても簡単です。"
 
-#: ../../TRANSLATING.md:17
+#: ../../TRANSLATING.md:22
 msgid ""
 "The process of actually translating the guide into different languages is"
 " called localization, or l10n for short. This is the step you will be "
 "helping with your contribution."
 msgstr "ガイドを実際に異なる言語に翻訳するプロセスをローカリゼーション、略してl10nと呼びます。 あなたが貢献するのはこのステップです。"
 
-#: ../../TRANSLATING.md:19
+#: ../../TRANSLATING.md:24
 msgid "Here is a quick overview of how the translation process works:"
 msgstr "ここでは、翻訳プロセスの概要を簡単に説明します:"
 
-#: ../../TRANSLATING.md:21
+#: ../../TRANSLATING.md:26
 msgid ""
 "The guide is originally written in English and stored in a set of "
 "MarkDown files."
 msgstr "このガイドはもともと英語で書かれており、MarkDownのファイル群に保存されています。"
 
-#: ../../TRANSLATING.md:22
+#: ../../TRANSLATING.md:27
 msgid ""
 "The source files are processed by Sphinx to generate a set of translation"
 " files stored in a folder for each target language."
 msgstr "ソースファイルはSphinxによって処理され、各ターゲット言語のフォルダに格納された翻訳ファイルのセットを生成します。"
 
-#: ../../TRANSLATING.md:23
+#: ../../TRANSLATING.md:28
 msgid ""
 "Contributors (like you!) translate these files into the different "
 "languages."
 msgstr "（あなたのような!）貢献者は、これらのファイルをさまざまな言語に翻訳します。"
 
-#: ../../TRANSLATING.md:24
+#: ../../TRANSLATING.md:29
 msgid ""
 "When the guide is built, Sphinx creates a version of the guide in the "
 "original language (English) and the translated versions for the languages"
 " defined in the configuration."
 msgstr "ガイドがビルドされると、Sphinxはオリジナルの言語(英語)と、設定で定義された言語の翻訳版のガイドを作成します。"
 
-#: ../../TRANSLATING.md:27
+#: ../../TRANSLATING.md:32
 msgid ""
 "You don't need to understand the technical details to contribute, but if "
 "you are interested in learning how Sphinx handles internationalization "
@@ -108,47 +112,47 @@ msgstr ""
 "[ここ](https://www.sphinx-doc.org/en/master/usage/advanced/intl.html) "
 "に詳しい情報があります。"
 
-#: ../../TRANSLATING.md:30
+#: ../../TRANSLATING.md:35
 msgid "Setting up Your Local Environment"
 msgstr "ローカル環境の設定"
 
-#: ../../TRANSLATING.md:32
+#: ../../TRANSLATING.md:37
 msgid "Before you start, you will need to set up your local work environment."
 msgstr "作業を始める前に、ローカルの作業環境を設定する必要があります。"
 
-#: ../../TRANSLATING.md:34
+#: ../../TRANSLATING.md:39
 msgid ""
 "First, fork the guide repository into your personal GitHub account and "
 "clone the forked repository to your local computer."
 msgstr "まず、ガイドリポジトリを個人のGitHubアカウントにフォークし、フォークしたリポジトリをローカルコンピューターにクローンします。"
 
-#: ../../TRANSLATING.md:36
+#: ../../TRANSLATING.md:41
 msgid ""
 "To create a virtual environment and install the development dependencies "
 "for the guide, run the following commands:"
 msgstr "仮想環境を作成し、ガイドの開発依存関係をインストールするには、以下のコマンドを実行します:"
 
-#: ../../TRANSLATING.md:45
+#: ../../TRANSLATING.md:50
 msgid ""
 "TODO: This section needs more work or to be replaced with a reference to "
 "the CONTRIBUTING guide."
 msgstr "TODO: このセクションは、より多くの作業が必要か、CONTRIBUTINGガイドへの参照に置き換える必要があります。"
 
-#: ../../TRANSLATING.md:47
+#: ../../TRANSLATING.md:52
 msgid "Starting a New Language Translation"
 msgstr "新しい言語の翻訳を始める"
 
-#: ../../TRANSLATING.md:49
+#: ../../TRANSLATING.md:54
 msgid ""
 "If you plan to work on an existing translation, you can skip this step "
 "and go directly to the next section."
 msgstr "既存の翻訳に手を加える場合は、このステップを飛ばして直接次のセクションに進んでください。"
 
-#: ../../TRANSLATING.md:51 ../../TRANSLATING.md:217
+#: ../../TRANSLATING.md:56 ../../TRANSLATING.md:222
 msgid "Important"
 msgstr "重要"
 
-#: ../../TRANSLATING.md:52
+#: ../../TRANSLATING.md:57
 msgid ""
 "If you would like to start the translation of the guide into a new "
 "language, start by [creating an issue](https://github.com/pyOpenSci"
@@ -157,7 +161,7 @@ msgstr ""
 "新しい言語へのガイドの翻訳を開始したい場合は、リポジトリに [issueを作成する](https://github.com/pyOpenSci"
 "/python-package-guide/issues) ことから始めてください。"
 
-#: ../../TRANSLATING.md:55
+#: ../../TRANSLATING.md:60
 msgid ""
 "To generate the translation files for a new language, add the language to"
 " the `LANGUAGES` list in the `noxfile.py` configuration file. "
@@ -168,7 +172,7 @@ msgstr ""
 "[Nox](https://nox.thea.codes/en/stable/index.html) "
 "はガイドとその翻訳のビルドを管理するために使うツールです。"
 
-#: ../../TRANSLATING.md:57
+#: ../../TRANSLATING.md:62
 msgid ""
 "Inside `noxfile.py`, find the `LANGUAGES` list and add the corresponding "
 "two-letter code. For example, if you want to start the translation of the"
@@ -177,7 +181,7 @@ msgstr ""
 "`noxfile.py` の中で `LANGUAGES` リストを見つけて、対応する2文字のコードを追加します。 "
 "例えば、フランス語への翻訳を開始したい場合は `'fr'` を追加します:"
 
-#: ../../TRANSLATING.md:68
+#: ../../TRANSLATING.md:73
 msgid ""
 "You can find a list of the two-letter Sphinx language option "
 "[here](https://www.sphinx-doc.org/en/master/usage/configuration.html"
@@ -186,11 +190,11 @@ msgstr ""
 "[ここで](https://www.sphinx-doc.org/en/master/usage/configuration.html"
 "#confval-language) 、2文字のSphinx言語オプションのリストを見つけることができます。"
 
-#: ../../TRANSLATING.md:71
+#: ../../TRANSLATING.md:76
 msgid "Preparing the Translation Files"
 msgstr "翻訳ファイルの準備"
 
-#: ../../TRANSLATING.md:73
+#: ../../TRANSLATING.md:78
 msgid ""
 "The translation files contain the original English text and a space for "
 "you to enter the translated text. Before starting to translate, you need "
@@ -200,19 +204,19 @@ msgstr ""
 "翻訳ファイルには、英語の原文と翻訳文を入力するスペースが含まれています。 "
 "翻訳を始める前に、翻訳ファイルがガイドの最新の変更に対応していることを確認する必要があります。"
 
-#: ../../TRANSLATING.md:75
+#: ../../TRANSLATING.md:80
 msgid ""
 "You can do this by running the following command, replacing LANG by the "
 "language code you plan to work on (e.g., `es` for Spanish):"
 msgstr "以下のコマンドを実行し、LANGを作業する予定の言語コードに置き換えてください (例えばスペイン語は `es`):"
 
-#: ../../TRANSLATING.md:81
+#: ../../TRANSLATING.md:86
 msgid ""
 "This command will create the translation files if they don't exist yet, "
 "or update them with the latest changes if they already exist."
 msgstr "このコマンドは、翻訳ファイルがまだ存在しない場合は作成し、すでに存在する場合は最新の変更内容で更新します。"
 
-#: ../../TRANSLATING.md:83
+#: ../../TRANSLATING.md:88
 msgid ""
 "The translation files are text files with the `.po` extension stored in "
 "the `./locales`, in folders corresponding to each language. For example, "
@@ -222,7 +226,7 @@ msgstr ""
 "翻訳ファイルは拡張子が `.po` のテキストファイルで、各言語に対応するフォルダ `./locales` に格納されています。 "
 "例えば、スペイン語の翻訳ファイルは `locale/es/LC_MESSAGES` ディレクトリに格納されています。"
 
-#: ../../TRANSLATING.md:85
+#: ../../TRANSLATING.md:90
 msgid ""
 "Because the translation files map the original English text to translated"
 " text, they are sometimes referred to as \"catalog\" files or \"portable "
@@ -231,7 +235,7 @@ msgstr ""
 "翻訳ファイルは、元の英文テキストと翻訳テキストを対応付けるため、 \"catalog\" ファイルや \"portable object\" "
 "ファイルと呼ばれることもあります。"
 
-#: ../../TRANSLATING.md:88
+#: ../../TRANSLATING.md:93
 msgid ""
 "You don't need to know all the details about the PO format in order to "
 "translate. If you are interested in learning more, you can find "
@@ -243,11 +247,11 @@ msgstr ""
 "documentation](https://www.gnu.org/software/gettext/manual/html_node/PO-"
 "Files.html) に詳細があります。"
 
-#: ../../TRANSLATING.md:91
+#: ../../TRANSLATING.md:96
 msgid "Working on a Translation"
 msgstr "翻訳作業"
 
-#: ../../TRANSLATING.md:93
+#: ../../TRANSLATING.md:98
 msgid ""
 "In order to start translating, go to the folder inside `./locales` "
 "corresponding to the target language you want to translate to (for "
@@ -256,13 +260,13 @@ msgstr ""
 "翻訳を開始するには、翻訳したいターゲット言語に対応する `./locales` 内のフォルダに移動します（例えば、スペイン語翻訳なら "
 "`./locale/es/LC_MESSAGES/` です）。"
 
-#: ../../TRANSLATING.md:95
+#: ../../TRANSLATING.md:100
 msgid ""
 "In this folder you will find a set of `.po` files, corresponding to the "
 "different sections of the guide:"
 msgstr "このフォルダには、ガイドの各セクションに対応する `.po` ファイルのセットがあります："
 
-#: ../../TRANSLATING.md:111
+#: ../../TRANSLATING.md:116
 msgid ""
 "You may also see some `.mo` files in the same folder. These are compiled "
 "versions of the `.po` files create by Sphinx during the build process, "
@@ -274,7 +278,7 @@ msgstr ""
 "ファイルをコンパイルしたもので、翻訳されたバージョンのガイドを生成するために使用されます。 "
 "これらは中間的なファイルで、直接編集したり、リポジトリに保存したりするものではありません。"
 
-#: ../../TRANSLATING.md:114
+#: ../../TRANSLATING.md:119
 msgid ""
 "If you are working on a new translation, choose one of the `.po` files to"
 " start with. If you are working on an existing translation, you can start"
@@ -283,7 +287,7 @@ msgstr ""
 "新しい翻訳をする場合は、`.po` ファイルを1つ選んで始めます。 既存の翻訳をする場合は、最も作業が必要な `.po` "
 "ファイルから始めることができます。"
 
-#: ../../TRANSLATING.md:116
+#: ../../TRANSLATING.md:121
 msgid ""
 "To see how much of each file has been translated, use the `sphinx-intl "
 "stat`. You will be able to see the number of translated, fuzzy, and "
@@ -292,33 +296,33 @@ msgstr ""
 "各ファイルがどれくらい翻訳されたかを見るには、 `sphinx-intl stat` を使ってください。 それぞれの `.po` "
 "ファイルに含まれる、翻訳された文字列、あいまいな文字列、未翻訳の文字列の数を見ることができます。"
 
-#: ../../TRANSLATING.md:118
+#: ../../TRANSLATING.md:123
 msgid ""
 "For example, to see the statistics for the Spanish translation, you would"
 " run:"
 msgstr "例えば、スペイン語翻訳の統計を見るには、次のように実行します:"
 
-#: ../../TRANSLATING.md:132
+#: ../../TRANSLATING.md:137
 msgid "What do these categories mean:"
 msgstr "これらのカテゴリーは何を意味するのか:"
 
-#: ../../TRANSLATING.md:134
+#: ../../TRANSLATING.md:139
 msgid ""
 "Translated strings are strings that have been translated into the target "
 "language."
 msgstr "Translated stringsは、ターゲット言語に翻訳された文字列です。"
 
-#: ../../TRANSLATING.md:135
+#: ../../TRANSLATING.md:140
 msgid ""
 "Fuzzy strings are strings that have been translated but need to be "
 "reviewed because the original English string in the guide changed."
 msgstr "Fuzzy stringsとは、翻訳されたものの、ガイドの元の英語の文字列が変更されたため、見直しが必要な文字列のことです。"
 
-#: ../../TRANSLATING.md:136
+#: ../../TRANSLATING.md:141
 msgid "Untranslated strings are strings that have not been translated yet."
 msgstr "Untranslated stringsは、まだ翻訳されていない文字列です。"
 
-#: ../../TRANSLATING.md:139
+#: ../../TRANSLATING.md:144
 msgid ""
 "When Sphinx is building the guide in another language, it will look into "
 "the corresponding folder in `./locales/` for translated strings. If the "
@@ -330,11 +334,11 @@ msgstr ""
 "もし翻訳が利用可能であれば、Sphinxは英語のテキストをターゲット言語の同等のテキストに置き換えます。 "
 "もし翻訳が利用できない場合、Sphinxはオリジナルの英語の文字列を使用します。"
 
-#: ../../TRANSLATING.md:142
+#: ../../TRANSLATING.md:147
 msgid "Editing the Translation Files"
 msgstr "翻訳ファイルの編集"
 
-#: ../../TRANSLATING.md:144
+#: ../../TRANSLATING.md:149
 msgid ""
 "You can use any text editor to edit the `.po` file. But if you prefer, "
 "there are also tools like [Poedit](https://poedit.net/) that provide a "
@@ -343,7 +347,7 @@ msgstr ""
 ".po`ファイルの編集にはどんなテキストエディタでも使えます。 しかし、お好みであれば、 "
 "[Poedit](https://poedit.net/) のようなグラフィックなインターフェースを提供するツールもあります。"
 
-#: ../../TRANSLATING.md:146
+#: ../../TRANSLATING.md:151
 msgid ""
 "Depending on your editor of choice, you may be able to install a plugin "
 "or extension that can provide syntax highlighting and other features for "
@@ -356,13 +360,13 @@ msgstr ""
 "[gettext](https://marketplace.visualstudio.com/items?itemName=mrorz"
 ".language-gettext) エクステンションのようなものです。"
 
-#: ../../TRANSLATING.md:148
+#: ../../TRANSLATING.md:153
 msgid ""
 "When you open a `.po` file, you will see a series of entries that look "
 "like this:"
 msgstr ".po`ファイルを開くと、次のようなエントリーが並んでいます:"
 
-#: ../../TRANSLATING.md:158
+#: ../../TRANSLATING.md:163
 msgid ""
 "The first line of an entry starts with `#:` and is a reference to the "
 "original source file and line number from which the text was extracted. "
@@ -372,7 +376,7 @@ msgstr ""
 "エントリーの最初の行は `#:` で始まり、テキストが抽出された元のソースファイルと行番号への参照となります。 "
 "この情報は、ガイド内のテキストの文脈を見つけるのに便利です。"
 
-#: ../../TRANSLATING.md:160
+#: ../../TRANSLATING.md:165
 msgid ""
 "The `msgid` field contains the original English text that needs to be "
 "translated. The `msgstr` field is where you will enter the translated "
@@ -382,7 +386,7 @@ msgstr ""
 "`msgid` フィールドには翻訳が必要な元の英語のテキストを入力します。 `msgstr` フィールドには翻訳されたテキストを入力します。 "
 "このフィールドには他の人がすでに翻訳したテキストが入るかもしれません。"
 
-#: ../../TRANSLATING.md:170
+#: ../../TRANSLATING.md:175
 msgid ""
 "Sometimes the original English text may be too long for a single line, "
 "and it may be split into multiple lines. In this case, you can keep the "
@@ -393,21 +397,21 @@ msgstr ""
 "英語の原文が1行では長すぎて、複数行に分かれている場合があります。 このような場合、翻訳されたテキストでも同じ構造を保つことができます。 "
 "以下の例の `msgid` フィールドと `msgstr` フィールドの両方が空文字列で始まっていることに注意してください。"
 
-#: ../../TRANSLATING.md:186
+#: ../../TRANSLATING.md:191
 msgid ""
 "The English text will sometimes contain Markdown formatting, such as bold"
 " or italic text. You should keep the formatting in the translated text, "
 "making sure to translate the text inside the formatting tags."
 msgstr "英語のテキストには、太字や斜体などのMarkdown書式が含まれていることがあります。翻訳されたテキストで書式を維持する必要があります、フォーマットタグの中のテキストを翻訳してください。"
 
-#: ../../TRANSLATING.md:188
+#: ../../TRANSLATING.md:193
 msgid ""
 "The English text may also contain links to other sections of the guide or"
 " external resources. You should keep the links in the translated text, "
 "making sure to update the link text when appropriate."
 msgstr "英文テキストには、ガイドの他のセクションや外部リソースへのリンクが含まれている場合があります。リンクは翻訳されたテキストの中に残してください、必要に応じてリンクテキストを更新してください。"
 
-#: ../../TRANSLATING.md:196
+#: ../../TRANSLATING.md:201
 msgid ""
 "An entry may be marked as `fuzzy`, which means that the original English "
 "text has changed since the translation was made, and the translation may "
@@ -418,13 +422,13 @@ msgstr ""
 "と表示されることがありますが、これは原文の英文が翻訳後に変更され、翻訳を修正する必要があることを意味します。このような場合、エントリーに `#,`"
 " で始まる行が追加されます:"
 
-#: ../../TRANSLATING.md:213
+#: ../../TRANSLATING.md:218
 msgid ""
 "You can review the translation and make any necessary changes, removing "
 "the `fuzzy` tag once you are satisfied with the translation."
 msgstr "翻訳を確認して必要な変更を加え、翻訳に満足したら `fuzzy` タグを削除することができます。"
 
-#: ../../TRANSLATING.md:215
+#: ../../TRANSLATING.md:220
 msgid ""
 "You can also add comments to the translation file, by adding lines that "
 "start with a `#` character to the entry. This can be helpful to add "
@@ -432,7 +436,7 @@ msgid ""
 " this might be only necessary in special circumstances."
 msgstr "文字で始まる行をエントリに追加することで、翻訳ファイルにコメントを追加することもできます。これは、他の翻訳者やレビュアーが翻訳を見るために文脈を追加するのに役立ちます、しかし、これは特別な状況でのみ必要かもしれません。"
 
-#: ../../TRANSLATING.md:218
+#: ../../TRANSLATING.md:223
 msgid ""
 "When working on a translation, you **should not** modify the original "
 "English text in the `msgid` field. If you see a typo or an error in the "
@@ -443,11 +447,11 @@ msgstr ""
 "翻訳作業をするときは、 `msgid` フィールドの元の英文を修正 **しないで** ください。 "
 "もし原文に誤字や脱字があった場合は、原文のソースファイル（エントリーの1行目から探してください）を修正し、別途プルリクエストを提出してください。"
 
-#: ../../TRANSLATING.md:221
+#: ../../TRANSLATING.md:226
 msgid "Building the Translated Documentation"
 msgstr "翻訳されたドキュメントの構築"
 
-#: ../../TRANSLATING.md:223
+#: ../../TRANSLATING.md:228
 msgid ""
 "Once you finished translating or when you want to check the translation "
 "in context, you can build the guide locally on your computer, using the "
@@ -457,7 +461,7 @@ msgstr ""
 "翻訳が終わったら、あるいは文脈の中で翻訳をチェックしたい場合は、次のコマンドを使用して、ガイドをコンピュータにローカルに構築することができます、 "
 "LANGを適切な言語コードに置き換えます (例: スペイン語なら `es` )。"
 
-#: ../../TRANSLATING.md:229
+#: ../../TRANSLATING.md:234
 msgid ""
 "This command will build all the translated versions of the guide defined "
 "in the `LANGUAGES` list in `noxfile.py`. These translations will be "
@@ -467,7 +471,7 @@ msgstr ""
 "このコマンドは `noxfile.py` の `LANGUAGES` リストで定義されたガイドの全ての翻訳版をビルドします。 これらの翻訳版は "
 "`_build/html` に、言語コードにちなんだ名前(例えば `es`、`fr` など)のフォルダに保存されます。"
 
-#: ../../TRANSLATING.md:231
+#: ../../TRANSLATING.md:236
 msgid ""
 "To view the translated version of the guide in your browser, open the "
 "corresponding `index.html` file. For example, to view the Spanish "
@@ -476,7 +480,7 @@ msgstr ""
 "ブラウザで翻訳版のガイドを見るには、対応する `index.html` ファイルを開いてください。 例えば、スペイン語の翻訳版を見るには、 "
 "`_build/html/es/index.html` を開きます。"
 
-#: ../../TRANSLATING.md:233
+#: ../../TRANSLATING.md:238
 msgid ""
 "You can also build a live version of the guide that updates automatically"
 " as you make changes to the translation files. To do this, use the `nox "
@@ -488,7 +492,7 @@ msgstr ""
 "live-lang` コマンドを使用します。 この場合、ビルドしたい言語を指定する必要があることに注意してください。 "
 "例えば、スペイン語翻訳に取り組んでいる場合、次のように実行します:"
 
-#: ../../TRANSLATING.md:239
+#: ../../TRANSLATING.md:244
 msgid ""
 "Note the `--` before the language code, it indicates that the following "
 "arguments should be passed into the nox session and not be interpreted "
@@ -498,7 +502,7 @@ msgstr ""
 "言語コードの前の `--` に注意してください。これは次の引数がnoxセッションに渡され、noxによって直接解釈されないことを示します。 もし "
 "`--` を忘れると、noxは代わりに 'es' という名前のセッションを探し、それが存在しないとエラーを発生させます。"
 
-#: ../../TRANSLATING.md:241
+#: ../../TRANSLATING.md:246
 msgid ""
 "This command will use `sphinx-autobuild` to launch a local web server "
 "where you can access the translated version of the guide. You can open "
@@ -508,17 +512,17 @@ msgstr ""
 "を使って、ローカルのWebサーバーを起動し、そこでガイドの翻訳版にアクセスすることができます。 ブラウザで "
 "`http://localhost:8000` に移動して、ガイドを開くことができます。"
 
-#: ../../TRANSLATING.md:243
+#: ../../TRANSLATING.md:248
 msgid ""
 "This is a great way to see how the translated version of the guide looks "
 "as you make changes to the translation files."
 msgstr "これは、翻訳ファイルに変更を加えながら、翻訳版のガイドがどのように見えるかを確認するのに最適な方法です。"
 
-#: ../../TRANSLATING.md:245
+#: ../../TRANSLATING.md:250
 msgid "Submitting a PR for Your Contribution"
 msgstr "貢献PRの提出"
 
-#: ../../TRANSLATING.md:247
+#: ../../TRANSLATING.md:252
 msgid ""
 "Once you are finished translating and before you submit a pull request "
 "(PR) for your translation, you need to make sure that the translated "
@@ -526,23 +530,23 @@ msgid ""
 "correctly in the browser."
 msgstr "翻訳が終わり、翻訳のプルリクエスト（PR）を提出する前に、翻訳されたバージョンのガイドがエラーや警告なしにビルドされ、ブラウザで正しく表示されることを確認する必要があります。"
 
-#: ../../TRANSLATING.md:249
+#: ../../TRANSLATING.md:254
 msgid "You can follow these steps:"
 msgstr "以下の手順に従ってください:"
 
-#: ../../TRANSLATING.md:251
+#: ../../TRANSLATING.md:256
 msgid ""
 "Build the translations of the guide with same parameters that will be "
 "used during the release:"
 msgstr "リリース時に使用されるのと同じパラメータでガイドの翻訳をビルドします:"
 
-#: ../../TRANSLATING.md:257
+#: ../../TRANSLATING.md:262
 msgid ""
 "Make sure there are no warnings or errors in the output. If there are, "
 "you will need to fix them before submitting the PR."
 msgstr "出力に警告やエラーがないことを確認してください。 もしあれば、PRを提出する前に修正する必要があります。"
 
-#: ../../TRANSLATING.md:258
+#: ../../TRANSLATING.md:263
 msgid ""
 "Make sure the translated version of the guide looks good in the browser "
 "by opening the `_build/html/<lang>/index.html` file, where `<lang>` is "
@@ -551,18 +555,18 @@ msgstr ""
 "`_build/html/<lang>/index.html` "
 "ファイルを開いて、翻訳版のガイドがブラウザでうまく表示されることを確認してください。 `<lang>` は作業中の言語です。"
 
-#: ../../TRANSLATING.md:260
+#: ../../TRANSLATING.md:265
 msgid "If everything looks good, you can submit a PR with your changes."
 msgstr "問題がなければ、変更内容をPRとして提出することができます。"
 
-#: ../../TRANSLATING.md:263
+#: ../../TRANSLATING.md:268
 msgid ""
 "When you submit a PR for a translation, you should only include changes "
 "to one language. If you worked in multiple languages, please submit a "
 "separate PR for each language."
 msgstr "翻訳のPRを提出する際は、1つの言語に対する変更のみを記載してください。 複数の言語で翻訳した場合は、言語ごとにPRを提出してください。"
 
-#: ../../TRANSLATING.md:266
+#: ../../TRANSLATING.md:271
 msgid ""
 "Translations PRs will be tagged with a label indicating the language to "
 "make them easier to identify and review. For example, contributions to "
@@ -571,11 +575,11 @@ msgstr ""
 "翻訳PRには、識別とレビューを容易にするため、言語を示すラベルが付けられます。 例えば、スペイン語翻訳への貢献には 'lang-es' "
 "というタグが付けられます。"
 
-#: ../../TRANSLATING.md:268
+#: ../../TRANSLATING.md:273
 msgid "TODO: This tagging could be automated with a GitHub Actions."
 msgstr "TODO: このタグ付けは、GitHub Actionsで自動化できるかもしれません。"
 
-#: ../../TRANSLATING.md:270
+#: ../../TRANSLATING.md:275
 msgid ""
 "When you submit the PR, make sure to include a short description of the "
 "changes you made and any context that might be helpful for the reviewer "
@@ -583,17 +587,17 @@ msgid ""
 "typos, etc.)"
 msgstr "PRを提出する際には、あなたが行った変更についての簡単な説明と、レビュアーにとって参考になりそうな文脈（新しい文字列を翻訳した、あいまいなエントリーを見直した、誤字脱字を修正した、など）を必ず含めてください。"
 
-#: ../../TRANSLATING.md:272
+#: ../../TRANSLATING.md:277
 msgid "The Review Process"
 msgstr "レビュープロセス"
 
-#: ../../TRANSLATING.md:274
+#: ../../TRANSLATING.md:279
 msgid ""
 "The review process for a translation contribution is similar to the "
 "review process for any other contribution to the guide."
 msgstr "翻訳貢献のレビュープロセスは、ガイドへの他のレビューのレビュープロセスと同様です。"
 
-#: ../../TRANSLATING.md:276
+#: ../../TRANSLATING.md:281
 msgid ""
 "TODO: This section needs more work, depending on the review workflow we "
 "decide to adopt. Other projects usually assign a coordinator/editor for "
@@ -603,7 +607,7 @@ msgstr ""
 "TODO: このセクションは、私たちが採用するレビューのワークフローによって、もっと作業が必要です。 "
 "他のプロジェクトでは、通常、言語ごとにコーディネーター/編集者を割り当て、その人が翻訳投稿のレビューとマージに責任を持ちます。"
 
-#: ../../TRANSLATING.md:278
+#: ../../TRANSLATING.md:283
 msgid ""
 "Each language has an assigned editor who is responsible for reviewing and"
 " merging translation contributions. The editor will review the changes to"
@@ -613,7 +617,7 @@ msgstr ""
 "各言語には担当エディターがおり、翻訳投稿の確認と統合を担当します。 "
 "エディターは、変更が正確で、ガイドのスタイルやトーンと一致していることを確認します。"
 
-#: ../../TRANSLATING.md:280
+#: ../../TRANSLATING.md:285
 msgid ""
 "Sometimes the editor may ask for clarification or suggest changes to "
 "improve the translation. If this happens, you can make the requested "
@@ -623,18 +627,18 @@ msgstr ""
 "エディターが翻訳を改善するために説明を求めたり、変更を提案したりすることがあります。 "
 "このような場合は、要求された変更を行い、元のPRを投稿したブランチにプッシュしてください。"
 
-#: ../../TRANSLATING.md:282
+#: ../../TRANSLATING.md:287
 msgid ""
 "When the editor is satisfied with the translation, they will merge the "
 "PR. The translated version of the guide will be available on the "
 "pyOpenSci website once the language is released."
 msgstr "エディターが翻訳に満足したら、PRをマージします。ガイドの翻訳版は言語がリリースされ次第、pyOpenSciのウェブサイトから入手できます。"
 
-#: ../../TRANSLATING.md:284
+#: ../../TRANSLATING.md:289
 msgid "The Release Process"
 msgstr "リリースのプロセス"
 
-#: ../../TRANSLATING.md:286
+#: ../../TRANSLATING.md:291
 msgid ""
 "If a language is ready to go live, the maintainers will add the language "
 "code to the `RELEASE_LANGUAGES` list in the `noxfile.py` configuration "
@@ -643,7 +647,7 @@ msgstr ""
 "言語がライブにする準備ができたら、メンテナは `noxfile.py` 設定ファイルの `RELEASE_LANGUAGES` "
 "リストに言語コードを追加します。"
 
-#: ../../TRANSLATING.md:288
+#: ../../TRANSLATING.md:293
 msgid ""
 "When the guide is built for release in CI, Sphinx will also generate the "
 "translated versions of the guide for the languages in the "
@@ -652,27 +656,28 @@ msgstr ""
 "ガイドがCIでリリースするためにビルドされると、Sphinxは `RELEASE_LANGUAGES` "
 "リストにある言語の翻訳版のガイドも生成します。"
 
-#: ../../TRANSLATING.md:290
+#: ../../TRANSLATING.md:295
+#, fuzzy
 msgid ""
 "Translations are released in the same way as the English version of the "
 "guide, and the translated versions will be available in folders named "
 "after the language code. For example, the Spanish translation will be "
-"available in [https://www.pyopensci.org/python-package-"
-"guide/es/](https://www.pyopensci.org/python-package-guide/es/)."
+"available at: `https://www.pyopensci.org/python-package-guide/es/` when "
+"it is published online."
 msgstr ""
 "翻訳版は英語版ガイドと同じ方法でリリースされ、言語コードにちなんだフォルダで利用できるようになります。 例えば、スペイン語版は "
 "[https://www.pyopensci.org/python-package-"
 "guide/es/](https://www.pyopensci.org/python-package-guide/es/) にあります。"
 
-#: ../../TRANSLATING.md:292
+#: ../../TRANSLATING.md:297
 msgid "Frequently Asked Questions (FAQ)"
 msgstr "よくある質問(FAQ)"
 
-#: ../../TRANSLATING.md:294
+#: ../../TRANSLATING.md:299
 msgid "How do I know which strings need to be translated?"
 msgstr "どの文字列を翻訳する必要があるか、どうすればわかりますか？"
 
-#: ../../TRANSLATING.md:296
+#: ../../TRANSLATING.md:301
 msgid ""
 "When you run the `sphinx-intl stat` command, you will see a list of `.po`"
 " files with the number of translated, fuzzy, and untranslated strings. "
@@ -681,11 +686,11 @@ msgstr ""
 "`sphinx-intl stat` コマンドを実行すると、翻訳された文字列、あいまいな文字列、未翻訳の文字列を含む `.po` "
 "ファイルのリストが表示されます。 未翻訳の文字列が最も多いファイルから、作業を始めることができます。"
 
-#: ../../TRANSLATING.md:298
+#: ../../TRANSLATING.md:303
 msgid "What happens when a string has changed in the original English text?"
 msgstr "英語の原文で文字列が変更された場合はどうなりますか？"
 
-#: ../../TRANSLATING.md:300
+#: ../../TRANSLATING.md:305
 msgid ""
 "If a string has changed in the original English version, it will be "
 "marked as `fuzzy` in the translation file the next time it is updated "
@@ -699,11 +704,11 @@ msgstr ""
 "翻訳に携わっているコントリビューターは、 `fuzzy` "
 "タグを削除する前に、あいまいなエントリを確認し、正確であることを確認するために必要な変更を行うことができます。"
 
-#: ../../TRANSLATING.md:302
+#: ../../TRANSLATING.md:307
 msgid "How do I handle links in the translated text?"
 msgstr "翻訳されたテキスト内のリンクはどのように扱えばいいですか？"
 
-#: ../../TRANSLATING.md:304
+#: ../../TRANSLATING.md:309
 msgid ""
 "You should keep the links in the translated text, but make sure to update"
 " the link text if necessary. For example, if the original English text "
@@ -715,11 +720,11 @@ msgstr ""
 "Python package?](/tutorials/intro)` へのリンクがある場合、翻訳文のリンクはそのままにして、リンクテキストを "
 "`[Pythonパッケージとは何ですか](/tutorials/intro)` に更新してください。"
 
-#: ../../TRANSLATING.md:306
+#: ../../TRANSLATING.md:311
 msgid "How do I handle formatting in the translated text?"
 msgstr "翻訳されたテキストの書式設定はどうすればよいですか？"
 
-#: ../../TRANSLATING.md:308
+#: ../../TRANSLATING.md:313
 msgid ""
 "You should keep the formatting in the translated text, but make sure to "
 "translate the text inside the formatting tags as well. For example, if "
@@ -731,11 +736,11 @@ msgstr ""
 "special cases:**` の場合、翻訳されたテキストでは太字の書式を維持しますが、書式タグ内のテキストを `**特殊ケーステスト:**`"
 " に更新する必要があります。"
 
-#: ../../TRANSLATING.md:310
+#: ../../TRANSLATING.md:315
 msgid "How do I handle strings that are too long for a single line?"
 msgstr "1行では長すぎる文字列はどう扱えばいいですか？"
 
-#: ../../TRANSLATING.md:312
+#: ../../TRANSLATING.md:317
 msgid ""
 "If the original English text is too long for a single line, it may be "
 "split into multiple lines. Multiline strings in the `.po` file are "
@@ -745,11 +750,11 @@ msgstr ""
 "元の英文が長すぎて1行に収まらない場合は、複数行に分けることができます。 `.po` ファイル内の複数行の文字列は `msgid` と "
 "`msgstr` フィールドに空の文字列を入れ、その後に次の行のテキストの続きを入れることで示されます。 例えば:"
 
-#: ../../TRANSLATING.md:325
+#: ../../TRANSLATING.md:330
 msgid "How do I translate images?"
 msgstr "画像を翻訳するにはどうすればよいですか？"
 
-#: ../../TRANSLATING.md:327
+#: ../../TRANSLATING.md:332
 msgid ""
 "You should not translate images in the guide. Producing translated "
 "versions of images is a complex process that requires additional tools "
@@ -761,20 +766,20 @@ msgstr ""
 "画像の翻訳版を作成するのは、追加のツールやリソースを必要とする複雑なプロセスであり、翻訳された画像がオリジナルの画像と一緒に作成されない限り、通常は行われません。"
 " 多くの場合、画像の周りのテキストは、必要な翻訳を含むように修正されます。"
 
-#: ../../TRANSLATING.md:329
+#: ../../TRANSLATING.md:334
 msgid ""
 "In some special cases, an image might be critical to the understanding of"
 " the content. In those cases, the translations will be handled by the "
 "maintainers and editors outside this workflow."
 msgstr "特殊なケースでは、画像がコンテンツの理解に不可欠な場合があります。 そのような場合、翻訳はこのワークフロー外のメンテナやエディタが担当します。"
 
-#: ../../TRANSLATING.md:331
+#: ../../TRANSLATING.md:336
 msgid ""
 "I am interested in translating the guide into a language that is not "
 "listed. How can I get started?"
 msgstr "ガイドに掲載されていない言語への翻訳に興味があります。 どうすれば始められますか？"
 
-#: ../../TRANSLATING.md:333
+#: ../../TRANSLATING.md:338
 msgid ""
 "If you want to start a new translation of the guide into a language that "
 "is not listed, you should [create an issue](https://github.com/pyOpenSci"
@@ -788,11 +793,11 @@ msgstr ""
 "して、あなたがその翻訳に取り組むつもりであることをメンテナに知らせてください。 "
 "こうすることで、作業の重複を避け、あなたが作業を終えたときにメンテナがあなたの貢献をレビューできるようになります。"
 
-#: ../../TRANSLATING.md:335
+#: ../../TRANSLATING.md:340
 msgid "How do I know when a translation is ready to be released?"
 msgstr "翻訳がいつリリースできるか、どうすればわかりますか？"
 
-#: ../../TRANSLATING.md:337
+#: ../../TRANSLATING.md:342
 msgid ""
 "When a translation is ready to be included in the next release of the "
 "guide, the maintainers will add the language code to the "
@@ -805,18 +810,18 @@ msgstr ""
 "リストに言語コードを追加します。 "
 "これにより、リリースプロセス中に翻訳のビルドが開始され、翻訳されたバージョンのガイドがpyOpenSciのウェブサイトで利用できるようになります。"
 
-#: ../../TRANSLATING.md:339
+#: ../../TRANSLATING.md:344
 msgid ""
 "TODO: There are many approaches here, some projects release a translation"
 " as soon as some strings are translated, others wait until a certain "
 "percentage of the content is translated."
 msgstr "TODO：ここにはさまざまなアプローチがあります。あるプロジェクトでは、いくつかの文字列が翻訳されるとすぐに翻訳をリリースしますし、ある一定の割合のコンテンツが翻訳されるまで待つプロジェクトもあります。"
 
-#: ../../TRANSLATING.md:341
+#: ../../TRANSLATING.md:346
 msgid "How can I get help with my translation?"
 msgstr "翻訳を手伝ってもらうにはどうすればよいですか？"
 
-#: ../../TRANSLATING.md:343
+#: ../../TRANSLATING.md:348
 msgid ""
 "If you have any questions or need help with your translation, you can "
 "create an [issue](https://github.com/pyOpenSci/python-package-"
@@ -827,7 +832,7 @@ msgstr ""
 "/python-package-guide) に [issue](https://github.com/pyOpenSci/python-"
 "package-guide/issues) を作成してください。"
 
-#: ../../TRANSLATING.md:345
+#: ../../TRANSLATING.md:350
 msgid ""
 "You can also ask in the PyOpenSci Discord server ([click "
 "here](https://discord.gg/NQtTTqtv) to join), you will find a general "
@@ -837,4 +842,5 @@ msgid ""
 msgstr ""
 "PyOpenSci Discord サーバでも質問できます (参加は [こちら](https://discord.gg/NQtTTqtv)) "
 "、私たちのワークフロー、プロセス、ツールに関する一般的な質問用のチャンネル (translation-general) "
-"と、私たちが取り組んでいる各言語のチャンネル (spanish-translation、japanese-translationなど) があります。"
+"と、私たちが取り組んでいる各言語のチャンネル (spanish-translation、japanese-translationなど) "
+"があります。"

--- a/locales/ja/LC_MESSAGES/documentation.po
+++ b/locales/ja/LC_MESSAGES/documentation.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pyOpenSci Python Package Guide\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-20 11:32+0900\n"
+"POT-Creation-Date: 2025-07-12 11:17+0200\n"
 "PO-Revision-Date: 2025-04-14 18:12+0000\n"
 "Last-Translator: Tetsuo Koyama <tkoyama010@gmail.com>, 2025\n"
 "Language: ja\n"
@@ -1500,11 +1500,12 @@ msgstr ""
 " セキュリティポリシーは黄色い丸で囲まれています。"
 
 #: ../../documentation/repository-files/intro.md:19
+#, fuzzy
 msgid ""
 "GitHub community health looks for a readme file among other elements when"
 " it evaluates the community level health of your repository. This example"
 " is from the [MovingPandas GitHub "
-"repo](https://github.com/anitagraser/movingpandas/community) *(screen "
+"repo](https://github.com/movingpandas/movingpandas/community) *(screen "
 "shot taken Nov 23 2022)*"
 msgstr ""
 "GitHub community health は、リポジトリのコミュニティレベルの健全性を評価する際に、他の要素の中から readme "
@@ -1543,7 +1544,8 @@ msgstr ""
 "*(スクリーンショットは2022年11月23日撮影)* 。"
 
 #: ../../documentation/repository-files/license-files.md:8
-msgid "License files for scientific Python open source software"
+#, fuzzy
+msgid "License files for Python open source software"
 msgstr "科学的Pythonオープンソースソフトウェアのライセンスファイル"
 
 #: ../../documentation/repository-files/license-files.md:10
@@ -1721,10 +1723,11 @@ msgid "License recommendations from the SciPy package"
 msgstr "SciPyパッケージからのライセンス勧告"
 
 #: ../../documentation/repository-files/license-files.md:72
+#, fuzzy
 msgid ""
 "[The SciPy documentation has an excellent overview of "
 "licenses.](https://docs.scipy.org/doc/scipy/dev/core-"
-"dev/index.html#licensing). One of the key elements that these docs "
+"dev/index.html#licensing) One of the key elements that these docs "
 "recommend is ensuring that the license that you select is compatible with"
 " licenses used in many parts of the scientific Python ecosystem. Below is"
 " a highlight of this text which outlines license that are compatible with"
@@ -2580,15 +2583,15 @@ msgstr ""
 "`nbsphinx` はチュートリアルのギャラリーを作成するために、Sphinx galleryと組み合わせることができます。 "
 "しかし、ギャラリーをグリッドとしてレンダリングするのではなく、1つのカラムに全てのギャラリー要素をリストアップします。"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:1
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:2
 msgid "Document the code in your package's API using docstrings"
 msgstr "docstringsを使って、パッケージのAPIのコードを文書化する。"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:3
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:4
 msgid "What is an API?"
 msgstr "APIとは何か？"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:5
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:6
 msgid ""
 "API stands for **A**pplied **P**rogramming **I**nterface. When discussed "
 "in the context of a (Python) package, the API refers to the functions, "
@@ -2598,7 +2601,7 @@ msgstr ""
 "API は **A**pplied **P**rogramming **I**nterface の略です。 "
 "(Pythonの)パッケージの文脈で議論される場合、APIはパッケージメンテナがユーザーのために作成する関数、クラス、メソッド、属性を指します。"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:9
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:10
 msgid ""
 "A simple example of a package API element: For instance, a package might "
 "have a function called `add_numbers()` that adds up a bunch of numbers. "
@@ -2611,17 +2614,17 @@ msgstr ""
 "を呼び出すだけで、パッケージの関数が値を計算して `6` を返します。 `add_numbers` "
 "関数を呼び出すことで、パッケージのAPIを使用していることになります。"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:15
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:16
 msgid ""
 "Package APIs consist of functions, classes, methods and attributes that "
 "create a user interface."
 msgstr "パッケージAPIは、ユーザーインターフェイスを作成する関数、クラス、メソッド、属性から構成されます。"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:17
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:18
 msgid "What is a docstring and how does it relate to documentation?"
 msgstr "docstringとは何ですか？docstringとドキュメンテーションの関係は？"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:19
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:20
 msgid ""
 "In Python, a docstring refers to text in a function, method or class that"
 " describes what the function does and its inputs and outputs. Python "
@@ -2637,11 +2640,11 @@ msgstr ""
 "または [\"arguments\"](https://docs.python.org/3/faq/programming.html#faq-"
 "argument-vs-parameter) と呼び、出力を \"return values\" と呼ぶことが多いです。"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:22
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:23
 msgid "The docstring is thus important for:"
 msgstr "docstringは以下のために重要です:"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:24
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:25
 msgid ""
 "When you call `help()` in Python, for example, `help(add_numbers)` will "
 "show the text of the function's docstring. The docstring thus helps a "
@@ -2651,20 +2654,20 @@ msgstr ""
 "Pythonで `help()` を呼び出すと、例えば `help(add_numbers)` は関数のdocstringのテキストを表示します。"
 " このようにdocstringは、ユーザが自分のワークフローにより効果的に関数を適用する方法をよりよく理解するのに役立ちます。"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:25
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:26
 msgid ""
 "When you build your package's documentation, the docstrings can also be "
 "used to automatically create full API documentation that provides a clean"
 " view of all its functions, classes, methods, and attributes."
 msgstr "パッケージのドキュメントを作成するとき、docstringsを使用して、すべての関数、クラス、メソッド、属性をきれいに表示する完全なAPIドキュメントを自動的に作成することもできます。"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:28
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:29
 msgid ""
 "Example API Documentation for all functions, classes, methods, and "
 "attributes in a package."
 msgstr "パッケージ内のすべての関数、クラス、メソッド、属性の API ドキュメントの例。"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:29
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:30
 msgid ""
 "[View example high-level API documentation for the Verde package. This "
 "page lists every function and class in the package along with a brief "
@@ -2674,25 +2677,25 @@ msgstr ""
 "[Verdeパッケージの高レベルAPIドキュメントの例をご覧ください。 "
 "このページには、パッケージ内のすべての関数とクラスが、その機能の簡単な説明とともに一覧表示されています](https://www.fatiando.org/verde/latest/api/index.html)"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:30
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:31
 msgid ""
 "[You can further dig down to see what a specific function does within the"
 " package by clicking on an API "
 "element](https://www.fatiando.org/verde/latest/api/generated/verde.grid_coordinates.html#verde.grid_coordinates)"
 msgstr "[APIエレメントをクリックすることで、パッケージ内で特定の関数が何を行っているかをさらに掘り下げて確認することができます](https://www.fatiando.org/verde/latest/api/generated/verde.grid_coordinates.html#verde.grid_coordinates)"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:33
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:34
 msgid "Python package API documentation"
 msgstr "PythonパッケージAPIドキュメント"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:35
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:36
 msgid ""
 "If you have a descriptive docstring for every user-facing class, method, "
 "attribute and/or function in your package (_within reason_), then your "
 "package's API is considered well-documented."
 msgstr "もし、あなたのパッケージのすべてのユーザー向けクラス、メソッド、属性、関数に説明的なdocstringがあれば（_合理的な範囲内で_）、そのパッケージのAPIは十分に文書化されているとみなされます。"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:38
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:39
 msgid ""
 "In Python, this means that you need to add a docstring for every user-"
 "facing class, method, attribute and/or function in your package (_within "
@@ -2701,53 +2704,53 @@ msgstr ""
 "Pythonの場合、これは、パッケージ内のすべてのユーザー向けのクラス、メソッド、属性、および/または関数について、 (_無理のない範囲で_) "
 "docstringを追加する必要があることを意味します:"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:42
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:43
 msgid "Explains what the function, method, attribute, or class does"
 msgstr "関数、メソッド、属性、またはクラスが何をするのかを説明します"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:43
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:44
 msgid "Defines the `type` inputs and outputs (ie. `string`, `int`, `np.array`)"
 msgstr "入力と出力の `type` を定義します( `string` 、 `int` 、 `np.array` など)"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:44
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:45
 msgid "Explains the expected output `return` of the object, method or function."
 msgstr "オブジェクト、メソッド、関数の期待される出力 `return` を説明する。"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:47
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:48
 msgid "Three Python docstring formats and why we like NumPy style"
 msgstr "Pythonの3つのdocstringフォーマットとNumPyスタイルが好きな理由"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:49
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:50
 msgid ""
 "There are several Python docstring formats that you can choose to use "
 "when documenting your package including:"
 msgstr "Pythonのdocstringフォーマットには、パッケージを文書化する際に使用できるものがいくつかあります:"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:52
-msgid ""
-"[NumPy-style](https://numpydoc.readthedocs.io/en/latest/format.html"
-"#docstring-standard)"
-msgstr ""
-"[NumPy-style](https://numpydoc.readthedocs.io/en/latest/format.html"
-"#docstring-standard)"
-
 #: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:53
 msgid ""
-"[google style](https://sphinxcontrib-"
-"napoleon.readthedocs.io/en/latest/example_google.html)"
+"[NumPy-style](https://numpydoc.readthedocs.io/en/latest/format.html"
+"#docstring-standard)"
 msgstr ""
-"[google style](https://sphinxcontrib-"
-"napoleon.readthedocs.io/en/latest/example_google.html)"
+"[NumPy-style](https://numpydoc.readthedocs.io/en/latest/format.html"
+"#docstring-standard)"
 
 #: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:54
 msgid ""
+"[google style](https://sphinxcontrib-"
+"napoleon.readthedocs.io/en/latest/example_google.html)"
+msgstr ""
+"[google style](https://sphinxcontrib-"
+"napoleon.readthedocs.io/en/latest/example_google.html)"
+
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:55
+msgid ""
 "[reST style](https://sphinx-rtd-"
 "tutorial.readthedocs.io/en/latest/docstrings.html)"
 msgstr ""
 "[reST style](https://sphinx-rtd-"
 "tutorial.readthedocs.io/en/latest/docstrings.html)"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:58
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:59
 msgid ""
 "We suggest using [NumPy-style "
 "docstrings](https://numpydoc.readthedocs.io/en/latest/format.html"
@@ -2757,7 +2760,7 @@ msgstr ""
 "docstrings](https://numpydoc.readthedocs.io/en/latest/format.html"
 "#docstring-standard) を使うことをお勧めします:"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:61
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:62
 msgid ""
 "NumPy style docstrings are core to the scientific Python ecosystem and "
 "defined in the [NumPy style "
@@ -2768,7 +2771,7 @@ msgstr ""
 "[NumPyスタイルガイド](https://numpydoc.readthedocs.io/en/latest/format.html) "
 "で定義されています。 そのため、NumPyスタイルガイドで広く使われています。"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:62
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:63
 msgid ""
 "The Numpy style docstring is simplified and thus easier to read both in "
 "the code and when calling `help()` in Python. In contrast, some feel that"
@@ -2779,7 +2782,7 @@ msgstr ""
 "を呼び出すときでも読みやすくなっています。 "
 "対照的に、reSTスタイルのdocstringは素早くスキャンするのが難しく、モジュールの中でより多くの行を占める可能性があると感じる人もいます。"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:65
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:66
 msgid ""
 "If you are using NumPy style docstrings, be sure to include the [sphinx "
 "napoleon extension](https://www.sphinx-"
@@ -2792,11 +2795,11 @@ msgstr ""
 "doc.org/en/master/usage/extensions/napoleon.html) を含めるようにしてください。 "
 "この拡張機能により、SphinxはNumPy形式のドキュメントを正しく読み、フォーマットすることができます。"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:70
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:71
 msgid "Docstring examples Better and Best"
 msgstr "Docstringの例 Better と Best"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:72
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:73
 msgid ""
 "Below is a good example of a well-documented function. Notice that this "
 "function's docstring describes the function's inputs and the function's "
@@ -2809,11 +2812,11 @@ msgstr ""
 "この関数のdocstringには、関数の入力と出力（または戻り値）が記述されていることに注目してください。 関数の最初の説明は短いです（1行）。 "
 "その1行の説明に続いて、関数が何をするのかについて少し長い説明があります（2～3文）。 関数の戻り値も指定されています。"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:106
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:107
 msgid "Best: a docstring with example use of the function"
 msgstr "ベスト: 関数の使用例を記載したdocstring"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:108
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:109
 msgid ""
 "This example contains an example of using the function that is also "
 "tested in sphinx using "
@@ -2822,7 +2825,7 @@ msgstr ""
 "この例には、sphinxでも [doctest](https://docs.python.org/3/library/doctest.html) "
 "を使ってテストされている関数の使用例が含まれています。"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:159
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:160
 msgid ""
 "Using the above NumPy format docstring in sphinx, the autodoc extension "
 "will create the about documentation section for the `extent_to_json` "
@@ -2833,13 +2836,13 @@ msgstr ""
 "関数のabout documentationセクションを作成します。  `es.extent_to_json(rmnp)` "
 "コマンドの出力は、doctestを使ってテストすることもできます。"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:165
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:166
 msgid ""
 "Using doctest to run docstring examples in your package's methods and "
 "functions"
 msgstr "doctestを使って、パッケージのメソッドや関数でdocstringのサンプルを実行します。"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:170
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:171
 msgid ""
 "Above, we provided some examples of good, better, best docstring formats."
 " If you are using Sphinx to create your docs, you can add the "
@@ -2859,7 +2862,7 @@ msgstr ""
 "ドキュメントのチュートリアルを実行するのと同様に、 `doctest` はパッケージのコード (API) "
 "が期待通りに動作することを保証する便利なステップになります。"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:177
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:178
 msgid ""
 "It's important to keep in mind that examples in your docstrings help "
 "users using your package. Running `doctest` on those examples provides a "
@@ -2874,18 +2877,18 @@ msgstr ""
 "これらの項目はどちらも、オペレーティングシステムや Python "
 "のバージョンにまたがってパッケージのコア機能をテストするように設計された、独立したテストスイートを置き換えるものではありません。"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:185
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:186
 msgid ""
 "Below is an example of a docstring with an example. doctest will run the "
 "example below and test that if you provide `add_me` with the values 1 and"
 " 3 it will return 4."
 msgstr "doctestは以下の例を実行し、 `add_me` に1と3の値を与えると4が返されることをテストします。"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:218
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:219
 msgid "Adding type hints to your docstrings"
 msgstr "docstringに型ヒントを追加する"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:220
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:221
 msgid ""
 "In the example above, you saw the use of numpy-style docstrings to "
 "describe data types that are passed into functions as parameters or into "
@@ -2898,13 +2901,13 @@ msgstr ""
 " numpyスタイルのdocstringでは、docstringのParametersセクションにそれらのデータ型を追加します。 "
 "下の例では、パラメータ `num1` と `num2` は両方とも Python の `int` (整数) 値であるべきであることがわかります。"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:235
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:236
 msgid ""
 "Describing the expected data type that a function or method requires "
 "helps users better understand how to call a function or method."
 msgstr "関数やメソッドが必要とするデータ型を記述することで、ユーザーが関数やメソッドの呼び出し方をより理解しやすくなります。"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:238
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:239
 msgid ""
 "Type-hints add another layer of type documentation to your code. Type-"
 "hints make it easier for new developers, your future self or contributors"
@@ -2913,38 +2916,38 @@ msgstr ""
 "型ヒントは、あなたのコードに型ドキュメントの別のレイヤーを追加します。 "
 "型ヒントは、新しい開発者や将来の自分、あるいは貢献者が、あなたのコードベースについて素早く知ることを容易にします。"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:242
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:243
 msgid ""
 "Type hints are added to the definition of your function. In the example "
 "below, the parameters aNum and aNum2 are defined as being type = int "
 "(integer)."
 msgstr "型のヒントは関数の定義に追加されます。 以下の例では、パラメータaNumとaNum2はtype = int（整数）として定義されています。"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:249
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:250
 msgid ""
 "You can further describe the expected function output using `->`. Below "
 "the output of the function is also an int."
 msgstr "さらに `->` を使って、期待される関数の出力を記述することができます。以下の関数の出力も int です。"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:257
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:258
 msgid "Why use type hints"
 msgstr "型ヒントを使う理由"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:259
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:260
 msgid "Type hints:"
 msgstr "型ヒント:"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:261
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:262
 msgid "Make development and debugging faster,"
 msgstr "開発とデバッグをより速くします、"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:262
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:263
 msgid ""
 "Make it easier for a user to see the data format inputs and outputs of "
 "methods and functions,"
 msgstr "メソッドや関数のデータ・フォーマットの入出力を、ユーザーが見やすくします、"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:263
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:264
 msgid ""
 "Support using static type checking tools such as [`mypy`](https://mypy-"
 "lang.org/) which will check your code to ensure types are correct."
@@ -2952,33 +2955,33 @@ msgstr ""
 "型が正しいことを確認するためにコードをチェックする [`mypy`](https://mypy-lang.org/) "
 "のような静的型チェックツールの使用をサポートします。"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:265
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:266
 msgid "You should consider adding type hinting to your code if:"
 msgstr "あなたのコードにタイプヒンティングを追加することを検討すべきです:"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:267
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:268
 msgid "Your package performs data processing,"
 msgstr "あなたのパッケージはデータ処理を行います、"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:268
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:269
 msgid "You use functions that require complex inputs"
 msgstr "複雑な入力を必要とする関数を使用しています"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:269
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:270
 msgid ""
 "You want to lower the entrance barrier for new contributors to help you "
 "with your code."
 msgstr "あなたは、あなたのコードを手助けしてくれる新しい貢献者の入り口の障壁を低くしたいです。"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:271
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:272
 msgid "Beware of too much type hinting"
 msgstr "型ヒントの多用に注意してください"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:274
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:275
 msgid "As you add type hints to your code consider that in some cases:"
 msgstr "コードに型ヒントを追加する際には、場合によってはこのようなこともあることを考慮してほしい:"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:276
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:277
 msgid ""
 "If you have a complex code base, type hints may make code more difficult "
 "to read. This is especially true when a parameter’s input takes multiple "
@@ -2987,23 +2990,23 @@ msgstr ""
 "複雑なコードベースを持っている場合、型ヒントはコードを読みにくくする可能性がある。 "
 "パラメーターの入力が複数のデータ型を取り、それぞれをリストアップする場合は特にそうだ。"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:277
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:278
 msgid ""
 "Writing type hints for simple scripts and functions that perform obvious "
 "operations don't make sense."
 msgstr "単純なスクリプトや明らかな操作を行う関数に型ヒントを書いても意味がありません。"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:280
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:281
 msgid "Gradually adding type hints"
 msgstr "型ヒントを徐々に追加"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:282
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:283
 msgid ""
 "Adding type hints can take a lot of time. However, you can add type hints"
 " incrementally as you work on your code."
 msgstr "型ヒントの追加には多くの時間がかかります。 しかし、コードを書きながら少しずつ型ヒントを追加していくことができます。"
 
-#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:286
+#: ../../documentation/write-user-documentation/document-your-code-api-docstrings.md:287
 msgid ""
 "Adding type hints is also a great task for new contributors. It will help"
 " them get to know your package's code and structure better before digging"
@@ -3131,8 +3134,9 @@ msgid ""
 "package is good to have here as well. Or you can link to useful tutorials"
 " in the get started section."
 msgstr ""
-"**Getting started:** このセクションは、あなたのパッケージをインストールするためのクイックスタート をユーザーに提供するものです。 "
-"パッケージの使い方の小さな例もここにあると良いでしょう。 または、便利なチュートリアルへのリンクを、スタートセクションに置くこともできます。"
+"**Getting started:** このセクションは、あなたのパッケージをインストールするためのクイックスタート "
+"をユーザーに提供するものです。 パッケージの使い方の小さな例もここにあると良いでしょう。 "
+"または、便利なチュートリアルへのリンクを、スタートセクションに置くこともできます。"
 
 #: ../../documentation/write-user-documentation/get-started.md:53
 msgid ""

--- a/locales/ja/LC_MESSAGES/index.po
+++ b/locales/ja/LC_MESSAGES/index.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pyOpenSci Python Package Guide\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-20 11:32+0900\n"
+"POT-Creation-Date: 2025-07-12 11:17+0200\n"
 "PO-Revision-Date: 2025-04-14 18:12+0000\n"
 "Last-Translator: Tetsuo Koyama <tkoyama010@gmail.com>, 2025\n"
 "Language: ja\n"
@@ -184,7 +184,8 @@ msgid "[What is a Python package?](/tutorials/intro)"
 msgstr "[Pythonパッケージとは何か?](/tutorials/intro)"
 
 #: ../../index.md:76
-msgid "[Make your code installable](/tutorials/create-python-package)"
+#, fuzzy
+msgid "[Create a Python package](/tutorials/create-python-package)"
 msgstr "[コードをインストール可能にする](/tutorials/create-python-package)"
 
 #: ../../index.md:77

--- a/locales/ja/LC_MESSAGES/package-structure-code.po
+++ b/locales/ja/LC_MESSAGES/package-structure-code.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pyOpenSci Python Package Guide\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-20 11:32+0900\n"
+"POT-Creation-Date: 2025-07-12 11:17+0200\n"
 "PO-Revision-Date: 2025-04-14 18:12+0000\n"
 "Last-Translator: Tetsuo Koyama <tkoyama010@gmail.com>, 2025\n"
 "Language: ja\n"
@@ -561,6 +561,7 @@ msgid "Diagram showing the steps of a pre-commit workflow from left to right."
 msgstr "左から右へ、 pre-commit ワークフローのステップを示す図。"
 
 #: ../../package-structure-code/code-style-linting-format.md:262
+#, fuzzy
 msgid ""
 "The pre-commit workflow begins with you adding files that have changes to"
 " be staged in git. Next, you'd run git commit. When you run git commit, "
@@ -570,7 +571,7 @@ msgid ""
 "commit is canceled. You will have to fix any flake8 issues, and then re-"
 "add / stage the files to be committed. [_Image "
 "Source_](https://ljvmiranda921.github.io/notebook/2018/06/21/precommits-"
-"using-black-and-flake8/*)"
+"using-black-and-flake8/)"
 msgstr ""
 "pre-commit のワークフローは、まず git にステージすべき変更があるファイルを追加することから始まります。 次に git commit"
 " を実行します。git commit を実行すると、pre-commit フックが実行されます。 この例では、コード整形ツールである Black "
@@ -889,7 +890,7 @@ msgstr ""
 
 #: ../../package-structure-code/declare-dependencies.md:8
 #: ../../package-structure-code/declare-dependencies.md:375
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:22
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:23
 msgid "Todo"
 msgstr "Todo"
 
@@ -2484,15 +2485,15 @@ msgstr ""
 "プルリクエストの内容に満足したら、プルリクエストをマージすることができます。 "
 "すぐにマージできるPRとは、通常、プルリクエストにある更新されたYAMLファイルに記載されているあなたのプロジェクトの依存関係（実行時要件として知られています）が、新しいリリースのPyPIメタデータと一致していることを確認することです。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:1
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:2
 msgid "Use a pyproject.toml file for your package configuration & metadata"
 msgstr "パッケージの設定とメタデータにはpyproject.tomlファイルを使用します。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:10
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:11
 msgid "Important pyproject.toml take aways"
 msgstr "pyproject.tomlから得られる重要なこと"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:14
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:15
 msgid ""
 "There are only two tables that are required for an installable Python "
 "package: **[build-system]** and **[project]**. The **[project]** table "
@@ -2501,13 +2502,13 @@ msgstr ""
 "インストール可能なPythonパッケージに必要なテーブルは2つだけです: **[build-system]** と **[project]** "
 "です。 **[project]** テーブルにはパッケージのメタデータが格納されます。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:15
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:16
 msgid ""
 "There are only two _required_ fields in the **[project]** table: "
 "**name=** and **version=**."
 msgstr "**[project]** テーブルの必須フィールドは2つだけです: **name=**と **version=** です。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:16
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:17
 msgid ""
 "We suggest you add additional metadata to your `pyproject.toml` file as "
 "it will make it easier for users to find your project on PyPI."
@@ -2515,7 +2516,7 @@ msgstr ""
 "`pyproject.toml` ファイルにメタデータを追加することをお勧めします。 "
 "そうすることで、ユーザがPyPIであなたのプロジェクトを見つけやすくなります。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:17
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:18
 msgid ""
 "When you are adding classifiers to the [project] table, only use valid "
 "values from [PyPI’s classifier page](https://PyPI.org/classifiers/). An "
@@ -2525,7 +2526,7 @@ msgstr ""
 "[project] テーブルに分類を追加するときは、 [PyPIの分類ページ](https://PyPI.org/classifiers/) "
 "にある有効な値のみを使用してください。 ここで無効な値を指定すると、パッケージをビルドするときやPyPIに公開するときにエラーが発生します。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:18
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:19
 msgid ""
 "There is no specific order for tables in the `pyproject.toml` file. "
 "However fields need to be placed within the correct table sections. For "
@@ -2536,7 +2537,7 @@ msgstr ""
 "しかし、フィールドは正しいテーブルセクションに配置する必要があります。 例えば `requires =` は常に **[build-"
 "system]** テーブルと関連付ける必要があります。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:19
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:20
 msgid ""
 "**python-requires**: is important to have in your `pyproject.toml` file "
 "as it helps pip install your package."
@@ -2544,27 +2545,27 @@ msgstr ""
 "**python-requires**: `pyproject.toml`ファイルに記述することが重要です。 "
 "これはpipがパッケージをインストールするのに役立つからです。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:24
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:25
 msgid "when these are published, remove this todo"
 msgstr "これらが公開されたら、このtodoを削除します"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:33
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:34
 msgid ""
 "Need help creating your pyproject.toml file?  This tutorial will walk you"
 " through the process."
 msgstr "pyproject.tomlファイルの作成にヘルプが必要ですか？ このチュートリアルはそのプロセスを説明します。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:47
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:48
 msgid ""
 "Click here if need help migrating from setup.py/setup.cfg to "
 "pyproject.toml"
 msgstr "setup.py/setup.cfg から pyproject.toml への移行にヘルプが必要な場合はここをクリックしてください。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:57
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:58
 msgid "About the pyproject.toml file"
 msgstr "pyproject.tomlファイルについて"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:59
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:60
 msgid ""
 "Every modern Python package should include a `pyproject.toml` file. If "
 "your project is pure Python and you're using a `setup.py` or `setup.cfg` "
@@ -2575,7 +2576,7 @@ msgstr ""
 "Python で、メタデータを記述するために `setup.py` や `setup.cfg` ファイルを使っているなら、メタデータとビルド情報を"
 " `pyproject.toml` ファイルに移行することを検討するべきです。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:61
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:62
 msgid ""
 "If your project isn’t pure-python, you might still require a `setup.py` "
 "file to build the non Python extensions. However, a `pyproject.toml` file"
@@ -2585,11 +2586,11 @@ msgstr ""
 "ファイルが必要になるかもしれません。 しかし、プロジェクトのメタデータを保存するために `pyproject.toml` "
 "ファイルを使用する必要があります。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:63
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:64
 msgid "What happened to setup.py & how do i migrate to pyproject.toml?"
 msgstr "setup.pyに何が起こったのか、そしてどのようにpyproject.tomlに移行するのか？"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:65
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:66
 msgid ""
 "Prior to August 2017, Python package metadata was stored either in the "
 "`setup.py` file or a `setup.cfg` file. In recent years, there has been a "
@@ -2600,11 +2601,11 @@ msgstr ""
 "ファイルに保存されていました。 近年、Python パッケージのメタデータは、よりユーザが読みやすい `pyproject.toml` "
 "フォーマットで保存されるようになりました。 すべてのメタデータを1つのファイルに持つことです:"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:67
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:68
 msgid "simplifies package management,"
 msgstr "パッケージ管理を簡素化します、"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:68
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:69
 msgid ""
 "allows you to use a suite of different [build "
 "backends](https://www.pyopensci.org/python-package-guide/package-"
@@ -2616,11 +2617,11 @@ msgstr ""
 "structure-code/python-package-build-tools.html#build-back-ends) "
 "を使うことができます。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:69
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:70
 msgid "aligns with modern best practices."
 msgstr "現代のベストプラクティスに合致しています。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:76
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:77
 msgid ""
 "The standard file that Python packages use to [specify build requirements"
 " and metadata is called a "
@@ -2634,11 +2635,11 @@ msgstr ""
 "project-metadata/) 。メタデータ、ビルド要件、パッケージの依存関係を **pyproject.toml** "
 "ファイルに追加することは、 setup.py や setup.cfg ファイルに情報を格納することに取って代わります。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:81
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:82
 msgid "About the .toml format"
 msgstr ".toml フォーマットについて"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:83
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:84
 msgid ""
 "The **pyproject.toml** file is written in [TOML (Tom's Obvious, Minimal "
 "Language) format](https://toml.io/en/). TOML is an easy-to-read structure"
@@ -2652,25 +2653,25 @@ msgstr ""
 "TOMLは読みやすい構造で、キーと値のペアで成り立っています。 **pyproject.toml** ファイルの各セクションは "
 "`[テーブル識別子]` を含んでいます。 そのテーブル識別子の下には、その特定のテーブルの設定をサポートするキーと値のペアがあります。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:87
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:88
 msgid "Below `[build-system]` is considered a table in the toml language."
 msgstr "`[build-system]` 以下はtoml言語ではテーブルとみなされます。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:88
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:89
 msgid "Within the `build-system` table below `requires =` is a key."
 msgstr "以下の `build-system` テーブルの中で `requires =` がキーです。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:89
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:90
 msgid ""
 "The associated value for `requires` is an array containing the value "
 "`\"hatchling\"`."
 msgstr "`requires` に関連する値は、値 `\"hatchling\"` を含む配列です。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:97
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:98
 msgid "How the pyproject.toml is used when you build a package"
 msgstr "パッケージのビルド時にpyproject.tomlがどのように使用されるか"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:101
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:102
 msgid ""
 "When you publish to PyPI, you will notice that each package has metadata "
 "listed. Let’s have a look at [xclim](https://pypi.org/project/xclim/), "
@@ -2691,7 +2692,7 @@ msgstr ""
 "file](https://github.com/Ouranosinc/xclim/blob/master/pyproject.toml) "
 "によって正しい構文と分類子を用いて定義されたメタデータを入力することができます。xclimパッケージがビルドされるとき、このメタデータは配布ファイルに変換され、PyPIがメタデータを読み込んでウェブサイトに出力できるようになります。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:103
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:104
 #: ../../package-structure-code/python-package-distribution-files-sdist-wheel.md:83
 msgid ""
 "Image showing the left side bar of PyPI for the package xclim. The "
@@ -2703,7 +2704,7 @@ msgstr ""
 "xclimパッケージのPyPI左サイドバーの画像です。一番上のセクションにはClassifierとあります。その下に、開発状況、対象読者、ライセンス、自然言語、オペレーティングシステム、プログラミング言語、トピックなどの項目があります。"
 " これらの各セクションの下には、さまざまな分類オプションがあります。 \" width=\"300px\">"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:108
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:109
 #: ../../package-structure-code/python-package-distribution-files-sdist-wheel.md:88
 msgid ""
 "When you add the classifier section to your pyproject.toml and your "
@@ -2715,11 +2716,11 @@ msgstr ""
 "pyproject.tomlにclassifierセクションを追加してパッケージがビルドされると、ビルドツールはメタデータをPyPIが理解できる形式に整理し、PyPIのランディングページに表示します。"
 " これらの分類子により、ユーザはサポートするpythonのバージョンやカテゴリなどでパッケージをソートすることもできます。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:113
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:114
 msgid "Benefits of using a pyproject.toml file"
 msgstr "pyproject.tomlファイルを使用する利点"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:115
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:116
 msgid ""
 "Including your package's metadata in a separate human-readable "
 "**pyproject.toml** format also allows someone to view the project's "
@@ -2728,11 +2729,11 @@ msgstr ""
 "パッケージのメタデータを人間が読める **pyproject.toml** "
 "形式で含めると、GitHubのリポジトリでプロジェクトのメタデータを見ることができます。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:123
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:124
 msgid "Setup.py is still useful for complex package builds"
 msgstr "Setup.py は、複雑なパッケージのビルドに便利です。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:127
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:128
 msgid ""
 "Using **setup.py** to manage package builds and metadata [can cause "
 "problems with package "
@@ -2747,11 +2748,11 @@ msgstr ""
 "/setup-py-deprecated.html) 。 Python パッケージのビルドが複雑な場合、**setup.py** "
 "ファイルが必要になるかもしれません。 このガイドでは複雑なビルドは扱いませんが、将来的には複雑なビルドを扱うリソースを提供する予定です。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:133
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:134
 msgid "Optional vs. Required pyproject.toml file fields"
 msgstr "pyproject.toml ファイルのフィールドの任意と必須"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:135
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:136
 msgid ""
 "When you create your `pyproject.toml` file, there are numerous metadata "
 "fields that you can use. Below we suggest specific fields to get you "
@@ -2760,7 +2761,7 @@ msgstr ""
 "`pyproject.toml` ファイルを作成するとき、使用できるメタデータフィールドがたくさんあります。 以下では、PyPI "
 "での公開とユーザがあなたのパッケージを見つけることをサポートする、特定のフィールドを提案します。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:137
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:138
 msgid ""
 "[An overview of all of the project metadata elements can be found "
 "here.](https://packaging.python.org/en/latest/specifications/core-"
@@ -2769,11 +2770,11 @@ msgstr ""
 "[プロジェクトの全メタデータ要素の概要は、こちらをご覧ください。](https://packaging.python.org/en/latest/specifications"
 "/core-metadata/#project-url-multiple-use)"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:139
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:140
 msgid "Required fields for the `[project]` table"
 msgstr "`[project]` テーブルの必須フィールド"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:141
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:142
 msgid ""
 "As mentioned above, your `pyproject.toml` file needs to have a **`name`**"
 " and **`version`** field in order to properly build your package:"
@@ -2781,11 +2782,11 @@ msgstr ""
 "上述したように、 `pyproject.toml` ファイルはパッケージを適切にビルドするために **`name`** と "
 "**`version`** フィールドを持つ必要があります:"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:143
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:144
 msgid "`name`: This is the name of your project provided as a string"
 msgstr "`name`: プロジェクトの名前を文字列で指定します。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:144
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:145
 msgid ""
 "`version`: This is the version of your project. If you are using a SCM "
 "tool for versioning (using git tags to determine versions), then the "
@@ -2794,11 +2795,11 @@ msgstr ""
 "`version`: プロジェクトのバージョンです。 バージョン管理に SCM ツール (git タグを使用してバージョンを決定する) "
 "を使用している場合は、このバージョンは動的なものになります (詳細は後述します)。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:146
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:147
 msgid "Optional fields to include in the `[project]` table"
 msgstr "`[project]` テーブルに含めるオプションフィールド"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:148
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:149
 msgid ""
 "We strongly suggest that you also add the metadata keys below as they "
 "will help users finding your package on PyPI. These fields will make it "
@@ -2808,11 +2809,11 @@ msgstr ""
 "以下のメタデータキーも追加することを強くお勧めします。 "
 "これらのフィールドを追加することで、あなたのパッケージがどのような構造になっているのか、どのプラットフォームをサポートしているのか、どのような依存関係が必要なのかを明確にすることができます。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:153
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:154
 msgid "**Description:** this is a short one-line description of your package."
 msgstr "**Description:** これはあなたのパッケージの短い一行説明です。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:154
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:155
 msgid ""
 "**Readme:** A link to your README.md file is used for the long long-"
 "description. This information will be published on your packages PyPI "
@@ -2821,7 +2822,7 @@ msgstr ""
 "**Readme:** 長い長い説明には README.md ファイルへのリンクが使われます。 "
 "この情報はあなたのパッケージのPyPIランディングページで公開されます。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:155
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:156
 msgid ""
 "**Requires-python** (used by pip): this is a field that is used by pip. "
 "Here you tell the installer whether you are using Python 2.x or 3.x. Most"
@@ -2830,18 +2831,18 @@ msgstr ""
 "**Requires-python** (pipで使用): これはpipが使用するフィールドです。 ここでは、Python "
 "2.xと3.xのどちらを使っているかをインストーラに伝えます。 ほとんどのプロジェクトは3.xを使うでしょう。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:156
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:157
 msgid "**License:** the license you are using"
 msgstr "**ライセンス:** 使用しているライセンス"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:157
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:158
 msgid ""
 "**Authors:** these are the original authors of the package. Sometimes the"
 " authors are different from the maintainers. Other times they might be "
 "the same."
 msgstr "**Authors:** パッケージの原作者です。 作者がメンテナと異なることもあります。 また、同じ場合もあります。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:158
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:159
 msgid ""
 "**Maintainers:** you can choose to populate this or not. You can populate"
 " this using a list with a sub element for each author or maintainer name,"
@@ -2850,7 +2851,7 @@ msgstr ""
 "**Maintainers:** これを入力するかどうかを選択できます。 "
 "各作者やメンテナーの名前、Eメール、メールアドレスなどのサブ要素を持つリストを使って、この情報を入力することができます。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:166
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:167
 msgid ""
 "**dependencies:** dependencies are optional but we strongly suggest you "
 "include them in your pyproject.toml. Dependencies will be installed by "
@@ -2859,7 +2860,7 @@ msgstr ""
 "**dependencies:** 依存関係はオプションですが、pyproject.tomlに含めることを強く推奨します。 "
 "依存関係はプロジェクトがインストールされるときにpipによってインストールされ、より良いユーザーエクスペリエンスを提供します。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:168
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:169
 msgid ""
 "**`[project.optional-dependencies]`:** the optional or development "
 "dependencies will be installed if someone runs `python -m pip install "
@@ -2870,7 +2871,7 @@ msgstr ""
 "projectname[dev]` を実行したときに、オプションまたは開発用の依存パッケージがインストールされます。 "
 "これは、あなたのプロジェクトに貢献したいユーザのために、開発用の依存関係を含める良い方法です。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:170
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:171
 msgid ""
 "**keywords:** These are the keywords that will appear on your PyPI "
 "landing page. Think of them as words that people might use to search for "
@@ -2879,7 +2880,7 @@ msgstr ""
 "**keywords:** これらはPyPIのランディングページに表示されるキーワードです。 "
 "人々があなたのパッケージを検索するときに使う言葉だと考えてください。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:171
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:172
 msgid ""
 "**classifiers:** The classifiers section of your metadata is also "
 "important for the landing page of your package in PyPI and for filtering "
@@ -2892,35 +2893,35 @@ msgstr ""
 " [分類子の全オプションはこちらです](https://PyPI.org/classifiers/) 。 "
 "以下のようなクラシファイアを検討する必要があります。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:172
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:173
 msgid "Development Status"
 msgstr "開発状況"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:173
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:174
 msgid "Intended Audience"
 msgstr "対象読者"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:174
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:175
 msgid "Topic"
 msgstr "トピック"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:175
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:176
 msgid "License"
 msgstr "License"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:176
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:177
 msgid "Programming language"
 msgstr "プログラミング言語"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:178
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:179
 msgid "Advanced options in the pyproject.toml file"
 msgstr "pyproject.tomlファイルの高度なオプション"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:180
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:181
 msgid "The examples at the bottom of this page contain ..."
 msgstr "このページの下にある例には ..."
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:182
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:183
 msgid ""
 "**`[project.scripts]` (Entry points):** Entry points are optional. If you"
 " have a command line tool that runs a specific script hosted in your "
@@ -2931,7 +2932,7 @@ msgstr ""
 "パッケージでホストされている特定のスクリプトを実行するコマンドラインツールがある場合、そのスクリプトを(Pythonシェルではなく)コマンドラインで直接呼び出すためのエントリポイントを含めることができます"
 " 。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:184
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:185
 msgid ""
 "Here is an example of[a package that has entry point "
 "script](https://github.com/pyOpenSci/pyosMeta/blob/main/pyproject.toml#L60)s."
@@ -2943,7 +2944,7 @@ msgstr ""
 " の例である。 そのパッケージには、一連のタスクを実行するいくつかのコアスクリプトが定義されていることに注目してほしい。 "
 "pyOpenSciはこれらのスクリプトを使ってメタデータを処理しています。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:185
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:186
 msgid ""
 "**Dynamic Fields:** if you have fields that are dynamically populated. "
 "One example of this is if you are using scm / version control based "
@@ -2954,12 +2955,12 @@ msgstr ""
 "`setuptooms_scm`のようなツールでscm/バージョン管理ベースのバージョンを使用している場合、ダイナミックフィールドを使用することができます。"
 " (scmを使用した)バージョンなど **dynamic = [\"version\"]**"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:187
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:188
 #: ../../package-structure-code/python-package-build-tools.md:392
 msgid "Add dependencies to your pyproject.toml file"
 msgstr "pyproject.tomlファイルに依存関係を追加"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:189
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:190
 msgid ""
 "The pyproject.toml file can also be used as a replacement for the "
 "requirements.txt file which has been traditionally used to store "
@@ -2967,7 +2968,7 @@ msgid ""
 "and documentation tools such as sphinx."
 msgstr "pyproject.tomlファイルは、従来pytestのような開発依存ファイル、Blackのようなコードフォーマッタ、sphinxのようなドキュメントツールを保存するために使われてきたrequirements.txtファイルの代わりとして使うこともできます。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:191
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:192
 msgid ""
 "To add dependencies to your build, add a `[project.optional-"
 "dependencies]` table to your pyproject.toml file."
@@ -2975,19 +2976,19 @@ msgstr ""
 "ビルドに依存関係を追加するには、 `[project.optional-dependencies]` "
 "テーブルをpyproject.tomlファイルに追加します。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:193
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:194
 msgid "Then specify dependency groups as follows:"
 msgstr "次に、依存グループを以下のように指定する:"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:200
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:201
 msgid "Following the above example, you install dependencies like this:"
 msgstr "上記の例に従って、依存関係を次のようにインストールします:"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:202
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:203
 msgid "`python -m pip install -e .[tests]`"
 msgstr "`python -m pip install -e .[tests]`"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:204
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:205
 msgid ""
 "The above will install both your package in editable mode and all of the "
 "dependencies declared in the tests section of your `[project.optional-"
@@ -2996,19 +2997,19 @@ msgstr ""
 "上記は、編集可能モードのパッケージと、 `[project.optional-dependencies]` "
 "テーブルのtestsセクションで宣言されたすべての依存関係の両方をインストールします。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:206
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:207
 msgid "To install all dependencies and also your package, you'd use:"
 msgstr "すべての依存関係をインストールし、あなたのパッケージもインストールするには、次のようにします:"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:208
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:209
 msgid "`python -m pip install -e .[tests,lint,docs]`"
 msgstr "`python -m pip install -e .[tests,lint,docs]`"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:210
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:211
 msgid "Recursive dependencies"
 msgstr "再帰的依存関係"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:214
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:215
 msgid ""
 "You can also setup sets of recursive dependencies. [See this blog post "
 "for more.](https://hynek.me/articles/python-recursive-optional-"
@@ -3017,11 +3018,11 @@ msgstr ""
 "再帰的依存関係のセットをセットアップすることもできます。 [詳しくはこのブログ記事を参照。](https://hynek.me/articles"
 "/python-recursive-optional-dependencies/)"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:217
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:218
 msgid "Example pyproject.toml for building using hatchling"
 msgstr "hatchlingを使用してビルドするpyproject.tomlの例"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:219
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:220
 msgid ""
 "Below is an example build configuration for a Python project. This "
 "example package setup uses **hatchling** to build the [package's sdist "
@@ -3031,15 +3032,15 @@ msgstr ""
 "](python-package-distribution-files-sdist-wheel) をビルドするのに **hatchling** "
 "を使っています。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:227
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:228
 msgid "Notice that dependencies are specified in this file."
 msgstr "このファイルには依存関係が指定されています。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:229
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:230
 msgid "Example pyproject.toml for building using setuptools"
 msgstr "setuptoolsを使ってビルドするpyproject.tomlの例"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:231
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:232
 msgid ""
 "The package metadata including authors, keywords, etc is also easy to "
 "read. Below you can see the same TOML file that uses a different build "
@@ -3050,11 +3051,11 @@ msgstr ""
 "下の図は、異なるビルドシステム(setuptools)を使った同じTOMLファイルです。 "
 "このパッケージのビルドに必要なツールを入れ替えるのがいかに簡単かに注目してください！"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:235
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:236
 msgid "In this example package setup you use:"
 msgstr "このパッケージのセットアップ例では:"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:237
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:238
 msgid ""
 "**setuptools** to build the [package's sdist and wheels](python-package-"
 "distribution-files-sdist-wheel)"
@@ -3062,13 +3063,13 @@ msgstr ""
 "[パッケージのsdistとwheel](python-package-distribution-files-sdist-wheel) "
 "をビルドするための **setuptools** 。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:238
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:239
 msgid ""
 "**setuptools_scm** to manage package version updates using version "
 "control tags"
 msgstr "**setuptools_scm** は、バージョン管理タグを使ってパッケージのバージョン更新を管理します。"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:240
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:241
 msgid ""
 "In the example below `[build-system]` is the first table of values. It "
 "has two keys that specify the build backend API and containing package:"
@@ -3076,15 +3077,15 @@ msgstr ""
 "以下の例では、`[build-system]` が最初の値のテーブルです。 "
 "このテーブルには2つのキーがあり、ビルドバックエンドAPIとそれを含むパッケージを指定します:"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:243
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:244
 msgid "`requires =`"
 msgstr "`requires =`"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:244
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:245
 msgid "`build-back-end =`"
 msgstr "`build-back-end =`"
 
-#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:251
+#: ../../package-structure-code/pyproject-toml-python-package-metadata.md:252
 msgid ""
 "[Click here to read about our packaging build tools including PDM, "
 "setuptools, Poetry and Hatch.](/package-structure-code/python-package-"
@@ -3552,23 +3553,30 @@ msgid "Twine, Build + setuptools"
 msgstr "Twine, Build + setuptools"
 
 #: ../../package-structure-code/python-package-build-tools.md:181
+#: ../../package-structure-code/python-package-build-tools.md:215
 #: ../../package-structure-code/python-package-build-tools.md:291
+#: ../../package-structure-code/python-package-build-tools.md:304
 msgid "Flit"
 msgstr "Flit"
 
 #: ../../package-structure-code/python-package-build-tools.md:182
+#: ../../package-structure-code/python-package-build-tools.md:215
 #: ../../package-structure-code/python-package-build-tools.md:331
+#: ../../package-structure-code/python-package-build-tools.md:348
 msgid "Hatch"
 msgstr "Hatch"
 
 #: ../../package-structure-code/python-package-build-tools.md:183
 #: ../../package-structure-code/python-package-build-tools.md:215
 #: ../../package-structure-code/python-package-build-tools.md:230
+#: ../../package-structure-code/python-package-build-tools.md:251
 msgid "PDM"
 msgstr "PDM"
 
 #: ../../package-structure-code/python-package-build-tools.md:184
+#: ../../package-structure-code/python-package-build-tools.md:215
 #: ../../package-structure-code/python-package-build-tools.md:374
+#: ../../package-structure-code/python-package-build-tools.md:392
 msgid "Poetry"
 msgstr "Poetry"
 
@@ -3649,8 +3657,13 @@ msgid "Package tool features table"
 msgstr "パッケージツール機能一覧表"
 
 #: ../../package-structure-code/python-package-build-tools.md:215
-msgid "Feature, Flit, Hatch, PDM, Poetry"
-msgstr "Flit, Hatch, PDM, Poetry の特徴"
+#: ../../package-structure-code/python-package-build-tools.md:251
+#: ../../package-structure-code/python-package-build-tools.md:304
+#: ../../package-structure-code/python-package-build-tools.md:348
+#: ../../package-structure-code/python-package-build-tools.md:392
+#, fuzzy
+msgid "Feature"
+msgstr "PDMの特徴"
 
 #: ../../package-structure-code/python-package-build-tools.md:215
 msgid "Default Build Back-end"
@@ -3764,8 +3777,12 @@ msgid "PDM Features"
 msgstr "PDMの特徴"
 
 #: ../../package-structure-code/python-package-build-tools.md:251
-msgid "Feature, PDM, Notes"
-msgstr "特徴, PDM, ノート"
+#: ../../package-structure-code/python-package-build-tools.md:304
+#: ../../package-structure-code/python-package-build-tools.md:348
+#: ../../package-structure-code/python-package-build-tools.md:392
+#, fuzzy
+msgid "Notes"
+msgstr "注釈:"
 
 #: ../../package-structure-code/python-package-build-tools.md:251
 msgid ""
@@ -4015,10 +4032,6 @@ msgid "Flit Features"
 msgstr "Flitの特徴"
 
 #: ../../package-structure-code/python-package-build-tools.md:304
-msgid "Feature, Flit, Notes"
-msgstr "特徴, Flit, ノート"
-
-#: ../../package-structure-code/python-package-build-tools.md:304
 #: ../../package-structure-code/python-package-build-tools.md:348
 #: ../../package-structure-code/python-package-build-tools.md:392
 msgid "Publish to PyPI and test PyPI"
@@ -4125,10 +4138,6 @@ msgstr ""
 #: ../../package-structure-code/python-package-build-tools.md:340
 msgid "Hatch features"
 msgstr "Hatchの特徴"
-
-#: ../../package-structure-code/python-package-build-tools.md:348
-msgid "Feature, Hatch, Notes"
-msgstr "特徴, Hatch, ノート"
 
 #: ../../package-structure-code/python-package-build-tools.md:348
 msgid ""
@@ -4309,21 +4318,9 @@ msgid "Poetry features"
 msgstr "Poetryの特徴"
 
 #: ../../package-structure-code/python-package-build-tools.md:392
-msgid "Feature, Poetry, Notes"
-msgstr "特徴, Poetry, ノート"
-
-#: ../../package-structure-code/python-package-build-tools.md:392
-msgid ""
-"Poetry helps you add dependencies to your `pyproject.toml` metadata. "
-"_NOTE: currently Poetry adds dependencies using an approach that is "
-"slightly out of alignment with current Python peps - however there is a "
-"plan to fix this in an upcoming release._ Poetry also allows you to "
-"organize dependencies in groups such as  documentation, packaging and "
-"tests."
-msgstr ""
-"Poetry は `pyproject.toml` メタデータに依存関係を追加するのに役立ちます。 _NOTE: 現在のところ、Poetry "
-"は現在の Python peps とは少しずれたアプローチで依存関係を追加しています - しかし、今後のリリースでこれを修正する予定です。 _ "
-"Poetryでは、ドキュメント、パッケージング、テストなどのグループに依存関係を整理することもできます。"
+#, fuzzy
+msgid "Poetry helps you add dependencies to your `pyproject.toml` metadata."
+msgstr "pyproject.tomlファイルに依存関係を追加"
 
 #: ../../package-structure-code/python-package-build-tools.md:392
 msgid "Dependency specification"
@@ -4385,23 +4382,16 @@ msgstr ""
 "を使ってパッケージのバージョンを上げることができます。"
 
 #: ../../package-structure-code/python-package-build-tools.md:392
-msgid "✖✅"
-msgstr "✖✅"
-
-#: ../../package-structure-code/python-package-build-tools.md:392
 msgid ""
-"Poetry does not quite support current packaging standards for adding "
-"metadata to the **pyproject.toml** file but plans to fix this in an "
-"upcoming release."
+"Since version 2.0, Poetry supports most current project metadata "
+"standards. However, not all standards are supported, and it also supports"
+" the legacy Poetry format. Read below for more."
 msgstr ""
-"Poetryは **pyproject.toml** "
-"ファイルにメタデータを追加する現在のパッケージング標準を完全にサポートしているわけではありませんが、今後のリリースでこれを修正する予定です。"
 
 #: ../../package-structure-code/python-package-build-tools.md:392
-msgid ""
-"Poetry supports installing your package in editable mode using "
-"`--editable`"
-msgstr "Poetry は `--editable` を使った編集可能モードでのパッケージのインストールをサポートしています。"
+#, fuzzy
+msgid "Poetry supports installing your package in editable mode."
+msgstr "PDMは編集可能モードでのパッケージのインストールをサポートしています。"
 
 #: ../../package-structure-code/python-package-build-tools.md:392
 msgid "Poetry will build your sdist and wheel distributions using `poetry build`"
@@ -4417,29 +4407,41 @@ msgstr "Poetryの課題には次のようなものがある:"
 
 #: ../../package-structure-code/python-package-build-tools.md:411
 msgid ""
+"Poetry has its own concept of grouped dependencies (`poetry add "
+"--group=GROUP_NAME DEPENDENCY`). Dependencies added as grouped "
+"dependencies are not optional and there is no Python standard for this "
+"type of dependency. This should not be confused with \"optional\" "
+"dependencies (`poetry add --optional=GROUP_NAME DEPENDENCY`), which is "
+"standardised and lets you group your dependencies into several optional "
+"groups."
+msgstr ""
+
+#: ../../package-structure-code/python-package-build-tools.md:412
+msgid ""
+"While Poetry supports \"development\" dependencies (i.e. dependencies you"
+" use for development but not running the code, such as `pytest`), Poetry "
+"does not yet follow the standardised format for specifying such "
+"dependencies."
+msgstr ""
+
+#: ../../package-structure-code/python-package-build-tools.md:413
+#, fuzzy
+msgid ""
 "Poetry, by default, pins dependencies using an \"upper bound\" limit "
-"specified with the `^` symbol by default. However, this behavior can be "
-"over-written by specifying the dependency when you use `Poetry add` as "
-"follows: `poetry add \"requests>=2.1\"` See breakout below for more "
-"discussion on issues surrounding upper-bounds pinning."
+"(which is specified with the `^` symbol in the legacy format). However, "
+"this behavior can be over-written by specifying the dependency when you "
+"use `poetry add` as follows: `poetry add \"requests>=2.1\"` See breakout "
+"below for more discussion on issues surrounding upper-bounds pinning."
 msgstr ""
 "Poetryは、デフォルトでは、`^`シンボルで指定された \"上限\" 制限を使用して依存関係をピンします。 しかし、この動作は `Poetry"
 " add` を使うときに依存関係を以下のように指定することで上書きすることができます: `poetry add "
 "\"requests>=2.1\"` アッパーバウンドピニングをめぐる問題については、以下のブレイクアウトを参照のしてください。"
 
-#: ../../package-structure-code/python-package-build-tools.md:412
+#: ../../package-structure-code/python-package-build-tools.md:415
+#, fuzzy
 msgid ""
-"_Minor Challenge:_ The way Poetry currently adds metadata to your "
-"pyproject.toml file does not follow current Python standards. However, "
-"this is going to be addressed with Poetry release version 2.0."
-msgstr ""
-"_マイナーチェンジ:_ "
-"Poetryが現在pyproject.tomlファイルにメタデータを追加する方法は、現在のPythonの標準に従っていません。 しかし、これは "
-"Poetry リリースバージョン 2.0 で対処される予定です。"
-
-#: ../../package-structure-code/python-package-build-tools.md:414
-msgid ""
-"Poetry is an excellent tool. Use caution when using it to pin "
+"Poetry is a popular packaging tool and introduced many very useful "
+"features. However, if you decide to use it, then use caution when adding "
 "dependencies as Poetry's approach to pinning can be problematic for many "
 "builds. If you use Poetry, we strongly suggest that you override the "
 "default upper bound dependency option."
@@ -6298,3 +6300,65 @@ msgid ""
 msgstr ""
 "バージョン番号は、 `pyproject.toml` のような設定ファイルとパッケージの **_version.py** "
 "ファイルの間で手動で更新されます。"
+
+#~ msgid "Feature, Flit, Hatch, PDM, Poetry"
+#~ msgstr "Flit, Hatch, PDM, Poetry の特徴"
+
+#~ msgid "Feature, PDM, Notes"
+#~ msgstr "特徴, PDM, ノート"
+
+#~ msgid "Feature, Flit, Notes"
+#~ msgstr "特徴, Flit, ノート"
+
+#~ msgid "Feature, Hatch, Notes"
+#~ msgstr "特徴, Hatch, ノート"
+
+#~ msgid "Feature, Poetry, Notes"
+#~ msgstr "特徴, Poetry, ノート"
+
+#~ msgid ""
+#~ "Poetry helps you add dependencies to "
+#~ "your `pyproject.toml` metadata. _NOTE: "
+#~ "currently Poetry adds dependencies using "
+#~ "an approach that is slightly out "
+#~ "of alignment with current Python peps"
+#~ " - however there is a plan to"
+#~ " fix this in an upcoming release._"
+#~ " Poetry also allows you to organize"
+#~ " dependencies in groups such as  "
+#~ "documentation, packaging and tests."
+#~ msgstr ""
+#~ "Poetry は `pyproject.toml` メタデータに依存関係を追加するのに役立ちます。"
+#~ " _NOTE: 現在のところ、Poetry は現在の Python peps "
+#~ "とは少しずれたアプローチで依存関係を追加しています - しかし、今後のリリースでこれを修正する予定です。 "
+#~ "_ Poetryでは、ドキュメント、パッケージング、テストなどのグループに依存関係を整理することもできます。"
+
+#~ msgid "✖✅"
+#~ msgstr "✖✅"
+
+#~ msgid ""
+#~ "Poetry does not quite support current"
+#~ " packaging standards for adding metadata"
+#~ " to the **pyproject.toml** file but "
+#~ "plans to fix this in an upcoming"
+#~ " release."
+#~ msgstr ""
+#~ "Poetryは **pyproject.toml** "
+#~ "ファイルにメタデータを追加する現在のパッケージング標準を完全にサポートしているわけではありませんが、今後のリリースでこれを修正する予定です。"
+
+#~ msgid ""
+#~ "Poetry supports installing your package "
+#~ "in editable mode using `--editable`"
+#~ msgstr "Poetry は `--editable` を使った編集可能モードでのパッケージのインストールをサポートしています。"
+
+#~ msgid ""
+#~ "_Minor Challenge:_ The way Poetry "
+#~ "currently adds metadata to your "
+#~ "pyproject.toml file does not follow "
+#~ "current Python standards. However, this "
+#~ "is going to be addressed with "
+#~ "Poetry release version 2.0."
+#~ msgstr ""
+#~ "_マイナーチェンジ:_ "
+#~ "Poetryが現在pyproject.tomlファイルにメタデータを追加する方法は、現在のPythonの標準に従っていません。 "
+#~ "しかし、これは Poetry リリースバージョン 2.0 で対処される予定です。"

--- a/locales/ja/LC_MESSAGES/tutorials.po
+++ b/locales/ja/LC_MESSAGES/tutorials.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pyOpenSci Python Package Guide\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-20 11:32+0900\n"
+"POT-Creation-Date: 2025-07-12 11:17+0200\n"
 "PO-Revision-Date: 2025-04-14 18:12+0000\n"
 "Last-Translator: Tetsuo Koyama <tkoyama010@gmail.com>, 2025\n"
 "Language: ja\n"
@@ -23,15 +23,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
-#: ../../tutorials/add-license-coc.md:1
+#: ../../tutorials/add-license-coc.md:6
 msgid "Add a `LICENSE` & `CODE_OF_CONDUCT` to your Python package"
 msgstr "Pythonパッケージに `LICENSE` と `CODE_OF_CONDUCT` を追加します。"
 
-#: ../../tutorials/add-license-coc.md:3
+#: ../../tutorials/add-license-coc.md:8
 msgid "In the [previous lesson](add-readme) you:"
 msgstr "[前のレッスン](add-readme) では、あなたは:"
 
-#: ../../tutorials/add-license-coc.md:5
+#: ../../tutorials/add-license-coc.md:10
 msgid ""
 "<i class=\"fa-solid fa-circle-check\" style=\"color: #703c87;\"></i> "
 "Created a basic `README.md` file for your scientific Python package"
@@ -39,7 +39,7 @@ msgstr ""
 "<i class=\"fa-solid fa-circle-check\" style=\"color: #703c87;\"></i> 科学的 "
 "Python パッケージの基本的な `README.md` ファイルを作成しました。"
 
-#: ../../tutorials/add-license-coc.md:7
+#: ../../tutorials/add-license-coc.md:12
 msgid ""
 "<i class=\"fa-solid fa-circle-check\" style=\"color: #703c87;\"></i> "
 "Learned about the core components that are useful to have in a `README` "
@@ -48,27 +48,26 @@ msgstr ""
 "<i class=\"fa-solid fa-circle-check\" style=\"color: #703c87;\"></i> "
 "`README` ファイルにあると便利なコアコンポーネントについて学んだ。"
 
-#: ../../tutorials/add-license-coc.md:9 ../../tutorials/add-readme.md:10
+#: ../../tutorials/add-license-coc.md:14 ../../tutorials/add-readme.md:15
 msgid "Learning objectives"
 msgstr "学習目標"
 
-#: ../../tutorials/add-license-coc.md:12 ../../tutorials/add-readme.md:12
-#: ../../tutorials/create-python-package.md:41 ../../tutorials/pyproject-toml.md:22
-#: ../../tutorials/setup-py-to-pyproject-toml.md:15
+#: ../../tutorials/add-license-coc.md:17 ../../tutorials/add-readme.md:17
+#: ../../tutorials/pyproject-toml.md:27
 msgid "In this lesson you will learn:"
 msgstr "このレッスンで学ぶこと:"
 
-#: ../../tutorials/add-license-coc.md:14
+#: ../../tutorials/add-license-coc.md:19
 msgid ""
 "How to select a license and add a `LICENSE` file to your package "
 "repository, with a focus on the GitHub interface."
 msgstr "ライセンスを選択し、パッケージリポジトリに `LICENSE` ファイルを追加する方法。"
 
-#: ../../tutorials/add-license-coc.md:15
+#: ../../tutorials/add-license-coc.md:20
 msgid "How to add a `CODE_OF_CONDUCT` file to your package repository."
 msgstr "パッケージリポジトリに `CODE_OF_CONDUCT` ファイルを追加する方法。"
 
-#: ../../tutorials/add-license-coc.md:16
+#: ../../tutorials/add-license-coc.md:21
 msgid ""
 "How you can use the Contributors Covenant website to add generic language"
 " as a starting place for your `CODE_OF_CONDUCT`."
@@ -76,11 +75,11 @@ msgstr ""
 "`CODE_OF_CONDUCT` の出発点として一般的な言語を追加するために、Contributors "
 "Covenantのウェブサイトをどのように利用できるか。"
 
-#: ../../tutorials/add-license-coc.md:19
+#: ../../tutorials/add-license-coc.md:24
 msgid "What is a license?"
 msgstr "ライセンスとは何か？"
 
-#: ../../tutorials/add-license-coc.md:21
+#: ../../tutorials/add-license-coc.md:26
 msgid ""
 "A license contains legal language about how users can use and reuse your "
 "software. To set the `LICENSE` for your project, you:"
@@ -88,17 +87,17 @@ msgstr ""
 "ライセンスには、ユーザーがあなたのソフトウェアをどのように使用し、再利用することができるかについての法的な文言が含まれています。あなたのプロジェクトに"
 " `LICENSE` を設定するには、次のようにします:"
 
-#: ../../tutorials/add-license-coc.md:23
+#: ../../tutorials/add-license-coc.md:28
 msgid ""
 "Create a `LICENSE` file in your project directory that specifies the "
 "license that you choose for your package."
 msgstr "プロジェクトディレクトリに `LICENSE` ファイルを作成し、パッケージに選択したライセンスを指定します。"
 
-#: ../../tutorials/add-license-coc.md:24
+#: ../../tutorials/add-license-coc.md:29
 msgid "Reference that file in your `pyproject.toml` data where metadata are set."
 msgstr "メタデータが設定されている `pyproject.toml` データでそのファイルを参照します。"
 
-#: ../../tutorials/add-license-coc.md:26
+#: ../../tutorials/add-license-coc.md:31
 msgid ""
 "By adding the `LICENSE` file to your `pyproject.toml` file, the `LICENSE`"
 " will be included in your package's metadata which is used to populate "
@@ -109,11 +108,11 @@ msgstr ""
 "がパッケージのメタデータに含まれるようになります。 `LICENSE` は GitHub "
 "リポジトリのランディングページのインターフェイスでも使用されます。"
 
-#: ../../tutorials/add-license-coc.md:28
+#: ../../tutorials/add-license-coc.md:33
 msgid "What license should you use?"
 msgstr "どのライセンスを使うべきか？"
 
-#: ../../tutorials/add-license-coc.md:30
+#: ../../tutorials/add-license-coc.md:35
 msgid ""
 "We suggest that you use a permissive license that accommodates the other "
 "most commonly used licenses in the scientific Python ecosystem (MIT[^mit]"
@@ -125,11 +124,11 @@ msgstr ""
 "[choosealicense.com](https://choosealicense.com/) で一般的に推奨されているライセンスである "
 "MIT を使ってください。"
 
-#: ../../tutorials/add-license-coc.md:33
+#: ../../tutorials/add-license-coc.md:38
 msgid "Licenses for the scientific Python ecosystem"
 msgstr "科学的Pythonエコシステムのためのライセンス"
 
-#: ../../tutorials/add-license-coc.md:34
+#: ../../tutorials/add-license-coc.md:39
 msgid ""
 "[We discuss licenses for the scientific Python ecosystem in more detail "
 "here in our guidebook.](../documentation/repository-files/license-files)"
@@ -137,11 +136,11 @@ msgstr ""
 "[科学的Pythonエコシステムのライセンスについては、ガイドブックで詳しく説明しています](../documentation"
 "/repository-files/license-files)"
 
-#: ../../tutorials/add-license-coc.md:37
+#: ../../tutorials/add-license-coc.md:42
 msgid "Where should the `LICENSE` file live"
 msgstr "`LICENSE` ファイルはどこに置くべきか"
 
-#: ../../tutorials/add-license-coc.md:39
+#: ../../tutorials/add-license-coc.md:44
 msgid ""
 "Your `LICENSE` file should be placed at the root of your package's "
 "repository. When you add the `LICENSE` at the root, GitHub will "
@@ -151,13 +150,13 @@ msgstr ""
 "`LICENSE` ファイルは、パッケージのリポジトリのルートに置く必要があります。 ルートに `LICENSE` を追加すると、GitHub "
 "が魔法のごとく自動的にそれを検出し、GitHub リポジトリ内の `LICENSE` ファイルへの直接リンクをユーザーに提供します。"
 
-#: ../../tutorials/add-license-coc.md:45
+#: ../../tutorials/add-license-coc.md:50
 msgid ""
 "Image showing the GitHub repository for SunPy an accepted pyOpenSci "
 "package."
 msgstr "pyOpenSci パッケージに採用された SunPy 用のGitHubリポジトリを示す画像。"
 
-#: ../../tutorials/add-license-coc.md:47
+#: ../../tutorials/add-license-coc.md:52
 msgid ""
 "Notice at the top of the README portion of the GitHub landing page, there"
 " are three tabs directly linking to the `README` file which is visible, "
@@ -169,15 +168,15 @@ msgstr ""
 "ファイル、そしてSunPyが使用するライセンスを指定するタブの3つに直接リンクしていることに注目してください。 "
 "これらのファイルは標準的な命名規則を使ってプロジェクトディレクトリのルートに置かれているため、GitHubによって発見されます。"
 
-#: ../../tutorials/add-license-coc.md:54
+#: ../../tutorials/add-license-coc.md:59
 msgid "How to add a `LICENSE` file to your package directory"
 msgstr "パッケージディレクトリに `LICENSE` ファイルを追加する方法"
 
-#: ../../tutorials/add-license-coc.md:56
+#: ../../tutorials/add-license-coc.md:61
 msgid "There are several ways to add a `LICENSE` file:"
 msgstr "`LICENSE` ファイルを追加するにはいくつかの方法があります:"
 
-#: ../../tutorials/add-license-coc.md:58
+#: ../../tutorials/add-license-coc.md:63
 msgid ""
 "When you create a new repository on GitHub, it will ask you if you wish "
 "to add a `LICENSE` file at that time. If you select yes, it will create "
@@ -186,7 +185,7 @@ msgstr ""
 "GitHub で新しいリポジトリを作成すると、そのときに `LICENSE` ファイルを追加するかどうかを尋ねられます。 yes "
 "を選ぶと、ファイルを作成してくれます。"
 
-#: ../../tutorials/add-license-coc.md:59
+#: ../../tutorials/add-license-coc.md:64
 msgid ""
 "You can add a `LICENSE` through the GitHub gui following the [<i class"
 "=\"fa-brands fa-github\"></i> instructions "
@@ -198,23 +197,23 @@ msgstr ""
 "your-project-for-healthy-contributions/adding-a-license-to-a-repository) "
 "に従って追加することができます。"
 
-#: ../../tutorials/add-license-coc.md:60
+#: ../../tutorials/add-license-coc.md:65
 msgid "You can add the file manually as we are doing in this lesson."
 msgstr "このレッスンで行っているように、手動でファイルを追加することもできます。"
 
-#: ../../tutorials/add-license-coc.md:63
+#: ../../tutorials/add-license-coc.md:68
 msgid "If you completed the past lessons including"
 msgstr "以下を含む過去のレッスンを修了した場合"
 
-#: ../../tutorials/add-license-coc.md:65
+#: ../../tutorials/add-license-coc.md:70
 msgid "[Making your code installable](create-python-package.md) and"
 msgstr "[コードをインストール可能にする](create-python-package.md) と"
 
-#: ../../tutorials/add-license-coc.md:66
+#: ../../tutorials/add-license-coc.md:71
 msgid "[publishing your package to PyPI](publish-pypi.md)"
 msgstr "[PyPIへのパッケージの公開](publish-pypi.md)"
 
-#: ../../tutorials/add-license-coc.md:68
+#: ../../tutorials/add-license-coc.md:73
 msgid ""
 "then you already have a `LICENSE` file containing text for the MIT "
 "license in your Python package. Thus you can skip to the next section of "
@@ -223,17 +222,17 @@ msgstr ""
 "は、Python パッケージの中に MIT ライセンスのテキストを含む `LICENSE` ファイルが既にあるということです。 "
 "従って、このチュートリアルの次のセクションの `CODE_OF_CONDUCT` の追加に進むことができます。"
 
-#: ../../tutorials/add-license-coc.md:70
+#: ../../tutorials/add-license-coc.md:75
 msgid ""
 "If you don't yet have a `LICENSE` file in your directory, then continue "
 "reading."
 msgstr "あなたのディレクトリにまだ `LICENSE` ファイルがない場合は、このまま読み進めてください。"
 
-#: ../../tutorials/add-license-coc.md:73
+#: ../../tutorials/add-license-coc.md:78
 msgid "How to add a `LICENSE` to your package - the manual way"
 msgstr "パッケージに `LICENSE` を追加する方法 - 手動の方法"
 
-#: ../../tutorials/add-license-coc.md:75
+#: ../../tutorials/add-license-coc.md:80
 msgid ""
 "If you don't already have a `LICENSE` file, and you are not yet using a "
 "platform such as GitHub or GitLab, then you can create a `LICENSE` file "
@@ -242,39 +241,39 @@ msgstr ""
 "まだ `LICENSE` ファイルがなく、GitHub や GitLab などのプラットフォームを使っていない場合は、次のようにして "
 "`LICENSE` ファイルを作成します。"
 
-#: ../../tutorials/add-license-coc.md:77
+#: ../../tutorials/add-license-coc.md:82
 msgid "Create a new file called `LICENSE`. If you are using shell you can type:"
 msgstr "`LICENSE` という新しいファイルを作成します。 シェルを使っている場合は:"
 
-#: ../../tutorials/add-license-coc.md:84
+#: ../../tutorials/add-license-coc.md:89
 msgid "Go to [choosealicense.com](https://choosealicense.com/)"
 msgstr "[choosealicense.com](https://choosealicense.com/) へ。"
 
-#: ../../tutorials/add-license-coc.md:85
+#: ../../tutorials/add-license-coc.md:90
 msgid "Select permissive license"
 msgstr "寛容なライセンスを選択する"
 
-#: ../../tutorials/add-license-coc.md:86
+#: ../../tutorials/add-license-coc.md:91
 msgid ""
 "It will suggest that you use the [MIT "
 "license](https://choosealicense.com/licenses/mit/)."
 msgstr "[MITライセンス](https://choosealicense.com/licenses/mit/) を使用するよう提案されます。"
 
-#: ../../tutorials/add-license-coc.md:87
+#: ../../tutorials/add-license-coc.md:92
 msgid ""
 "Copy the license text that it provides into your `LICENSE` file that you "
 "created above."
 msgstr "そのライセンステキストを、上記で作成した `LICENSE` ファイルにコピーしてください。"
 
-#: ../../tutorials/add-license-coc.md:88
+#: ../../tutorials/add-license-coc.md:93
 msgid "Save your file. You're all done!"
 msgstr "ファイルを保存します。これで完了です！"
 
-#: ../../tutorials/add-license-coc.md:90
+#: ../../tutorials/add-license-coc.md:95
 msgid "An overview of licenses in the scientific Python ecosystem"
 msgstr "科学的Pythonエコシステムにおけるライセンスの概要"
 
-#: ../../tutorials/add-license-coc.md:93
+#: ../../tutorials/add-license-coc.md:98
 msgid ""
 "In the pyOpenSci [packaging guidebook](../documentation/repository-files"
 "/license-files), we provide an overview of licenses in the scientific "
@@ -286,7 +285,7 @@ msgstr ""
 "files) では、科学的Pythonエコシステムにおけるライセンスの概要を提供します。 "
 "なぜライセンスファイルが重要なのか、どのライセンスファイルが科学ソフトウェアに最もよく使われるのか、正しいライセンスを選択する方法についてレビューします。"
 
-#: ../../tutorials/add-license-coc.md:95
+#: ../../tutorials/add-license-coc.md:100
 msgid ""
 "If you want a broad overview of why licenses are important for protecting"
 " open source software, [check out this blog post that overviews the legal"
@@ -305,13 +304,13 @@ msgstr "GitHubのインターフェイス内に `LICENSE` ファイルを追加�
 msgid "Add license: new GitHub repository"
 msgstr "ライセンスの追加: 新しいGitHubリポジトリ"
 
-#: ../../tutorials/add-license-coc.md:106
+#: ../../tutorials/add-license-coc.md:111
 msgid ""
 "When you create a new GitHub repository you can add a `LICENSE` file "
 "through the GitHub interface."
 msgstr "GitHub リポジトリを新規作成する際に、GitHub インターフェースから `LICENSE` ファイルを追加することができます。"
 
-#: ../../tutorials/add-license-coc.md:111
+#: ../../tutorials/add-license-coc.md:116
 msgid ""
 "Screenshot of the create new repository interface that GitHub provides. "
 "The elements of this are the owner and repository name for the new repo. "
@@ -327,7 +326,7 @@ msgstr ""
 "READMEチェックボックスがあり、空白のReadmeファイルを追加してくれます。 "
 "一番下には、.gitignoreファイルを追加する行と、ライセンスを選択する行があります。"
 
-#: ../../tutorials/add-license-coc.md:113
+#: ../../tutorials/add-license-coc.md:118
 msgid ""
 "Image showing the GitHub interface that allows you to add a `LICENSE` and"
 " `README` file when you create a new repository."
@@ -337,7 +336,7 @@ msgstr "新規リポジトリ作成時に `LICENSE` と `README` ファイルを
 msgid "Add `LICENSE`: Existing GitHub repository"
 msgstr "`LICENSE` を追加する: 既存のGitHubリポジトリ"
 
-#: ../../tutorials/add-license-coc.md:119
+#: ../../tutorials/add-license-coc.md:124
 msgid ""
 "If you already have a GitHub repository for your package, then you can "
 "add a `LICENSE` using the GitHub interface by adding a new file to the "
@@ -346,7 +345,7 @@ msgstr ""
 "パッケージ用のGitHubリポジトリが既にある場合は、GitHubのインターフェースで新しいファイルを追加することで `LICENSE` "
 "ファイルを追加できます。"
 
-#: ../../tutorials/add-license-coc.md:121
+#: ../../tutorials/add-license-coc.md:126
 msgid ""
 "Follow the instructions to select and add a license to your repository on"
 " the [GitHub LICENSE page](https://docs.github.com/en/communities"
@@ -357,7 +356,7 @@ msgstr ""
 "your-project-for-healthy-contributions/adding-a-license-to-a-repository) "
 "の指示に従って、リポジトリにライセンスを選択し追加してください。"
 
-#: ../../tutorials/add-license-coc.md:122
+#: ../../tutorials/add-license-coc.md:127
 msgid ""
 "Once you have added your `LICENSE` file, be sure to sync your git local "
 "repository with the repository on GitHub.com. This means running `git "
@@ -366,7 +365,7 @@ msgstr ""
 "`LICENSE`ファイルを追加したら、必ずローカルのgitリポジトリをGitHub.com上のリポジトリと同期してください。これは、`git "
 "pull`を実行してローカルブランチを更新することを意味します。"
 
-#: ../../tutorials/add-license-coc.md:125
+#: ../../tutorials/add-license-coc.md:130
 msgid ""
 "Image showing what the LICENSE file looks like in the GItHub interface. "
 "At the top you can see the actual license which in this image is BSD "
@@ -379,13 +378,13 @@ msgstr ""
 "revised "
 "licenseです。そして、そのライセンスが何であるかと、そのライセンスに関連するパーミッションの両方を説明するテキストがあります。画像の下部には、ライセンスの実際のテキストがLICENSEファイルに表示されています。"
 
-#: ../../tutorials/add-license-coc.md:127
+#: ../../tutorials/add-license-coc.md:132
 msgid ""
 "You can view a summary of the `LICENSE` chosen on your project's GitHub "
 "landing page."
 msgstr "あなたのプロジェクトのGitHubのランディングページで、選ばれた `LICENSE` の概要を見ることができます。"
 
-#: ../../tutorials/add-license-coc.md:134
+#: ../../tutorials/add-license-coc.md:139
 msgid ""
 "Now you know how to add a `LICENSE` to your project. Next, you'll learn "
 "about the `CODE_OF_CONDUCT.md` file and how to add it to your package "
@@ -394,43 +393,43 @@ msgstr ""
 "これで、プロジェクトに`LICENSE`を追加する方法がわかりました。 "
 "次は、`CODE_OF_CONDUCT.md`ファイルと、それをパッケージディレクトリに追加する方法を説明します。"
 
-#: ../../tutorials/add-license-coc.md:139
+#: ../../tutorials/add-license-coc.md:144
 msgid "What is a code of conduct file?"
 msgstr "code of conduct ファイルとは何ですか？"
 
-#: ../../tutorials/add-license-coc.md:141
+#: ../../tutorials/add-license-coc.md:146
 msgid ""
 "A `CODE_OF_CONDUCT` file is used to establish guidelines for how people "
 "in your community interact."
 msgstr "`CODE_OF_CONDUCT` ファイルは、あなたのコミュニティの人々がどのように交流するかのガイドラインを確立するために使用されます。"
 
-#: ../../tutorials/add-license-coc.md:143
+#: ../../tutorials/add-license-coc.md:148
 msgid ""
 "This file is critical to supporting your community as it grows. The "
 "`CODE_OF_CONDUCT`:"
 msgstr "このファイルは、あなたのコミュニティが成長するのをサポートするために非常に重要です。 `CODE_OF_CONDUCT` は:"
 
-#: ../../tutorials/add-license-coc.md:146
+#: ../../tutorials/add-license-coc.md:151
 msgid ""
 "Establishes guidelines for how users and contributors interact with each "
 "other and you in your software repository."
 msgstr "ソフトウェアリポジトリにおいて、ユーザーやコントリビューターがどのように相互作用するかについてのガイドラインを確立します。"
 
-#: ../../tutorials/add-license-coc.md:147
+#: ../../tutorials/add-license-coc.md:152
 msgid "Identifies negative behaviors that you don't want in your interactions."
 msgstr "あなたが交流の中で望まない否定的な行動を特定します。"
 
-#: ../../tutorials/add-license-coc.md:149
+#: ../../tutorials/add-license-coc.md:154
 msgid ""
 "You can use your code of conduct as a tool that can be referenced when "
 "moderating challenging conversations."
 msgstr "行動規範は、困難な会話をモデレーティングする際に参照できるツールとして使うことができます。"
 
-#: ../../tutorials/add-license-coc.md:151
+#: ../../tutorials/add-license-coc.md:156
 msgid "What to put in your `CODE_OF_CONDUCT` file"
 msgstr "`CODE_OF_CONDUCT` ファイルに書くべきこと"
 
-#: ../../tutorials/add-license-coc.md:153
+#: ../../tutorials/add-license-coc.md:158
 msgid ""
 "If you are unsure of what language to add to your `CODE_OF_CONDUCT` file,"
 " we suggest that you adopt the [contributor covenant "
@@ -441,7 +440,7 @@ msgstr ""
 "language](https://www.contributor-"
 "covenant.org/version/2/1/code_of_conduct/) を出発点として採用することをお勧します。"
 
-#: ../../tutorials/add-license-coc.md:156
+#: ../../tutorials/add-license-coc.md:161
 msgid ""
 "![Contributor "
 "Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)"
@@ -449,27 +448,27 @@ msgstr ""
 "![Contributor "
 "Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)"
 
-#: ../../tutorials/add-license-coc.md:156
+#: ../../tutorials/add-license-coc.md:161
 msgid "Contributor Covenant"
 msgstr "Contributor Covenant"
 
-#: ../../tutorials/add-license-coc.md:158
+#: ../../tutorials/add-license-coc.md:163
 msgid ""
 "The `CODE_OF_CONDUCT.md` should be placed at the root of your project "
 "directory, similar to the `LICENSE` file."
 msgstr "`CODE_OF_CONDUCT.md` は、 `LICENSE` ファイルと同様に、プロジェクトディレクトリのルートに置く必要があります。"
 
-#: ../../tutorials/add-license-coc.md:160
+#: ../../tutorials/add-license-coc.md:165
 msgid "How to add a `CODE_OF_CONDUCT` file to your package directory"
 msgstr "パッケージディレクトリに `CODE_OF_CONDUCT` ファイルを追加する方法。"
 
-#: ../../tutorials/add-license-coc.md:162
+#: ../../tutorials/add-license-coc.md:167
 msgid ""
 "Add a `CODE_OF_CONDUCT.md` file to the root of your repository if it "
 "doesn't already exist."
 msgstr "`CODE_OF_CONDUCT.md` ファイルがまだ存在しない場合は、リポジトリのルートに追加してください。"
 
-#: ../../tutorials/add-license-coc.md:168
+#: ../../tutorials/add-license-coc.md:173
 msgid ""
 "Visit the [contributor covenant website](https://www.contributor-"
 "covenant.org/) and add [the markdown version of their code of "
@@ -485,15 +484,15 @@ msgstr ""
 "covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) を追加します。 "
 "プレースホルダーの情報は必ず記入してください。 本文をよく読み、内容を理解し、同意すること！"
 
-#: ../../tutorials/add-license-coc.md:170
+#: ../../tutorials/add-license-coc.md:175
 msgid "That's it - you've now added a code of conduct to your package directory."
 msgstr "これであなたのパッケージディレクトリに行動規範が追加されたことになります。"
 
-#: ../../tutorials/add-license-coc.md:172
+#: ../../tutorials/add-license-coc.md:177
 msgid "Additional Code of Conduct resources"
 msgstr "行動規範に関するその他のリソース"
 
-#: ../../tutorials/add-license-coc.md:175
+#: ../../tutorials/add-license-coc.md:180
 msgid ""
 "[<i class=\"fa-brands fa-github\"></i> Guide: `CODE_OF_CONDUCT.md` "
 "files](https://docs.github.com/en/communities/setting-up-your-project-"
@@ -503,7 +502,7 @@ msgstr ""
 "ファイル](https://docs.github.com/en/communities/setting-up-your-project-for-"
 "healthy-contributions/adding-a-code-of-conduct-to-your-project)"
 
-#: ../../tutorials/add-license-coc.md:176
+#: ../../tutorials/add-license-coc.md:181
 msgid ""
 "[pyOpenSci package guide `CODE_OF_CONDUCT.md` "
 "overview](https://www.pyopensci.org/python-package-guide/documentation"
@@ -513,29 +512,29 @@ msgstr ""
 "/python-package-guide/documentation/repository-files/code-of-conduct-"
 "file.html)"
 
-#: ../../tutorials/add-license-coc.md:179 ../../tutorials/add-readme.md:233
-#: ../../tutorials/publish-conda-forge.md:463
-#: ../../tutorials/pyproject-toml.md:673
+#: ../../tutorials/add-license-coc.md:184 ../../tutorials/add-readme.md:238
+#: ../../tutorials/publish-conda-forge.md:468
+#: ../../tutorials/pyproject-toml.md:686
 msgid "<i class=\"fa-solid fa-hands-bubbles\"></i> Wrap up"
 msgstr "<i class=\"fa-solid fa-hands-bubbles\"></i> まとめ"
 
-#: ../../tutorials/add-license-coc.md:181
+#: ../../tutorials/add-license-coc.md:186
 msgid "In this lesson and the [last lesson](add-readme), you have added a:"
 msgstr "このレッスンと [最後のレッスンでは](add-readme), 以下を追加しました:"
 
-#: ../../tutorials/add-license-coc.md:183
+#: ../../tutorials/add-license-coc.md:188
 msgid "`README` file;"
 msgstr "`README` ファイル;"
 
-#: ../../tutorials/add-license-coc.md:184
+#: ../../tutorials/add-license-coc.md:189
 msgid "`LICENSE` file and a"
 msgstr "`LICENSE` ファイルと"
 
-#: ../../tutorials/add-license-coc.md:185
+#: ../../tutorials/add-license-coc.md:190
 msgid "`CODE_OF_CONDUCT` file."
 msgstr "`CODE_OF_CONDUCT` ファイル。"
 
-#: ../../tutorials/add-license-coc.md:187
+#: ../../tutorials/add-license-coc.md:192
 msgid ""
 "These are fundamental files needed for every scientific Python package "
 "repository. These files help users understand how to use your package and"
@@ -544,11 +543,12 @@ msgstr ""
 "これらはすべての科学的なPythonパッケージリポジトリに必要な基本的なファイルです。 "
 "これらのファイルは、ユーザがあなたのパッケージの使い方を理解し、パッケージメンテナとやりとりするのに役立ちます。"
 
-#: ../../tutorials/add-license-coc.md:191
+#: ../../tutorials/add-license-coc.md:196
+#: ../../tutorials/create-python-package.md:446
 msgid "In the upcoming lessons, you will:"
 msgstr "これからのレッスンでは、あなたは:"
 
-#: ../../tutorials/add-license-coc.md:193
+#: ../../tutorials/add-license-coc.md:198
 msgid ""
 "[Add more metadata to your `pyproject.toml` file](pyproject-toml) to "
 "support building and publishing your package on PyPI."
@@ -556,74 +556,74 @@ msgstr ""
 "PyPI でのパッケージのビルドと公開をサポートするために [`pyproject.toml` ファイルにメタデータを追加します"
 "](pyproject-toml)  。"
 
-#: ../../tutorials/add-license-coc.md:194
+#: ../../tutorials/add-license-coc.md:199
 msgid ""
 "Publish a new version of your Python package to the test PyPI to preview "
 "the updated metadata landing page."
 msgstr "あなたのPythonパッケージの新しいバージョンをテストPyPIに公開して、更新されたメタデータランディングページをプレビューしてください。"
 
-#: ../../tutorials/add-license-coc.md:199
-#: ../../tutorials/create-python-package.md:642
-#: ../../tutorials/publish-conda-forge.md:475
-#: ../../tutorials/publish-pypi.md:394
+#: ../../tutorials/add-license-coc.md:204
+#: ../../tutorials/create-python-package.md:541
+#: ../../tutorials/publish-conda-forge.md:480
+#: ../../tutorials/publish-pypi.md:400
 msgid "Footnotes"
 msgstr "脚注"
 
-#: ../../tutorials/add-license-coc.md:201
+#: ../../tutorials/add-license-coc.md:206
 msgid "https://opensource.org/license/mit/"
 msgstr "https://opensource.org/license/mit/"
 
-#: ../../tutorials/add-license-coc.md:202
+#: ../../tutorials/add-license-coc.md:207
 msgid "https://opensource.org/license/bsd-3-clause/"
 msgstr "https://opensource.org/license/bsd-3-clause/"
 
-#: ../../tutorials/add-readme.md:1
+#: ../../tutorials/add-readme.md:6
 msgid "Add a README file to your Python package"
 msgstr "PythonパッケージにREADMEファイルを追加する"
 
-#: ../../tutorials/add-readme.md:3
+#: ../../tutorials/add-readme.md:8
 msgid "In the previous lessons you learned:"
 msgstr "前回のレッスンであなたは以下のことを学びました:"
 
-#: ../../tutorials/add-readme.md:5
+#: ../../tutorials/add-readme.md:10
 msgid "[What a Python package is](intro.md)"
 msgstr "[Pythonパッケージとは何か?](intro.md)"
 
-#: ../../tutorials/add-readme.md:6
+#: ../../tutorials/add-readme.md:11
 msgid "[How to make your code installable](create-python-package)"
 msgstr "[コードをインストール可能にする](create-python-package)"
 
-#: ../../tutorials/add-readme.md:7
+#: ../../tutorials/add-readme.md:12
 msgid "[How to publish your package to (test) PyPI](publish-pypi.md)"
 msgstr "[(test) PyPIにパッケージを公開する方法](publish-pypi.md)"
 
-#: ../../tutorials/add-readme.md:8
+#: ../../tutorials/add-readme.md:13
 msgid "[How to publish your package to conda-forge](publish-conda-forge.md)"
 msgstr "[パッケージをconda-forgeに公開する方法](publish-conda-forge.md)"
 
-#: ../../tutorials/add-readme.md:14
+#: ../../tutorials/add-readme.md:19
 msgid "How to add a **README.md** file to your package."
 msgstr "パッケージに **README.md** ファイルを追加する方法。"
 
-#: ../../tutorials/add-readme.md:15
+#: ../../tutorials/add-readme.md:20
 msgid "What the core elements of a **README.md** file are."
 msgstr "**README.md** ファイルの核となる要素は何か。"
 
-#: ../../tutorials/add-readme.md:18
+#: ../../tutorials/add-readme.md:23
 msgid "What is a README file?"
 msgstr "README ファイルとは何か？"
 
-#: ../../tutorials/add-readme.md:20
+#: ../../tutorials/add-readme.md:25
 msgid ""
 "The `README.md` file is a markdown file located at the root of your "
 "project directory that helps a user understand:"
 msgstr "`README.md` ファイルはプロジェクトディレクトリのルートにあるマークダウンファイルで、ユーザーの理解を助けるものです:"
 
-#: ../../tutorials/add-readme.md:23
+#: ../../tutorials/add-readme.md:28
 msgid "You package's name"
 msgstr "パッケージ名"
 
-#: ../../tutorials/add-readme.md:24
+#: ../../tutorials/add-readme.md:29
 msgid ""
 "What the package does. Your README file should clearly state the "
 "problem(s) that your software is designed to solve and its target "
@@ -632,23 +632,23 @@ msgstr ""
 "パッケージが何をするのか。 "
 "READMEファイルには、あなたのソフトウェアが解決するために設計された(複数の)問題と、その対象読者を明確に記述してください。"
 
-#: ../../tutorials/add-readme.md:25
+#: ../../tutorials/add-readme.md:30
 msgid "The current development \"state\" of the package (through badges)"
 msgstr "パッケージの現在の開発 \"状態\" （バッジを通して）"
 
-#: ../../tutorials/add-readme.md:26
+#: ../../tutorials/add-readme.md:31
 msgid "How to get started with using your package."
 msgstr "パッケージの使い始め方"
 
-#: ../../tutorials/add-readme.md:27
+#: ../../tutorials/add-readme.md:32
 msgid "How to contribute to your package"
 msgstr "パッケージに貢献する方法"
 
-#: ../../tutorials/add-readme.md:28
+#: ../../tutorials/add-readme.md:33
 msgid "How to cite your package"
 msgstr "パッケージの引用方法"
 
-#: ../../tutorials/add-readme.md:30
+#: ../../tutorials/add-readme.md:35
 msgid ""
 "Your **README.md** file is important as it is often the first thing that "
 "someone sees before they install your package. The README file is also "
@@ -657,7 +657,7 @@ msgstr ""
 "**README.md** ファイルは、誰かがあなたのパッケージをインストールする前に、最初に目にすることが多いので重要です。 "
 "READMEファイルはPyPIのランディングページに入力するためにも使われます。"
 
-#: ../../tutorials/add-readme.md:32
+#: ../../tutorials/add-readme.md:37
 msgid ""
 "Note that there is no specific content structure for README files. "
 "However, this tutorial outlines the sections that we suggest that you "
@@ -666,63 +666,63 @@ msgstr ""
 "READMEファイルには特定のコンテンツ構造はないことに注意してください。 "
 "しかし、このチュートリアルでは、READMEファイルに含めることを推奨するセクションの概要を説明します。"
 
-#: ../../tutorials/add-readme.md:36
+#: ../../tutorials/add-readme.md:41
 msgid "Create a README.md file for your package"
 msgstr "パッケージの README.md ファイルを作成する"
 
-#: ../../tutorials/add-readme.md:38
+#: ../../tutorials/add-readme.md:43
 msgid "It's time to add a `README.md` file to your project directory."
 msgstr "`README.md` ファイルをプロジェクト・ディレクトリに追加しましょう。"
 
-#: ../../tutorials/add-readme.md:40
+#: ../../tutorials/add-readme.md:45
 msgid "Step 0: Create a README file"
 msgstr "ステップ0: READMEファイルの作成"
 
-#: ../../tutorials/add-readme.md:41
+#: ../../tutorials/add-readme.md:46
 msgid ""
 "To get started, if you don't already have a README.md file in your "
 "project directory, create one."
 msgstr "まず、プロジェクトディレクトリにまだREADME.mdファイルがない場合は、作成してください。"
 
-#: ../../tutorials/add-readme.md:44
+#: ../../tutorials/add-readme.md:49
 msgid "If you created your project directory from"
 msgstr "以下からプロジェクトディレクトリを作成した場合"
 
-#: ../../tutorials/add-readme.md:46
+#: ../../tutorials/add-readme.md:51
 msgid "a GitHub repository online"
 msgstr "オンラインのGitHubリポジトリ"
 
-#: ../../tutorials/add-readme.md:47
+#: ../../tutorials/add-readme.md:52
 msgid "using `hatch init`"
 msgstr "`hatch init` を使用する。"
 
-#: ../../tutorials/add-readme.md:49
+#: ../../tutorials/add-readme.md:54
 msgid "Then you may already have a README.MD file in your project directory."
 msgstr "その場合、プロジェクトディレクトリに README.MD ファイルが既にあるかもしれません。"
 
-#: ../../tutorials/add-readme.md:55
+#: ../../tutorials/add-readme.md:60
 msgid "Step 1: Add the name of your package as the README title"
 msgstr "ステップ1: READMEのタイトルにパッケージ名を追加する"
 
-#: ../../tutorials/add-readme.md:57
+#: ../../tutorials/add-readme.md:62
 msgid "At the top of the `README.md` file, add the name of your package."
 msgstr "`README.md` ファイルの先頭に、パッケージ名を追加します。"
 
-#: ../../tutorials/add-readme.md:59
+#: ../../tutorials/add-readme.md:64
 msgid ""
 "If you are using markdown it should be a header 1 (H1) tag which is "
 "denoted with a single `#` sign."
 msgstr "マークダウンを使用している場合は、 `#` 記号1つで示されるヘッダー1  (H1) タグでなければなりません。"
 
-#: ../../tutorials/add-readme.md:61
+#: ../../tutorials/add-readme.md:66
 msgid "`# Package-title-here`"
 msgstr "`# Package-title-here`"
 
-#: ../../tutorials/add-readme.md:63
+#: ../../tutorials/add-readme.md:68
 msgid "Step 2: add badges to the top of your README file"
 msgstr "ステップ2: READMEファイルの先頭にバッジを追加する"
 
-#: ../../tutorials/add-readme.md:65
+#: ../../tutorials/add-readme.md:70
 msgid ""
 "It's common for maintainers to add badges to the top of their README "
 "files. Badges allow you and your package users to track things like:"
@@ -730,21 +730,21 @@ msgstr ""
 "メンテナが README ファイルの先頭にバッジを追加するのはよくあることです。 "
 "バッジをつけることで、あなたとあなたのパッケージのユーザは以下のようなことを追跡できるようになります:"
 
-#: ../../tutorials/add-readme.md:67
+#: ../../tutorials/add-readme.md:72
 msgid "Broken documentation and test builds."
 msgstr "ドキュメントとテストビルドが壊れています。"
 
-#: ../../tutorials/add-readme.md:68
+#: ../../tutorials/add-readme.md:73
 msgid "Versions of your package that are on PyPI and conda."
 msgstr "PyPIとcondaにあるあなたのパッケージのバージョン。"
 
-#: ../../tutorials/add-readme.md:69
+#: ../../tutorials/add-readme.md:74
 msgid ""
 "Whether your package has been reviewed and vetted by an organization such"
 " as pyOpenSci and/or JOSS."
 msgstr "あなたのパッケージがpyOpenSciやJOSSのような組織によってレビューされ、審査されたかどうか。"
 
-#: ../../tutorials/add-readme.md:71
+#: ../../tutorials/add-readme.md:76
 msgid ""
 "If you have already published your package to pypi.org you can use "
 "[shields.io to create a package version badge](https://shields.io/badges"
@@ -755,51 +755,51 @@ msgstr ""
 "[shields.ioでパッケージのバージョンバッジを作成](https://shields.io/badges/py-pi-version) "
 "することができます。 このバッジは、あなたが新しいバージョンのパッケージをPyPIにリリースすると動的に更新されます。"
 
-#: ../../tutorials/add-readme.md:73
+#: ../../tutorials/add-readme.md:78
 msgid ""
 "If not, you can leave the top empty for now and add badges to your README"
 " at a later point as they make sense."
 msgstr "そうでない場合は、今のところ上部を空にしておいて、後でREADMEにバッジを追加することができます。"
 
-#: ../../tutorials/add-readme.md:75
+#: ../../tutorials/add-readme.md:80
 msgid "Step 3: Add a description of what your package does"
 msgstr "ステップ 3: パッケージの説明を追加する"
 
-#: ../../tutorials/add-readme.md:77
+#: ../../tutorials/add-readme.md:82
 msgid ""
 "Below the badges (if you have them), add a section of text that provides "
 "an easy-to-understand overview of what your package does."
 msgstr "バッジの下に（バッジがある場合）、あなたのパッケージが何をするのかをわかりやすく説明するテキストのセクションを追加します。"
 
-#: ../../tutorials/add-readme.md:81
+#: ../../tutorials/add-readme.md:86
 msgid "Keep this section short."
 msgstr "このセクションは短めにしてください。"
 
-#: ../../tutorials/add-readme.md:82
+#: ../../tutorials/add-readme.md:87
 msgid "Try to avoid jargon."
 msgstr "専門用語はなるべく避けてください。"
 
-#: ../../tutorials/add-readme.md:83
+#: ../../tutorials/add-readme.md:88
 msgid ""
 "Define technical terms that you use to make the description accessible to"
 " more people."
 msgstr "説明をより多くの人が理解できるように、使用する専門用語を定義します。"
 
-#: ../../tutorials/add-readme.md:85
+#: ../../tutorials/add-readme.md:90
 msgid ""
 "Remember that the more people understand what your package does, the more"
 " people will use it."
 msgstr "あなたのパッケージが何をするものなのか、より多くの人が理解すればするほど、より多くの人がそれを使うようになることを忘れないでください。"
 
-#: ../../tutorials/add-readme.md:87
+#: ../../tutorials/add-readme.md:92
 msgid "Step 4: Add package installation instructions"
 msgstr "ステップ4: パッケージのインストール方法を追加する"
 
-#: ../../tutorials/add-readme.md:89
+#: ../../tutorials/add-readme.md:94
 msgid "Next, add instructions that tell users how to install your package."
 msgstr "次に、ユーザーにパッケージのインストール方法を説明するインストラクションを追加します。"
 
-#: ../../tutorials/add-readme.md:91
+#: ../../tutorials/add-readme.md:96
 msgid ""
 "For example, can they use pip to install your package? `python -m pip "
 "install packagename`"
@@ -807,25 +807,25 @@ msgstr ""
 "例えば、彼らはあなたのパッケージをインストールするためにpipを使うことができますか？ `python -m pip install "
 "packagename`"
 
-#: ../../tutorials/add-readme.md:94
+#: ../../tutorials/add-readme.md:99
 msgid "or conda?"
 msgstr "それともconda？"
 
-#: ../../tutorials/add-readme.md:96
+#: ../../tutorials/add-readme.md:101
 msgid "`conda install -c conda-forge packagename`."
 msgstr "conda install -c conda-forge packagename`."
 
-#: ../../tutorials/add-readme.md:98
+#: ../../tutorials/add-readme.md:103
 msgid ""
 "If you haven't yet published your package to pypi.org then you can skip "
 "this section and come back and add these instructions later."
 msgstr "まだパッケージをpypi.orgに公開していない場合は、このセクションを読み飛ばして、後でこれらの説明を追加してください。"
 
-#: ../../tutorials/add-readme.md:102
+#: ../../tutorials/add-readme.md:107
 msgid "Step 5: Any additional setup"
 msgstr "ステップ5：追加設定"
 
-#: ../../tutorials/add-readme.md:104
+#: ../../tutorials/add-readme.md:109
 msgid ""
 "In some cases, your package users may need to manually install other "
 "tools in order to use your package. If that is the case, be sure to add a"
@@ -834,31 +834,31 @@ msgstr ""
 "場合によっては、あなたのパッケージを使用するために、あなたのパッケージのユーザーが他のツールを手動でインストールする必要があるかもしれません。 "
 "その場合は、READMEファイルに追加セットアップのセクションを追加してください。"
 
-#: ../../tutorials/add-readme.md:109
+#: ../../tutorials/add-readme.md:114
 msgid ""
 "Here, briefly document (or link to documentation for) any additional "
 "setup that is required to use your package. This might include:"
 msgstr "ここで、あなたのパッケージを使うために必要な追加設定を簡単に文書化 (または文書へのリンク) をしてください。これには以下が含まれます:"
 
-#: ../../tutorials/add-readme.md:113
+#: ../../tutorials/add-readme.md:118
 msgid "authentication information, if it is applicable to your package."
 msgstr "認証情報、あなたのパッケージに適用される場合。"
 
-#: ../../tutorials/add-readme.md:114
+#: ../../tutorials/add-readme.md:119
 msgid "additional tool installations, such as GDAL."
 msgstr "GDALのような追加ツールのインストール。"
 
-#: ../../tutorials/add-readme.md:117
+#: ../../tutorials/add-readme.md:122
 msgid ""
 "Many packages won't need an additional setup section in their README. In "
 "that case you can always skip this section."
 msgstr "多くのパッケージでは、READMEに追加のセットアップセクションは必要ありません。 その場合、このセクションはいつでも読み飛ばすことができます。"
 
-#: ../../tutorials/add-readme.md:122
+#: ../../tutorials/add-readme.md:127
 msgid "Step 6: Add a get started section"
 msgstr "ステップ6: スタートセクションの追加"
 
-#: ../../tutorials/add-readme.md:124
+#: ../../tutorials/add-readme.md:129
 msgid ""
 "Next add a get-started section. Within this section, add a small code "
 "example that demonstrates importing and using some of the functionality "
@@ -867,33 +867,33 @@ msgstr ""
 "次に、get-started セクションを追加します。 "
 "このセクションに、パッケージの機能の一部をインポートして使用することを示す、小さなコード例を追加します。"
 
-#: ../../tutorials/add-readme.md:127
+#: ../../tutorials/add-readme.md:132
 msgid "Provide a fully functional code snippet if possible"
 msgstr "可能であれば、完全に機能するコードスニペットを提供してください。"
 
-#: ../../tutorials/add-readme.md:130
+#: ../../tutorials/add-readme.md:135
 msgid ""
 "It is important to try to make the code examples that you provide your "
 "users as useful as possible."
 msgstr "ユーザーに提供するコード例は、できるだけ役立つものにするよう努めることが重要です。"
 
-#: ../../tutorials/add-readme.md:132
+#: ../../tutorials/add-readme.md:137
 msgid ""
 "Be sure to provide a copy/paste code example that will work as-is when "
 "pasted into a Jupyter Notebook or .py file if that is possible."
 msgstr "可能であれば、Jupyter Notebookや.pyファイルに貼り付けてもそのまま動作するようなコピー＆ペーストのコード例を必ず提示してください。"
 
-#: ../../tutorials/add-readme.md:134
+#: ../../tutorials/add-readme.md:139
 msgid ""
 "If there are tokens and other steps needed to run your package, be sure "
 "to be clear about what those steps are."
 msgstr "あなたのパッケージを実行するために必要なトークンや他のステップがある場合、それらのステップが何であるかを明確にするようにしてください。"
 
-#: ../../tutorials/add-readme.md:137
+#: ../../tutorials/add-readme.md:142
 msgid "For the pyosPackage, a short get started demo might look like this:"
 msgstr "pyosPackageの場合、簡単に始めるデモは次のようになります:"
 
-#: ../../tutorials/add-readme.md:145
+#: ../../tutorials/add-readme.md:150
 msgid ""
 "Or it could simply be a link to a getting started tutorial that you have "
 "created. If you don't have this yet, you can leave it empty for the time "
@@ -902,17 +902,17 @@ msgstr ""
 "あるいは、あなたが作成したチュートリアルへのリンクでもかまいません。 "
 "まだチュートリアルをお持ちでない場合は、当分の間、空欄のままにしておいてください。"
 
-#: ../../tutorials/add-readme.md:148
+#: ../../tutorials/add-readme.md:153
 msgid ""
 "This would also be a great place to add links to tutorials that help "
 "users understand how to use your package for common workflows."
 msgstr "また、一般的なワークフローでのパッケージの使い方を理解するのに役立つチュートリアルへのリンクを追加するのにも最適な場所です。"
 
-#: ../../tutorials/add-readme.md:153
+#: ../../tutorials/add-readme.md:158
 msgid "Step 7: Community section"
 msgstr "ステップ7: コミュニティセクション"
 
-#: ../../tutorials/add-readme.md:155
+#: ../../tutorials/add-readme.md:160
 msgid ""
 "The community section of your README file is a place to include "
 "information for users who may want to engage with your project. This "
@@ -921,7 +921,7 @@ msgstr ""
 "READMEファイルのコミュニティセクションは、あなたのプロジェクトに参加したいユーザーのための情報を含める場所です。 この参加は、おそらく "
 "GitHub や GitLab のようなプラットフォームで行われるでしょう。"
 
-#: ../../tutorials/add-readme.md:157
+#: ../../tutorials/add-readme.md:162
 msgid ""
 "In the community section, you will add links to your contributing guide "
 "and `CODE_OF_CONDUCT.md`. You will create a [`CODE_OF_CONDUCT.md` file in"
@@ -930,40 +930,40 @@ msgstr ""
 "コミュニティセクションでは、あなたの貢献ガイドと `CODE_OF_CONDUCT.md` へのリンクを追加します。 [次のレッスンでは "
 "`CODE_OF_CONDUCT.md` ファイル](add-license-coc) を作成することになります。"
 
-#: ../../tutorials/add-readme.md:160
+#: ../../tutorials/add-readme.md:165
 msgid ""
 "As your package grows you may also have a link to a development guide "
 "that contributors and your maintainer team will follow. The development "
 "guide outlines how to perform maintenance tasks such as:"
 msgstr "パッケージが大きくなるにつれて、貢献者やメンテナチームが従う開発ガイドへのリンクを持つこともできます。この開発ガイドには、次のようなメンテナンス作業の方法が概説されています:"
 
-#: ../../tutorials/add-readme.md:163
+#: ../../tutorials/add-readme.md:168
 msgid "running tests"
 msgstr "テストの実行"
 
-#: ../../tutorials/add-readme.md:164
+#: ../../tutorials/add-readme.md:169
 msgid "making package releases"
 msgstr "パッケージのリリース"
 
-#: ../../tutorials/add-readme.md:165
+#: ../../tutorials/add-readme.md:170
 msgid "building documentation"
 msgstr "ドキュメントの作成"
 
-#: ../../tutorials/add-readme.md:166
+#: ../../tutorials/add-readme.md:171
 msgid "and more."
 msgstr "などなど。"
 
-#: ../../tutorials/add-readme.md:170
+#: ../../tutorials/add-readme.md:175
 msgid "Step 8: Citation information"
 msgstr "ステップ8: 引用情報"
 
-#: ../../tutorials/add-readme.md:172
+#: ../../tutorials/add-readme.md:177
 msgid ""
 "Finally it is important to let users know how to cite your package. You "
 "can communicate citation information in a few different ways."
 msgstr "最後に、ユーザーにあなたのパッケージの引用方法を知らせることが重要です。 引用情報を伝える方法はいくつかあります。"
 
-#: ../../tutorials/add-readme.md:175
+#: ../../tutorials/add-readme.md:180
 msgid ""
 "You can use a tool such as zenodo to create a DOI and associated citation"
 " information for your package if it is hosted on a platform such as "
@@ -974,7 +974,7 @@ msgstr ""
 " [この短いチュートリアルで、その設定をチェックしてみましょう。](https://coderefinery.github.io/github-"
 "without-command-line/doi/)"
 
-#: ../../tutorials/add-readme.md:179
+#: ../../tutorials/add-readme.md:184
 msgid ""
 "Alternatively if you send your package through a peer review process such"
 " as the [one lead by pyOpenSci](https://www.pyopensci.org/about-peer-"
@@ -990,15 +990,15 @@ msgstr ""
 "Softwareとの提携により](https://www.pyopensci.org/about-peer-review/index.html) "
 "相互参照DOIを得ることができます。"
 
-#: ../../tutorials/add-readme.md:183
+#: ../../tutorials/add-readme.md:188
 msgid "The finished README file"
 msgstr "完成したREADMEファイル"
 
-#: ../../tutorials/add-readme.md:185
+#: ../../tutorials/add-readme.md:190
 msgid "Your finished `README.md` file should look something like this:"
 msgstr "完成した `README.md` ファイルは次のようになるはずです:"
 
-#: ../../tutorials/add-readme.md:235
+#: ../../tutorials/add-readme.md:240
 msgid ""
 "It's important to consider the information that a new user or contributor"
 " might need when creating your `README.md` file. While there is no "
@@ -1011,7 +1011,7 @@ msgstr ""
 "完璧なテンプレートは存在しないが、上記はこれから始めようとしているあなたへの推奨事項です。 "
 "あなたがパッケージをさらに開発し、コミュニティがあなたのパッケージを使い始めるにつれて、このファイルに他の要素を追加する必要性が出てくるかもしれません。"
 
-#: ../../tutorials/add-readme.md:241
+#: ../../tutorials/add-readme.md:246
 msgid ""
 "In the [next lesson](add-license-coc.md), you will add a LICENSE file to "
 "your Python package. A license file is critical as it tells users how "
@@ -1020,19 +1020,19 @@ msgstr ""
 "[次のレッスン](add-license-coc.md) では、 LICENSEファイルをPythonパッケージに追加します。 "
 "ライセンスファイルは、ユーザーがあなたのパッケージを合法的にどのように使うことができるのか（そして使うことができないのか）を示す重要なものです。また:"
 
-#: ../../tutorials/add-readme.md:245
+#: ../../tutorials/add-readme.md:250
 msgid "Builds trust with your users"
 msgstr "ユーザーとの信頼関係を築く"
 
-#: ../../tutorials/add-readme.md:246
+#: ../../tutorials/add-readme.md:251
 msgid "Discourages misuse of your package and associated code"
 msgstr "パッケージと関連コードの悪用を防ぐ"
 
-#: ../../tutorials/command-line-reference.md:1 ../../tutorials/intro.md:54
+#: ../../tutorials/command-line-reference.md:6 ../../tutorials/intro.md:60
 msgid "Command Line Reference Guide"
 msgstr "コマンドラインリファレンスガイド"
 
-#: ../../tutorials/command-line-reference.md:4
+#: ../../tutorials/command-line-reference.md:9
 msgid ""
 "**What these tables are:** These tables summarize the command line inputs"
 " (e.g., `pipx install hatch`,  `hatch build`) necessary to complete all "
@@ -1043,7 +1043,7 @@ msgstr ""
 "でのパッケージの公開まで、パッケージ作成プロセスのすべてのステップを完了するために必要なコマンドライン入力 (e.g., `pipx "
 "install hatch`, `hatch build`) をまとめたものです。"
 
-#: ../../tutorials/command-line-reference.md:6
+#: ../../tutorials/command-line-reference.md:11
 msgid ""
 "**What these tables are not:** These tables do not cover the manual/non-"
 "automated steps (e.g., create PyPI account, create PyPI API token) you "
@@ -1052,7 +1052,7 @@ msgstr ""
 "**これらの表は何でないか:** これらの表は、パッケージの作成プロセスを通して完了しなければならない手動/非自動ステップ "
 "(PyPIアカウントの作成、PyPI APIトークンの作成など) をカバーしていません。"
 
-#: ../../tutorials/command-line-reference.md:8
+#: ../../tutorials/command-line-reference.md:13
 msgid ""
 "**Operating system note:** The current iteration of this guide has been "
 "tested on the Windows OS only. Many commands are Windows-specific. OS-"
@@ -1065,502 +1065,61 @@ msgstr ""
 "[COMMAND_DESCRIPTION] (Windows) のように括弧をつけて表示されます。 "
 "macOSとLinuxに対応するコマンドは今後追加されます。"
 
-#: ../../tutorials/command-line-reference.md:11
+#: ../../tutorials/command-line-reference.md:16
 msgid "Environment Setup"
 msgstr "環境設定"
 
-#: ../../tutorials/command-line-reference.md:33
+#: ../../tutorials/command-line-reference.md:38
 msgid "Package Development"
 msgstr "パッケージ開発"
 
-#: ../../tutorials/command-line-reference.md:52
+#: ../../tutorials/command-line-reference.md:57
 msgid "Package Publishing"
 msgstr "パッケージパブリッシング"
 
-#: ../../tutorials/command-line-reference.md:71
+#: ../../tutorials/command-line-reference.md:76
 msgid "Versions and Environments"
 msgstr "バージョンと環境"
 
-#: ../../tutorials/get-to-know-hatch.md:1
-msgid "Get to Know Hatch"
-msgstr "Hatchを知る"
-
-#: ../../tutorials/get-to-know-hatch.md:3
-msgid ""
-"Our Python packaging tutorials use the tool "
-"[Hatch](https://hatch.pypa.io/latest/). While there are [many great "
-"packaging tools](/package-structure-code/python-package-build-tools) out "
-"there, we have selected Hatch because:"
-msgstr ""
-"私たちの Python パッケージングチュートリアルは [Hatch](https://hatch.pypa.io/latest/) "
-"というツールを使っています。 世の中には [たくさんの素晴らしいパッケージングツール](/package-structure-code"
-"/python-package-build-tools) があります、私たちはHatchを選ぶ理由は:"
-
-#: ../../tutorials/get-to-know-hatch.md:8
-msgid ""
-"It is an end-to-end tool that supports most of the steps required to "
-"create a quality Python package. Beginners will have fewer tools to learn"
-" if they use Hatch."
-msgstr "高品質なPythonパッケージを作成するために必要なステップのほとんどをサポートするエンドツーエンドのツールです。Hatchを使えば、初心者は覚えるツールが少なくて済みます。"
-
-#: ../../tutorials/get-to-know-hatch.md:11
-msgid ""
-"It supports different build back-ends if you ever need to compile code in"
-" other languages."
-msgstr "他の言語のコードをコンパイルする必要がある場合は、異なるビルドバックエンドをサポートします。"
-
-#: ../../tutorials/get-to-know-hatch.md:13
-msgid ""
-"As a community, pyOpenSci has decided that Hatch is a user-friendly tool "
-"that supports many different scientific Python use cases."
-msgstr "コミュニティとして、pyOpenSciはHatchが多くの異なる科学的なPythonの使用例をサポートするユーザーフレンドリーなツールであると決定しました。"
-
-#: ../../tutorials/get-to-know-hatch.md:16
-msgid ""
-"In this tutorial, you will install and get to know Hatch a bit more "
-"before starting to use it."
-msgstr "このチュートリアルでは、Hatchをインストールし、使い始める前にもう少しHatchについて知ってもらいます。"
-
-#: ../../tutorials/get-to-know-hatch.md:19
-msgid "You need two things to successfully complete this tutorial:"
-msgstr "このチュートリアルを成功させるために必要なものは2つあります:"
-
-#: ../../tutorials/get-to-know-hatch.md:21
-msgid "You need Python installed."
-msgstr "Pythonがインストールされている必要があります。"
-
-#: ../../tutorials/get-to-know-hatch.md:22
-msgid "You need Hatch installed."
-msgstr "Hatchをインストールする必要があります。"
-
-#: ../../tutorials/get-to-know-hatch.md:25
-msgid ""
-"If you don't already have Python installed on your computer, Hatch will "
-"do it for you when you install Hatch."
-msgstr "Pythonがまだインストールされていない場合は、Hatchをインストールする際にPythonがインストールされます。"
-
-#: ../../tutorials/get-to-know-hatch.md:29
-msgid "Install Hatch"
-msgstr "Hatchのインストール"
-
-#: ../../tutorials/get-to-know-hatch.md:31
-msgid ""
-"To begin, follow the operating-system-specific instructions below to "
-"install Hatch."
-msgstr "まず、以下のオペレーティングシステム別の説明に従ってHatchをインストールしてください。"
-
-#: ../../tutorials/get-to-know-hatch.md
-msgid "MAC"
-msgstr "MAC"
-
-#: ../../tutorials/get-to-know-hatch.md:38
-msgid ""
-"Follow the instructions "
-"[here](https://hatch.pypa.io/latest/install/#installers)."
-msgstr "[こちら](https://hatch.pypa.io/latest/install/#installers) の指示に従ってください。"
-
-#: ../../tutorials/get-to-know-hatch.md:40
-msgid ""
-"Download the latest GUI installer for MAC [hatch-"
-"universal.pkg](https://github.com/pypa/hatch/releases/latest/download"
-"/hatch-universal.pkg)."
-msgstr ""
-"MAC用最新GUIインストーラー [hatch-"
-"universal.pkg](https://github.com/pypa/hatch/releases/latest/download"
-"/hatch-universal.pkg) をダウンロードしてください。"
-
-#: ../../tutorials/get-to-know-hatch.md:41
-msgid "Run the installer and follow the setup instructions."
-msgstr "インストーラーを実行し、セットアップ手順に従ってください。"
-
-#: ../../tutorials/get-to-know-hatch.md:42
-msgid "If your terminal is open, then restart it."
-msgstr "ターミナルが開いている場合は、再起動してください。"
-
-#: ../../tutorials/get-to-know-hatch.md
-msgid "Windows"
-msgstr "Windows"
-
-#: ../../tutorials/get-to-know-hatch.md:48
-msgid ""
-"In your browser, download the correct `.msi` file for your system: "
-"[hatch-x64.msi](https://github.com/pypa/hatch/releases/latest/download/hatch-x64.msi)"
-msgstr ""
-"ブラウザで、お使いのシステムに合った `.msi` ファイルをダウンロードしてください: "
-"[hatch-x64.msi](https://github.com/pypa/hatch/releases/latest/download/hatch-x64.msi)"
-
-#: ../../tutorials/get-to-know-hatch.md:50
-msgid "Run your downloaded installer file and follow the on-screen instructions."
-msgstr "ダウンロードしたインストーラーファイルを実行し、画面の指示に従ってください。"
-
-#: ../../tutorials/get-to-know-hatch.md
-msgid "Linux"
-msgstr "Linux"
-
-#: ../../tutorials/get-to-know-hatch.md:56
-msgid ""
-"We suggest that you install Hatch using pipx on Linux. however, if you "
-"prefer another method, check out the [Hatch installation "
-"documentation](https://hatch.pypa.io/latest/install/) for other methods."
-msgstr ""
-"Linux上ではpipxを使用してHatchをインストールすることをお勧めしますが、他の方法をご希望の場合は、 "
-"[Hatchのインストールドキュメント](https://hatch.pypa.io/latest/install/) をご覧ください。"
-
-#: ../../tutorials/get-to-know-hatch.md:70
-msgid ""
-"Hatch can also be installed directly using "
-"[pip](https://hatch.pypa.io/latest/install/#pip) or "
-"[conda](https://hatch.pypa.io/latest/install/#conda). We encourage you to"
-" follow the instructions above because we have found that the Hatch "
-"installers for Windows and Mac are the easiest and most efficient."
-msgstr ""
-"Hatchは [pip](https://hatch.pypa.io/latest/install/#pip) や "
-"[conda](https://hatch.pypa.io/latest/install/#conda) "
-"を使って直接インストールすることもできる。WindowsとMac用のHatchインストーラーが最も簡単で効率的であることがわかりましたので、上記の指示に従うことをお勧めします。"
-
-#: ../../tutorials/get-to-know-hatch.md:74
-msgid ""
-"Our Linux users have found success installing Hatch with pipx if they "
-"already use apt install."
-msgstr "私たちのLinuxユーザーは、すでにapt installを使っている場合、pipxを使ってHatchをインストールすることに成功しています。"
-
-#: ../../tutorials/get-to-know-hatch.md:77
-msgid ""
-"Both approaches (using a graphical installer on Windows/Mac and pipx) "
-"ensure that you have Hatch installed globally. A global install means "
-"that Hatch is available across all of your Python environments on your "
-"computer."
-msgstr ""
-"どちらのアプローチ（Windows/Macでグラフィカルインストーラを使う方法とpipxを使う方法）も、Hatchがグローバルにインストールされていることを保証します。"
-" グローバルインストールとは、コンピュータ上の全てのPython環境でHatchが利用できることを意味します。"
-
-#: ../../tutorials/get-to-know-hatch.md:82
-msgid "Check that hatch installed correctly"
-msgstr "hatchが正しく取り付けられているか確認します"
-
-#: ../../tutorials/get-to-know-hatch.md:84
-msgid ""
-"Once you have completed the installation instructions above, you can open"
-" your terminal, and make sure that Hatch installed correctly using the "
-"command below:"
-msgstr "上記のインストール手順が完了したら、ターミナルを開き、以下のコマンドを使用してHatchが正しくインストールされたことを確認してください:"
-
-#: ../../tutorials/get-to-know-hatch.md:92
-msgid ""
-"*Note the version number output of `hatch --version` will likely  be "
-"different from the output above in this tutorial.*"
-msgstr "* `hatch --version` で出力されるバージョン番号は、このチュートリアルの上記の出力とは異なる可能性が高いことに注意してください。*"
-
-#: ../../tutorials/get-to-know-hatch.md:95
-msgid "Configure Hatch"
-msgstr "Hatchの設定"
-
-#: ../../tutorials/get-to-know-hatch.md:97
-msgid ""
-"Once you have installed Hatch, you can customize its configuration. This "
-"includes setting the default name and setup for every package you create."
-" While this step is not required, we suggest that you do it."
-msgstr ""
-"Hatchをインストールしたら、その設定をカスタマイズすることができます。 "
-"これには、作成するすべてのパッケージにデフォルト名とセットアップを設定することも含まれます。 "
-"このステップは必須ではありませんが、行うことをお勧めします。"
-
-#: ../../tutorials/get-to-know-hatch.md:101
-msgid ""
-"Hatch stores your configuration in a [`config.toml` "
-"file](https://hatch.pypa.io/latest/config/project-templates/)."
-msgstr ""
-"Hatchは設定を [`config.toml`ファイル](https://hatch.pypa.io/latest/config"
-"/project-templates/) に保存します。"
-
-#: ../../tutorials/get-to-know-hatch.md:103
-msgid ""
-"While you can update the `config.toml` file through the command line, it "
-"might be easier to look at and update it in a text editor if you are "
-"using it for the first time."
-msgstr ""
-"コマンドラインから `config.toml` ファイルを更新することができます, "
-"初めて使う場合は、テキストエディタで見て更新する方が簡単かもしれません。"
-
-#: ../../tutorials/get-to-know-hatch.md:107
-msgid "Step 1: Open and Edit Your `config.toml` File"
-msgstr "ステップ 1: `config.toml` ファイルを開いて編集する"
-
-#: ../../tutorials/get-to-know-hatch.md:109
-msgid ""
-"To open the config file in your file browser, run the following command "
-"in your shell:"
-msgstr "ファイルブラウザで設定ファイルを開くには、シェルで以下のコマンドを実行します:"
-
-#: ../../tutorials/get-to-know-hatch.md:112
-msgid "`hatch config explore`"
-msgstr "`hatch config explore`"
-
-#: ../../tutorials/get-to-know-hatch.md:114
-msgid ""
-"This will open up a directory window that allows you to double-click on "
-"the file and open it in your favorite text editor."
-msgstr "ディレクトリウィンドウが開き、ファイルをダブルクリックして好きなテキストエディタで開くことができます。"
-
-#: ../../tutorials/get-to-know-hatch.md:117
-msgid ""
-"You can also retrieve the location of the Hatch config file by running "
-"the following command in your shell:"
-msgstr "シェルで以下のコマンドを実行すれば、Hatchのコンフィグファイルの場所を取得することもできます:"
-
-#: ../../tutorials/get-to-know-hatch.md:125
-msgid "Step 2 - update your email and name"
-msgstr "ステップ2 - Eメールと名前を更新する"
-
-#: ../../tutorials/get-to-know-hatch.md:127
-msgid ""
-"Once the file is open, update the [template] table of the `config.toml` "
-"file with your name and email. This information will be used in any "
-"`pyproject.toml` metadata files that you create using Hatch."
-msgstr ""
-"ファイルを開いたら、 `config.toml` ファイルの[template]テーブルをあなたの名前とEメールで更新します。 "
-"この情報は、Hatchを使用して作成した `pyproject.toml` メタデータファイルに使用されます。"
-
-#: ../../tutorials/get-to-know-hatch.md:137
-msgid "Step 3"
-msgstr "ステップ3"
-
-#: ../../tutorials/get-to-know-hatch.md:139
-msgid "Next, set tests to false in the `[template.plugins.default]` table."
-msgstr "次に、 `[template.plugins.default]` テーブルでtestsをfalseに設定します。"
-
-#: ../../tutorials/get-to-know-hatch.md:141
-msgid ""
-"While tests are important, setting the tests configuration in Hatch to "
-"`true` will create a more complex `pyproject.toml` file. You won't need "
-"to use this feature in this beginner friendly tutorial series but we will"
-" introduce it in later tutorials."
-msgstr ""
-"テストは重要ですが、Hatchのtests設定を `true` にすると、より複雑な `pyproject.toml` "
-"ファイルが作成されます。この初心者向けチュートリアルシリーズではこの機能を使う必要はありませんが、後のチュートリアルで紹介します。"
-
-#: ../../tutorials/get-to-know-hatch.md:146
-msgid "Your `config.toml` file should look something like the one below."
-msgstr "あなたの `config.toml` ファイルは以下のようになるはずです。"
-
-#: ../../tutorials/get-to-know-hatch.md:184
-msgid ""
-"Also notice that the default license option is MIT. While we will discuss"
-" license in more detail in a later lesson, the MIT license is the "
-"recommended permissive license from "
-"[choosealicense.com](https://www.choosealicense.com) and as such we will "
-"use it for this tutorial series."
-msgstr ""
-"また、デフォルトのライセンスオプションがMITであることにも注目してください。 ライセンスについては後のレッスンで詳しく説明しますが、 "
-"MITライセンスは [choosealicense.com](https://www.choosealicense.com) "
-"が推奨する寛容なライセンスです、そしてこのチュートリアルシリーズではこれを使用します。"
-
-#: ../../tutorials/get-to-know-hatch.md:190
-msgid "You are of course welcome to select another license."
-msgstr "もちろん、他のライセンスを選択することも歓迎します。"
-
-#: ../../tutorials/get-to-know-hatch.md:192
-#: ../../tutorials/create-python-package.md:22
-#: ../../tutorials/create-python-package.md:411
-#: ../../tutorials/create-python-package.md:502 ../../tutorials/intro.md:235
-#: ../../tutorials/publish-pypi.md:3 ../../tutorials/publish-pypi.md:178
-#: ../../tutorials/publish-pypi.md:350 ../../tutorials/pyproject-toml.md:718
-msgid "Todo"
-msgstr "Todo"
-
-#: ../../tutorials/get-to-know-hatch.md:193
-msgid ""
-"I think we'd need the SPDX license options here if they want to chose "
-"bsd-3 for instance"
-msgstr "例えばbsd-3を選びたいのであれば、SPDXライセンスのオプションが必要だと思います。"
-
-#: ../../tutorials/get-to-know-hatch.md:196
-msgid "Step 4: Close the config file and run `hatch config show`"
-msgstr "ステップ4: 設定ファイルを閉じて、 `hatch config show` を実行します。"
-
-#: ../../tutorials/get-to-know-hatch.md:198
-msgid ""
-"Once you have completed the steps above run the following command in your"
-" shell."
-msgstr "上記の手順が完了したら、シェルで以下のコマンドを実行します。"
-
-#: ../../tutorials/get-to-know-hatch.md:200
-msgid "`hatch config show`"
-msgstr "`hatch config show`"
-
-#: ../../tutorials/get-to-know-hatch.md:202
-msgid ""
-"`hatch config show` will print out the contents of your `config.toml` "
-"file in your shell. Look at the values and ensure that your name, email "
-"is set. Also make sure that `tests=false`."
-msgstr ""
-"`hatch config show` はシェルの `config.toml` ファイルの内容を出力します。 "
-"値を見て、あなたの名前とEメールが設定されていることを確認してください。また、 `tests=false` であることを確認すること。"
-
-#: ../../tutorials/get-to-know-hatch.md:206
-msgid "Hatch features"
-msgstr "Hatchの特徴"
-
-#: ../../tutorials/get-to-know-hatch.md:208
-msgid ""
-"Hatch offers a suite of features that will make creating, publishing and "
-"maintaining your Python package easier."
-msgstr "Hatchは、Pythonパッケージの作成、公開、保守を容易にする一連の機能を提供します。"
-
-#: ../../tutorials/get-to-know-hatch.md:211
-msgid "Comparison to other tools"
-msgstr "他のツールとの比較"
-
-#: ../../tutorials/get-to-know-hatch.md:213
-msgid ""
-"[We compared Hatch to several of the other popular packaging tools in the"
-" ecosystem including flit, pdm and poetry. Learn more here](package-"
-"features)"
-msgstr ""
-"[私たちはHatchを、flit、pdm、poetryなど、エコシステムで人気のある他のパッケージングツールと比較しました。 詳細はこちら"
-"](package-features)"
-
-#: ../../tutorials/get-to-know-hatch.md:216
-msgid "[More on Hatch here](hatch)"
-msgstr "[Hatchの詳細はこちら](hatch)"
-
-#: ../../tutorials/get-to-know-hatch.md:218
-msgid "A few features that Hatch offers"
-msgstr "Hatchが提供するいくつかの機能"
-
-#: ../../tutorials/get-to-know-hatch.md:220
-msgid ""
-"It will convert metadata stored in a `setup.py` or `setup.cfg` file to a "
-"pyproject.toml file for you (see [Migrating setup.py to pyproject.toml "
-"using Hatch](setup-py-to-pyproject-toml.md ))"
-msgstr ""
-"これは `setup.py` または `setup.cfg` ファイルに保存されたメタデータを pyproject.toml "
-"ファイルに変換します。 ([Hatchを使用してsetup.pyをpyproject.tomlに移行する](setup-py-to-"
-"pyproject-toml.md ) を参照)"
-
-#: ../../tutorials/get-to-know-hatch.md:222
-msgid ""
-"It will help you by storing configuration information for publishing to "
-"PyPI after you've entered it once."
-msgstr "PyPIに公開するための設定情報を、一度入力した後に保存してくれます。"
-
-#: ../../tutorials/get-to-know-hatch.md:224
-msgid "Use `hatch -h` to see all of the available commands."
-msgstr "利用可能なコマンドをすべて表示するには、 `hatch -h` を使用します。"
-
-#: ../../tutorials/get-to-know-hatch.md:226
-msgid "What's next"
-msgstr "次のレッスン"
-
-#: ../../tutorials/get-to-know-hatch.md:228
-msgid ""
-"In the next lesson you'll learn how to package and make your code "
-"installable using Hatch."
-msgstr "次のレッスンでは、Hatchを使ってコードをパッケージ化し、インストール可能にする方法を学びます。"
-
-#: ../../tutorials/create-python-package.md:6
-msgid "Make your Python code installable"
-msgstr "Pythonコードをインストール可能にする"
-
-#: ../../tutorials/create-python-package.md:8
-msgid "What we previously covered"
-msgstr "以前取り上げたレッスン"
+#: ../../tutorials/create-python-package.md:7
+#, fuzzy
+msgid "Create a pure Python package"
+msgstr "Pythonパッケージの作成と公開"
 
 #: ../../tutorials/create-python-package.md:9
-msgid ""
-"[In the previous lesson](intro), you learned about what a Python package "
-"is. You also learned about the [benefits of creating a Python package"
-"](package-benefits)."
-msgstr ""
-"[前のレッスンで](intro) 、Pythonパッケージとは何かについて学びました。また、 [Pythonパッケージを作成する利点"
-"](package-benefits) についても学びました。"
-
-#: ../../tutorials/create-python-package.md:13
-msgid ""
-"Your next step in our packaging tutorial series is to create a Python "
-"package that is installable both locally and remotely from a website such"
-" as GitHub (or GitLab). The package that you create in this lesson will "
-"have the bare minimum elements needed to be installable into a Python "
-"environment."
-msgstr ""
-"パッケージングチュートリアルシリーズの次のステップは、ローカルでも GitHub (または GitLab) "
-"などのウェブサイトからリモートでもインストール可能な Python "
-"パッケージを作成することです。このレッスンで作成するパッケージは、Python環境にインストールするために必要な最低限の要素しか持っていません。"
-
-#: ../../tutorials/create-python-package.md:18
-msgid ""
-"Making your code installable is an important steps towards creating a "
-"full Python package that is directly installable from PyPI."
-msgstr "あなたのコードをインストール可能にすることは、PyPIから直接インストール可能な完全なPythonパッケージを作成するための重要なステップです。"
-
-#: ../../tutorials/create-python-package.md:23
-msgid ""
-"Is it clear where to add commands? Bash vs. Python console Bash vs. Zsh "
-"is different"
-msgstr "コマンドを追加する場所は明確ですか？ BashとPythonのコンソールの違い BashとZshの違い"
-
-#: ../../tutorials/create-python-package.md:25
-msgid "Does this lesson run as expected on windows and mac?"
-msgstr "このレッスンは、windowsやmacで期待通りに動きますか？"
-
-#: ../../tutorials/create-python-package.md:26
-msgid ""
-"ADD: note about what makes something \"package worthy\", with a common "
-"misconception being that a package should be production-ready code that's"
-" valuable to a broad audience. This may not be a pervasive misconception "
-"in Python, but a quick break-out with an explanation of what a package "
-"can consist of would be helpful."
-msgstr ""
-"追加: 何をもって \"パッケージに値する\" とするのかについて、 "
-"一般的な誤解は、パッケージは幅広いオーディエンスにとって価値のある、生産可能なコードであるべきだというものです。これはPythonに蔓延している誤解ではないかもしれませんが、パッケージがどのようなもので構成されるかを簡単に説明することは役に立つでしょう。"
-
-#: ../../tutorials/create-python-package.md:31
-msgid ""
-"Diagram showing the basic steps to creating an installable package. There"
-" are 4 boxes with arrows pointing towards the right. The boxes read, your"
-" code, create package structure, add metadata to pyproject.toml and pip "
-"install package."
-msgstr ""
-"インストール可能なパッケージを作成する基本的な手順を示した図です。 右を向いた矢印の箱が4つあります。 "
-"ボックスは、あなたのコード、パッケージ構造の作成、pyproject.tomlへのメタデータの追加、およびpip "
-"installパッケージを読み込みます。"
-
-#: ../../tutorials/create-python-package.md:33
-msgid ""
-"A basic installable package needs a few things: code, a [specific package"
-" file structure](https://www.pyopensci.org/python-package-guide/package-"
-"structure-code/python-package-structure.html) and a `pyproject.toml` "
-"containing your package's name and version. Once you have these items in "
-"the correct directory structure, you can pip install your package into "
-"any environment on your computer. You will learn how to create a basic "
-"installable package in this lesson."
-msgstr ""
-"基本的なインストール可能パッケージには、以下のものが必要です: コード、 "
-"[特定のパッケージファイル構造](https://www.pyopensci.org/python-package-guide/package-"
-"structure-code/python-package-structure.html) 、パッケージの名前とバージョンを含む "
-"`pyproject.toml` "
-"が必要です。これらのアイテムが正しいディレクトリ構造になっていれば、pipであなたのコンピュータのどの環境にもパッケージをインストールすることができます。このレッスンでは、基本的なインストール可能パッケージの作成方法を学びます。"
-
-#: ../../tutorials/create-python-package.md:37
+#: ../../tutorials/develop-python-package-hatch.md:9
 msgid "About this lesson"
 msgstr "このレッスンについて"
 
-#: ../../tutorials/create-python-package.md:43
+#: ../../tutorials/create-python-package.md:13
 msgid ""
-"How to make your code installable into any Python environment both "
+"This lesson uses the pyOpenSci Python package copier template to create a"
+" Python package quickly. Your package will be installable both locally "
+"and remotely from a website such as GitHub (or GitLab) into a Python "
+"environment."
+msgstr ""
+
+#: ../../tutorials/create-python-package.md:16
+#: ../../tutorials/setup-py-to-pyproject-toml.md:20
+#, fuzzy
+msgid "In this lesson, you will learn:"
+msgstr "このレッスンで学ぶこと:"
+
+#: ../../tutorials/create-python-package.md:18
+#, fuzzy
+msgid ""
+"How to make your code installable into any Python environment, both "
 "locally and from GitHub"
 msgstr "ローカルとGitHubの両方で、あなたのコードをあらゆるPython環境にインストール可能にする方法"
 
-#: ../../tutorials/create-python-package.md:44
+#: ../../tutorials/create-python-package.md:19
+#, fuzzy
 msgid ""
-"How to create a basic `pyproject.toml` file that includes package "
-"dependencies and metadata. This file is required to make your package "
-"installable."
-msgstr ""
-"パッケージの依存関係とメタデータを含む基本的な `pyproject.toml` "
-"ファイルの作成方法。このファイルは、パッケージをインストール可能にするために必要です。"
+"How to update a `pyproject.toml` file, which contains the metadata needed"
+" to build, install, and publish your package."
+msgstr "最後のレッスンでは、パッケージのビルドに必要なコア要素を含む、素のpyproject.tomlファイルを作成しました:"
 
-#: ../../tutorials/create-python-package.md:45
+#: ../../tutorials/create-python-package.md:20
 msgid ""
 "How to declare a [build backend](build_backends) which will be used to "
 "[build](build-package) and install your package"
@@ -1568,56 +1127,39 @@ msgstr ""
 "パッケージの [ビルド](build-package) とインストールに使用する [ビルドバックエンド](build_backends) "
 "を宣言する方法"
 
-#: ../../tutorials/create-python-package.md:46
+#: ../../tutorials/create-python-package.md:21
 msgid "How to install your package in editable mode for interactive development"
 msgstr "インタラクティブな開発のために編集可能モードでパッケージをインストールする方法"
 
-#: ../../tutorials/create-python-package.md:48
+#: ../../tutorials/create-python-package.md:24
 msgid "**What you need to complete this lesson**"
 msgstr "**このレッスンを完了するために必要なもの**"
 
-#: ../../tutorials/create-python-package.md:50
+#: ../../tutorials/create-python-package.md:26
+#, fuzzy
 msgid ""
-"To complete this lesson you will need a local Python environment and "
-"shell on your computer. You will also need to have [Hatch installed](get-"
-"to-know-hatch)."
+"To complete this lesson, you will need a local Python environment and "
+"shell on your computer.  You will need to have "
+"[Copier](https://copier.readthedocs.io/en/stable/) and [Hatch installed"
+"](get-to-know-hatch) to complete the lesson successfully."
 msgstr ""
 "このレッスンを完了するには、あなたのコンピュータにローカルのPython環境とシェルが必要です。　[Hatchのインストール](get-to-"
 "know-hatch) も必要です。"
 
-#: ../../tutorials/create-python-package.md:53
+#: ../../tutorials/create-python-package.md:30
+#, fuzzy
 msgid ""
 "If you are using Windows or are not familiar with Shell, you may want to "
 "check out the Carpentries shell lesson[^shell-lesson]. Windows users will"
-" likely need to configure a tool for any Shell and git related steps."
+" likely need to configure a tool such as "
+"[gitbash](https://gitforwindows.org/) for any Shell and git-related "
+"steps."
 msgstr ""
 "Windowsを使用している、またはシェルに精通していない場合は、Carpentriesのシェルレッスン[^shell-lesson] "
 "をチェックアウトすることをお勧めします。 "
 "Windowsユーザーは、Shellやgitに関連するステップのためにツールを設定する必要があるでしょう。"
 
-#: ../../tutorials/create-python-package.md:55
-msgid "**What comes next**"
-msgstr "**次に来るもの**"
-
-#: ../../tutorials/create-python-package.md:57
-msgid "In the upcoming lessons you will learn how to:"
-msgstr "これからのレッスンでは、その方法を学びます:"
-
-#: ../../tutorials/create-python-package.md:59
-msgid "[Publish your package to PyPI](publish-pypi)"
-msgstr "[PyPIへのパッケージの公開](publish-pypi)"
-
-#: ../../tutorials/create-python-package.md:60
-msgid "Add a README file to your package to support community use"
-msgstr "コミュニティの利用をサポートするために、パッケージに README ファイルを追加してください。"
-
-#: ../../tutorials/create-python-package.md:61
-msgid ""
-"Add additional project metadata to your package to support PyPI "
-"publication"
-msgstr "PyPI公開をサポートするために、パッケージにプロジェクトのメタデータを追加します"
-
-#: ../../tutorials/create-python-package.md:67
+#: ../../tutorials/create-python-package.md:36
 msgid ""
 "This diagram has two smaller boxes with arrows pointing to the right to a"
 " Python environment. The small boxes read your-package and pip install "
@@ -1630,57 +1172,694 @@ msgstr ""
 "Matplotlib、NumPy、Pandas、Xarray、GeoPandasなどのコアパッケージとともに、your-"
 "packageがリストアップされています。"
 
-#: ../../tutorials/create-python-package.md:69
+#: ../../tutorials/create-python-package.md:38
+#, fuzzy
 msgid ""
-"Making your code installable is the first step towards creating a "
-"publishable Python package. Once your code is installable, it is a Python"
-" package and can be added to any Python environment on your computer and "
-"imported in the same way that you might import a package such as Pandas "
-"or GeoPandas. If your code is on GitHub or GitLab you can also install it"
-" directly from there."
+"In a [previous lesson, you learned what a Python package is](intro). "
+"Creating a Python package allows you to install your code into any Python"
+" environment on your computer. You can then import it into workflows in "
+"the same way that you might import a package such as Pandas or GeoPandas."
+" If you push your code to GitHub or GitLab, you can also install it "
+"directly from there. [Scroll to the bottom of the page to learn more "
+"about the basic elements of a Python package.](package-overview)."
 msgstr ""
 "あなたのコードをインストール可能にすることは、公開可能なPythonパッケージを作成するための最初のステップです。 "
 "あなたのコードがインストール可能になると、それはPythonパッケージとなり、あなたのコンピュータ上の任意のPython環境に追加し、PandasやGeoPandasなどのパッケージをインポートするのと同じ方法でインポートすることができます。あなたのコードがGitHubやGitLabにあるなら、そこから直接インストールすることもできます。"
 
-#: ../../tutorials/create-python-package.md:74
+#: ../../tutorials/create-python-package.md:44
+#, fuzzy
+msgid "Create your Python package"
+msgstr "Pythonパッケージを作成しましょう！"
+
+#: ../../tutorials/create-python-package.md:46
+msgid ""
+"Below, you will create a pure Python package using the [pyOpenSci copier "
+"template](https://github.com/pyOpenSci/pyos-package-template). Our "
+"template uses Hatch as the default packaging tool. At the bottom of this "
+"lesson, you'll learn more about the basics of the Python package "
+"directory structure, and associated key files (`__init__.py` and "
+"`pyproject.toml`)."
+msgstr ""
+
+#: ../../tutorials/create-python-package.md:48
+msgid "Step 1: Set Up the Package Directory Structure"
+msgstr "ステップ1: パッケージのディレクトリ構造を設定する"
+
+#: ../../tutorials/create-python-package.md:50
+msgid "Open your shell or preferred terminal."
+msgstr "シェルまたはお好みのターミナルを開きます。"
+
+#: ../../tutorials/create-python-package.md:51
+#, fuzzy
+msgid ""
+"Use the shell `cd` command to navigate in your shell to the location "
+"where you'd like your package to live. Our template will create the "
+"package directory structure for you"
+msgstr "シェルで `cd` コマンドを使い、パッケージのディレクトリを置く場所に移動します。 Hatchがパッケージディレクトリを作成してくれます。"
+
+#: ../../tutorials/create-python-package.md:52
+msgid "Choose a name for your package. The name should:"
+msgstr "パッケージの名前を決めてください。 名前は以下のようにします:"
+
+#: ../../tutorials/create-python-package.md:53
+msgid "Have no spaces (*Required*)"
+msgstr "スペースがない (*必須*)"
+
+#: ../../tutorials/create-python-package.md:54
+#, fuzzy
+msgid ""
+"Use all lowercase characters (*Recommended*). For this tutorial, we will "
+"use `pyospackage`."
+msgstr "すべて小文字を使用 (*推奨*)。 このチュートリアルでは `pyospackage` を使用します。"
+
+#: ../../tutorials/create-python-package.md:55
+#, fuzzy
+msgid ""
+"Only use letters and the characters _ or - in the name. This means that "
+"the name `pyos*package` is not an acceptable name. However, the names "
+"`pyos_package` or `pyos-package` are both OK."
+msgstr ""
+"名前にはアルファベットと _ または - "
+"のみを使用してください。これは、`pyos*package`という名前は使えないことを意味します。しかし、 `pyos_package` または "
+"`pyos-package` という名前であれば、どちらでも構いません。"
+
+#: ../../tutorials/create-python-package.md:57
+msgid ""
+"In your terminal, **run the command below**. This will begin a series of "
+"prompts that will ask you questions and help you to customize your Python"
+" package."
+msgstr ""
+
+#: ../../tutorials/create-python-package.md:63
+msgid ""
+"After running the command above, the template will walk you through a "
+"series of questions."
+msgstr ""
+
+#: ../../tutorials/create-python-package.md:65
+msgid ""
+"Note that when you reach the prompt \"Do you want to answer one more "
+"question, and skip the rest, using the default values?\" you can choose "
+"<kbd>Yes, but with a minimal setup</kbd> to create the most basic version"
+" of your package that contains documentation, tests and a example module "
+"for you to use."
+msgstr ""
+
+#: ../../tutorials/create-python-package.md:67
+msgid ""
+"After this question, the template will ask you for your preferred GitHub "
+"username and will then create a package with basic tests, documentation, "
+"and GitHub configuration setup for you."
+msgstr ""
+
+#: ../../tutorials/create-python-package.md:88
+msgid ""
+"The template will then begin to copy files into the directory that used "
+"above. (`.` means current working directory"
+msgstr ""
+
+#: ../../tutorials/create-python-package.md:96
+#, fuzzy
+msgid "The final package structure will look like this:"
+msgstr "最終的なプロジェクトのディレクトリ構造は以下のようになるはずです:"
+
+#: ../../tutorials/create-python-package.md
+msgid "A full package with tests, docs, and GitHub infrastructure"
+msgstr ""
+
+#: ../../tutorials/create-python-package.md:114
+msgid ""
+"If you use the \"bells and whistles\" default option when working through"
+" the template prompts, our template will create a complete package setup "
+"with GitHub CI actions, typing, tests, environments , and more using "
+"Hatch. If you customize the entire package, then you can select what "
+"platform you wish to host it on (GitHub vs GitLab), whether you want "
+"typing, what documentation engine you want to use, and more."
+msgstr ""
+
+#: ../../tutorials/create-python-package.md:118
+#, fuzzy
+msgid "The resulting package directory looks like this"
+msgstr "プロジェクトディレクトリはこのようになっているはずです:"
+
+#: ../../tutorials/create-python-package.md:141
+msgid "The default tools that your package uses are:"
+msgstr ""
+
+#: ../../tutorials/create-python-package.md:143
+msgid ""
+"[Sphinx](https://www.pyopensci.org/python-package-guide/documentation"
+"/hosting-tools/sphinx-python-package-documentation-tools.html) with the "
+"pydata_sphinx_theme for documentation"
+msgstr ""
+
+#: ../../tutorials/create-python-package.md:144
+msgid "pytest for testing"
+msgstr ""
+
+#: ../../tutorials/create-python-package.md:145
+#, fuzzy
+msgid "Hatch for environment setup"
+msgstr "Hatchと環境"
+
+#: ../../tutorials/create-python-package.md:147
+msgid ""
+"**Full customization** If you want to customize any elements of your "
+"package setup, choose `No, I want to fully customize the template.`.  "
+"This will allow you to select:"
+msgstr ""
+
+#: ../../tutorials/create-python-package.md:150
+msgid "sphinx vs [mkdocs](https://www.mkdocs.org/) vs no documentation"
+msgstr ""
+
+#: ../../tutorials/create-python-package.md:151
+#, fuzzy
+msgid "GitHub vs GitLab"
+msgstr "GitHub & GitLab vs. Git"
+
+#: ../../tutorials/create-python-package.md:152
+msgid "VCS versioning"
+msgstr ""
+
+#: ../../tutorials/create-python-package.md:153
+#, fuzzy
+msgid "and more"
+msgstr "などなど。"
+
+#: ../../tutorials/create-python-package.md:156
+#, fuzzy
+msgid "Step 2: Explore the existing module in your package"
+msgstr "ステップ 2: パッケージにモジュールを追加する"
+
+#: ../../tutorials/create-python-package.md:158
+#, fuzzy
+msgid ""
+"A Python module refers to a `.py` file containing the code that you want "
+"your package to access and run. Within the `pyospackage` subdirectory, "
+"you have an example.py module that you can use to test out your package "
+"quickly."
+msgstr ""
+"Python モジュールとは、パッケージにアクセスさせ、実行させたいコードを含む `.py` ファイルを指します。 `pyospackage` "
+"サブディレクトリに、少なくとも1つのPythonモジュール (.py ファイル) を追加します。"
+
+#: ../../tutorials/create-python-package.md:160
+msgid "Notice that the code in the example.py module, has a few features:"
+msgstr ""
+
+#: ../../tutorials/create-python-package.md:162
+msgid "It has a [numpy-style docstring](numpy-docstring)"
+msgstr "これは [numpyスタイルのdocstring](numpy-docstring) を持っています。"
+
+#: ../../tutorials/create-python-package.md:163
+msgid "It uses [typing](type-hints)"
+msgstr "[typing](type-hints) を使用します。"
+
+#: ../../tutorials/create-python-package.md:164
+msgid ""
+"At the top of the module, there is a docstring explaining what the module"
+" does."
+msgstr ""
+
+#: ../../tutorials/create-python-package.md:166
+#, fuzzy
+msgid ""
+"Python supports different docstring formats. The most popular formats for"
+" documenting Python objects are NumPy Style Docstring[^numpydoc], Google "
+"Style Docstring[^googledoc], and the Epytext Style "
+"Docstrings[^epytextdoc]."
+msgstr ""
+"Pythonは、使いたいドキュメントのビルドシステムに応じて、多くの異なるdocstringsフォーマットをサポートすることができます。 "
+"Pythonオブジェクトを文書化するために最もよくサポートされている形式は、NumPy Style "
+"Docstring[^numpydoc]、Google Style Docstring[^googledoc]、Epytext Style "
+"Docstring[^epytextdoc]です。"
+
+#: ../../tutorials/create-python-package.md:168
+msgid "**pyOpenSci recommends using the NumPy Docstring convention.**"
+msgstr "**pyOpenSciは、NumPyのDocstring規約を使用することを推奨します。**"
+
+#: ../../tutorials/create-python-package.md:170
+msgid ""
+"[Learn more about docstrings here](api-docstrings) for an overview of "
+"both topics."
+msgstr ""
+
+#: ../../tutorials/create-python-package.md:199
+msgid "Python modules and the `__init__.py` file"
+msgstr "Pythonモジュールと `__init__.py` ファイル"
+
+#: ../../tutorials/create-python-package.md:203
+#, fuzzy
+msgid "The word module refers to a `.py` file containing Python code."
+msgstr "モジュールという言葉を目にしたとき、私たちはPythonのコードを含む `.py` ファイルを指しています。"
+
+#: ../../tutorials/create-python-package.md:205
+msgid ""
+"The `__init__.py`  allows Python to recognize that a directory contains "
+"at least one module that may be imported and used in your code. A package"
+" can have multiple modules[^python-modules]."
+msgstr ""
+"`__init__.py` は、Pythonがディレクトリに少なくとも1つのモジュールが含まれていることを認識できるようにします。 "
+"パッケージは複数のモジュール [^python-modules] を持つことができます。"
+
+#: ../../tutorials/create-python-package.md:210
+#, fuzzy
+msgid "Step 3: Optional -- Add code to your module"
+msgstr "ステップ3: モジュールにコードを追加する"
+
+#: ../../tutorials/create-python-package.md:212
+msgid ""
+"If you want, add a second function to the `example.py` module. It can be "
+"a simple function. For example, write a second function that multiplies "
+"numbers."
+msgstr ""
+
+#: ../../tutorials/create-python-package.md:215
+#, fuzzy
+msgid "Step 4: Check out the metadata in your `pyproject.toml` file"
+msgstr "ステップ 4: `pyproject.toml` ファイルのメタデータを修正する"
+
+#: ../../tutorials/create-python-package.md:217
+msgid ""
+"A `pyproject.toml` file stores metadata that provides instructions to "
+"various tools interacting with it, including Hatch, which will build your"
+" package. You can also specify metadata for your package."
+msgstr ""
+
+#: ../../tutorials/create-python-package.md:219
+#, fuzzy
+msgid ""
+"You will learn more about the `pyproject.toml` format in the [next lesson"
+" when you add additional metadata/information to this file.](pyproject-"
+"toml.md)"
+msgstr ""
+"`pyproject.toml` フォーマットについては、 [このファイルにメタデータや情報を追加する次のレッスン](pyproject-"
+"toml.md) で詳しく学びます。"
+
+#: ../../tutorials/create-python-package.md:222
+msgid ""
+"The metadata in your generated pyproject.toml is already setup for you "
+"using the information you provided the copier template above."
+msgstr ""
+
+#: ../../tutorials/create-python-package.md:224
+msgid "Brief overview of the TOML file"
+msgstr "TOMLファイルの概要"
+
+#: ../../tutorials/create-python-package.md:227
+msgid ""
+"[The TOML format](https://toml.io/en/) consists of tables and variables. "
+"Tables are sections of information denoted by square brackets:"
+msgstr "[TOMLフォーマット](https://toml.io/en/) は表と変数で構成されます。 表は角括弧で示される情報のセクションです:"
+
+#: ../../tutorials/create-python-package.md:229
+msgid "`[this-is-a-table]`."
+msgstr "`[this-is-a-table]`."
+
+#: ../../tutorials/create-python-package.md:231
+#, fuzzy
+msgid ""
+"Tables can contain variables within them defined by a variable name and "
+"an `=` sign. For instance, a `build-system` table most often holds two "
+"(2) variables:"
+msgstr ""
+"テーブルには、変数名と `=` 記号で定義された変数を入れることができます。 例えば、`build-system` "
+"テーブルは以下の2(つの)変数を保持することが多いです:"
+
+#: ../../tutorials/create-python-package.md:234
+msgid ""
+"`requires = `, which tells a build tool what tools it needs to install "
+"prior to building your package. In this case "
+"[hatchling](https://pypi.org/project/hatchling/)"
+msgstr ""
+"`requires=` は、ビルドツールに対して、パッケージをビルドする前にインス トールする必要があるツールを指示します。 この場合 "
+"[hatchling](https://pypi.org/project/hatchling/)"
+
+#: ../../tutorials/create-python-package.md:236
+msgid ""
+"`build-backend = `, which is used to define the specific build-backend "
+"name, (in this example we are using `hatchling.build`)."
+msgstr ""
+"`build-backend = ` 、これは、特定のビルドバックエンド名を定義するために使われます、(この例では、 "
+"`hatchling.build` を使用しています)。"
+
+#: ../../tutorials/create-python-package.md:245
+msgid ""
+"TOML organizes data structures, defining relationships within a "
+"configuration file."
+msgstr "TOMLはデータ構造を整理し、設定ファイル内の関係を定義します。"
+
+#: ../../tutorials/create-python-package.md:248
+#, fuzzy
+msgid "[Learn more about the pyproject.toml format here.](pyprojecttoml-metadata)"
+msgstr ""
+"[pyproject.tomlフォーマットの詳細はこちら。](../package-structure-code/pyproject-toml-"
+"python-package-metadata)"
+
+#: ../../tutorials/create-python-package.md:251
+msgid ""
+"Open up the `pyproject.toml` file that Hatch created in your favorite "
+"text editor. It should look something like the example below."
+msgstr "Hatchが作成した `pyproject.toml` ファイルをお好みのテキストエディタで開いてください。 下の例のようになるはずです。"
+
+#: ../../tutorials/create-python-package.md:252
+msgid ""
+"Make sure the package version, package name, and author name look "
+"correct. The email is optional."
+msgstr ""
+
+#: ../../tutorials/create-python-package.md:291
+msgid ""
+"At the bottom of the template-generated `pyproject.toml` file, you will "
+"see a section that defines Hatch environments. We will cover Hatch "
+"environments in a later lesson."
+msgstr ""
+
+#: ../../tutorials/create-python-package.md:293
+msgid "The bare minimum needed in a pyproject.toml file"
+msgstr "pyproject.tomlファイルに最低限必要なもの"
+
+#: ../../tutorials/create-python-package.md:296
+#, fuzzy
+msgid ""
+"The core information that you need in a `pyproject.toml` file to publish "
+"on PyPI is your **package's name**  and the **version**. However, we "
+"suggest that you flesh out your metadata early on in the `pyproject.toml`"
+" file."
+msgstr ""
+"PyPIで公開するために `pyproject.toml` ファイルに必要な情報は、 **パッケージ名** と **バージョン** です。 "
+"しかし、 `pyproject.toml` ファイルの早い段階でメタデータを具体化することをお勧めします。"
+
+#: ../../tutorials/create-python-package.md:298
+#, fuzzy
+msgid ""
+"Once you have your project metadata in the `pyproject.toml` file, you "
+"will rarely update it."
+msgstr "一度pyproject.tomlファイルにプロジェクトのメタデータがあれば、それを更新することはほとんどありません。次のレッスンでは、このファイルにさらにメタデータと構造を追加します。"
+
+#: ../../tutorials/create-python-package.md:302
+msgid "Step 5: Install your package locally"
+msgstr "ステップ 5: パッケージをローカルにインストールする"
+
+#: ../../tutorials/create-python-package.md:304
+#, fuzzy
+msgid "At this point, you should have:"
+msgstr "この時点であなたは以下を持っているはずです:"
+
+#: ../../tutorials/create-python-package.md:306
+msgid "A project directory structure with a `pyproject.toml` file at the root"
+msgstr "`pyproject.toml` ファイルをルートに持つプロジェクトのディレクトリ構造"
+
+#: ../../tutorials/create-python-package.md:307
+msgid "A package directory containing an empty `__init__.py` file and"
+msgstr "空の `__init__.py` ファイルを含むパッケージ・ディレクトリと"
+
+#: ../../tutorials/create-python-package.md:308
+#, fuzzy
+msgid "At least one Python module (e.g. `example.py`)"
+msgstr "少なくとも1つのPythonモジュール (e.g. `add_numbers.py`)"
+
+#: ../../tutorials/create-python-package.md:310
+msgid "You are now ready to install (and build) your Python package!"
+msgstr "これで Python パッケージをインストール（ビルド）する準備ができました！"
+
+#: ../../tutorials/create-python-package.md:312
+#, fuzzy
+msgid ""
+"While you can do this using Hatch, we will use pip for this lesson, so "
+"you can see how to install your tool into your preferred environment."
+msgstr "hatchを使ってもできますが、このレッスンではpipを使います、そうすれば、あなたの好みの環境にツールをインストールする方法を見ることができます。"
+
+#: ../../tutorials/create-python-package.md:314
+#, fuzzy
+msgid ""
+"First, open your preferred shell (Windows users may use something like "
+"GitBash) and `cd` into your project directory if you are not already "
+"there."
+msgstr ""
+"まず、お好みのシェルを開き (Windowsユーザーはgitbashのようなものを使っているかもしれません) "
+"、まだプロジェクトディレクトリにいなければ、 `cd` してください。"
+
+#: ../../tutorials/create-python-package.md:315
+msgid "Activate the Python environment that you wish to use."
+msgstr "使用したいPython環境をアクティブにします。"
+
+#: ../../tutorials/create-python-package.md:316
+msgid "Run `python -m pip install -e .`"
+msgstr "`python -m pip install -e .` を実行します。"
+
+#: ../../tutorials/create-python-package.md:318
+#: ../../tutorials/create-python-package.md:551
+#: ../../tutorials/create-python-package.md:558
+#: ../../tutorials/get-to-know-hatch.md:197 ../../tutorials/intro.md:241
+#: ../../tutorials/publish-pypi.md:8 ../../tutorials/publish-pypi.md:183
+#: ../../tutorials/publish-pypi.md:356 ../../tutorials/pyproject-toml.md:731
+msgid "Todo"
+msgstr "Todo"
+
+#: ../../tutorials/create-python-package.md:319
+msgid "Add this back in when the lesson is published"
+msgstr "レッスンが公開されたら、これを追加してください。"
+
+#: ../../tutorials/create-python-package.md:320
+msgid ""
+"Activate the Python environment that you wish to use. If you need help "
+"with working with virtual environments check out this lesson (add link)."
+msgstr "使用したいPython環境をアクティブにします。 仮想環境での作業で助けが必要な場合は、このレッスンをチェックしてください（リンクを追加）。"
+
+#: ../../tutorials/create-python-package.md:346
+msgid "What does `python -m pip install -e .` do?"
+msgstr "`python -m pip install -e .` は何をしているのか？"
+
+#: ../../tutorials/create-python-package.md:349
+#, fuzzy
+msgid ""
+"`python -m pip install -e .` installs your package into the current "
+"active Python environment in **editable mode** (`-e`). Installing your "
+"package in editable mode, allows you to work on your code and then test "
+"the updates interactively in your favorite Python interface. One "
+"important caveat of editable mode is that every time you update your "
+"code, you need to restart Python."
+msgstr ""
+"`python -m pip install -e .` は、 **編集可能モード** (`-e`) で、現在のアクティブな Python "
+"環境にパッケージをインストールします。 "
+"編集可能モードでパッケージをインストールすることで、あなたのコードで作業し、お気に入りのPythonインターフェースでインタラクティブに更新をテストすることができます。"
+" 編集可能モードの重要な注意点のひとつは、コードを更新するたびに、そのコードが更新されるということです、 "
+"その場合、Pythonを再起動する必要があるかもしれません。"
+
+#: ../../tutorials/create-python-package.md:354
+msgid ""
+"If you wish to install the package regularly (not in editable mode) you "
+"can use:"
+msgstr "(編集可能モードではなく) 定期的にパッケージをインストールしたい場合は、次のようにします:"
+
+#: ../../tutorials/create-python-package.md:357
+msgid "`python -m pip install . `"
+msgstr "`python -m pip install . `"
+
+#: ../../tutorials/create-python-package.md:359
+msgid "**Using `python -m` when calling `pip`**"
+msgstr "**`pip` を呼び出す際に `python -m` を使用する**"
+
+#: ../../tutorials/create-python-package.md:361
+msgid ""
+"Above, you use`python -m` to call the version of pip installed into your "
+"current active environment. `python -m` is important to ensure that you "
+"are calling the version of pip installed in your current environment."
+msgstr ""
+"上記では、 `python -m` を使用して、現在アクティブな環境にインストールされている pip のバージョンを呼び出します。 `python"
+" -m` は、現在の環境にインストールされているバージョンの pip を呼び出していることを確認するために重要です。"
+
+#: ../../tutorials/create-python-package.md:365
+msgid ""
+"IMPORTANT: pip can also be used to install packages from PyPI. However, "
+"in this case, you are telling pip to install your package from a local "
+"folder by using the `.`. You could also specify a path to the project "
+"directory on your computer instead of the `.` which tells pip to use the "
+"current working directory."
+msgstr ""
+
+#: ../../tutorials/create-python-package.md:368
+msgid "Look for pyospackage in your environment"
+msgstr "あなたの環境でpyospackageを探す"
+
+#: ../../tutorials/create-python-package.md:370
+#, fuzzy
+msgid ""
+"Once you have installed your package, you can view it in your current "
+"environment. If you are using `venv` or `conda`, `pip` list will return a"
+" list of packages in the current active environment."
+msgstr ""
+"パッケージをインストールしたら、現在の環境でそれを見ることができます。 `venv` または `conda` を使用している場合、 `pip` "
+"list で現在インストールされているパッケージを確認することができます。"
+
+#: ../../tutorials/create-python-package.md:374
+#, fuzzy
+msgid ""
+"Note that because `pyospackage` is installed in editable mode (`-e`), pip"
+" will show you the directory path to your project's code"
+msgstr ""
+"pyospackageは編集可能モード (`-e`) "
+"でインストールされるため、pipはプロジェクトのコードへのディレクトリパスを表示することに注意してください。"
+
+#: ../../tutorials/create-python-package.md:402
+msgid "Step 6: Test out your new package"
+msgstr "ステップ 6: 新しいパッケージをテストする"
+
+#: ../../tutorials/create-python-package.md:404
+msgid ""
+"After installing your package, type “python” at the command prompt in "
+"your chosen terminal to start a Python session in your active Python "
+"environment."
+msgstr ""
+"パッケージをインストールしたら、選択したターミナルのコマンドプロンプトで \"python\" "
+"と入力し、アクティブなPython環境でPythonセッションを開始します。"
+
+#: ../../tutorials/create-python-package.md:407
+#, fuzzy
+msgid "You can now import your package and access the `add_numbers` function."
+msgstr "これでパッケージをインポートして `add_num` 関数にアクセスできます。"
+
+#: ../../tutorials/create-python-package.md:419
+msgid "Installing packages from GitHub"
+msgstr "GitHubからパッケージをインストールする"
+
+#: ../../tutorials/create-python-package.md:421
+msgid ""
+"If you wish to share your code without publishing to PyPI you can always "
+"install packages directly from GitHub using the syntax:"
+msgstr "PyPIに公開せずにコードを共有したい場合は、いつでも構文を使ってGitHubから直接パッケージをインストールできます:"
+
+#: ../../tutorials/create-python-package.md:428
+msgid "To make your package GitHub installable, you can:"
+msgstr "GitHubのパッケージをインストール可能にするには、次のようにします:"
+
+#: ../../tutorials/create-python-package.md:430
+msgid "Create a new GitHub repository"
+msgstr "新しいGitHubリポジトリを作成する"
+
+#: ../../tutorials/create-python-package.md:431
+msgid ""
+"Push the contents of the project directory that you created above, to "
+"GitHub"
+msgstr "上記で作成したプロジェクトディレクトリの内容をGitHubにプッシュします"
+
+#: ../../tutorials/create-python-package.md:432
+msgid ""
+"Finally install the package from GitHub using the command above. When you"
+" use the command above, don't forget to substitute the user, repo, and "
+"branch_or_tag with your specific values."
+msgstr ""
+"最後に、上記のコマンドを使ってGitHubからパッケージをインストールします。 "
+"上記のコマンドを使用する際は、user、repo、branch_or_tag を特定の値に置き換えることをお忘れなく。"
+
+#: ../../tutorials/create-python-package.md:434
+msgid ""
+"For instance below you install the pyospackage from the main branch of "
+"the pyOpenSci repository."
+msgstr "例えば、以下のようにpyOpenSciリポジトリのmainブランチからpyospackageをインストールします。"
+
+#: ../../tutorials/create-python-package.md:437
+msgid "`python -m pip install git+https://github.com/user/repo.git@branch_or_tag`"
+msgstr "`python -m pip install git+https://github.com/user/repo.git@branch_or_tag`"
+
+#: ../../tutorials/create-python-package.md:441
+msgid "Congratulations! You created your first Python package"
+msgstr "おめでとうございます！ あなたは最初のPythonパッケージを作成しました"
+
+#: ../../tutorials/create-python-package.md:443
+#, fuzzy
+msgid ""
+"You have now created a Python package that you can install into any "
+"Python environment."
+msgstr "やったね！ これでどんなPython環境にもインストールできるPythonパッケージができました。"
+
+#: ../../tutorials/create-python-package.md:448
+msgid ""
+"Add a [README file](add-readme.md) and [LICENSE](add-license-coc.md) to "
+"your package"
+msgstr "[READMEファイル](add-readme.md) と [LICENSE](add-license-coc.md) をパッケージに追加する。"
+
+#: ../../tutorials/create-python-package.md:449
+msgid ""
+"[Add more metadata to your `pyproject.toml`](pyproject-toml.md) file to "
+"support PyPI publication."
+msgstr ""
+"PyPI での公開をサポートするために [ `pyproject.toml` ファイルにメタデータを追加します。](pyproject-"
+"toml.md)"
+
+#: ../../tutorials/create-python-package.md:450
+msgid ""
+"[Learn how to build your package distribution](publish-pypi) files "
+"(**sdist** and **wheel**) and publish to **test PyPI**."
+msgstr ""
+"[パッケージ配布ファイルをビルド](publish-pypi) して (**sdist** と **wheel**) 、 **test "
+"PyPI** に公開する方法を学びます。"
+
+#: ../../tutorials/create-python-package.md:451
+msgid ""
+"Finally you will learn how to [publish to **conda-forge**](publish-conda-"
+"forge) from **PyPI**."
+msgstr "**PyPI** から [**conda-forge**](publish-conda-forge)  に公開する方法を学んでください。"
+
+#: ../../tutorials/create-python-package.md:455
 msgid "About the Python package directory structure"
 msgstr "Pythonパッケージのディレクトリ構造について"
 
-#: ../../tutorials/create-python-package.md:76
+#: ../../tutorials/create-python-package.md:457
 msgid ""
 "To make your Python code installable you need to create a specific "
 "directory structure with the following elements:"
 msgstr "Pythonコードをインストール可能にするには、以下の要素を含む特定のディレクトリ構造を作成する必要があります:"
 
-#: ../../tutorials/create-python-package.md:78
+#: ../../tutorials/create-python-package.md:459
 msgid "A `pyproject.toml` file."
 msgstr "`pyproject.toml` ファイル。"
 
-#: ../../tutorials/create-python-package.md:79
+#: ../../tutorials/create-python-package.md:460
 msgid "A specific directory structure."
 msgstr "特定のディレクトリ構造。"
 
-#: ../../tutorials/create-python-package.md:80
+#: ../../tutorials/create-python-package.md:461
 msgid "Some code."
 msgstr "いくつかのコード。"
 
-#: ../../tutorials/create-python-package.md:81
+#: ../../tutorials/create-python-package.md:462
 msgid "An `__init__.py` file in your code directory."
 msgstr "コードディレクトリの `__init__.py` ファイル。"
 
-#: ../../tutorials/create-python-package.md:83
+#: ../../tutorials/create-python-package.md:464
 msgid "The directory structure you'll create in this lesson will look like this:"
 msgstr "このレッスンで作成するディレクトリ構造は次のようになります:"
 
-#: ../../tutorials/create-python-package.md:95
+#: ../../tutorials/create-python-package.md:479
+msgid ""
+"Diagram showing the basic steps to creating an installable package. There"
+" are 4 boxes with arrows pointing towards the right. The boxes read, your"
+" code, create package structure, add metadata to pyproject.toml and pip "
+"install package."
+msgstr ""
+"インストール可能なパッケージを作成する基本的な手順を示した図です。 右を向いた矢印の箱が4つあります。 "
+"ボックスは、あなたのコード、パッケージ構造の作成、pyproject.tomlへのメタデータの追加、およびpip "
+"installパッケージを読み込みます。"
+
+#: ../../tutorials/create-python-package.md:481
+#, fuzzy
+msgid ""
+"Once you have the basic items of a Python package (code, metadata and a "
+"file structure), you can `pip install` your package into any Python "
+"environment on your computer."
+msgstr "やったね！ これでどんなPython環境にもインストールできるPythonパッケージができました。"
+
+#: ../../tutorials/create-python-package.md:484
 msgid "About the basic package directory structure"
 msgstr "基本パッケージのディレクトリ構造について"
 
-#: ../../tutorials/create-python-package.md:97
+#: ../../tutorials/create-python-package.md:486
 msgid "Notice a few things about the above layout:"
 msgstr "上記のレイアウトについて、いくつかの点に注目してください:"
 
-#: ../../tutorials/create-python-package.md:99
+#: ../../tutorials/create-python-package.md:488
 msgid ""
 "Your package code lives within a `src/packagename` directory. We suggest "
 "that you use `src` (short for **source code**) directory as it [ensures "
@@ -1694,7 +1873,7 @@ msgstr ""
 "structure.html#the-src-layout-and-testing) `src`（ **source code** "
 "の略）ディレクトリを使用することをお勧めします。"
 
-#: ../../tutorials/create-python-package.md:100
+#: ../../tutorials/create-python-package.md:489
 msgid ""
 "Within the `src` directory you have a package directory called "
 "`pyospackage`. Use the name of your package for that directory name. This"
@@ -1704,7 +1883,7 @@ msgstr ""
 "`src` ディレクトリの中に `pyospackage` というパッケージディレクトリがあります。 ディレクトリ名にはパッケージ名を使用します。"
 " これは、インストール後にPythonコードでパッケージをインポートする際の名前になります。"
 
-#: ../../tutorials/create-python-package.md:101
+#: ../../tutorials/create-python-package.md:490
 msgid ""
 "In your package directory, you have an `__init__.py` file and all of your"
 " Python modules. You will learn more about the `__init__.py` file below."
@@ -1712,11 +1891,11 @@ msgstr ""
 "パッケージディレクトリには `__init__.py` ファイルと Python モジュールがあります。以下に `__init__.py` "
 "ファイルについて詳しく説明します。"
 
-#: ../../tutorials/create-python-package.md:102
+#: ../../tutorials/create-python-package.md:491
 msgid "The `pyproject.toml` file lives at the root directory of your package."
 msgstr "`pyproject.toml` ファイルはパッケージのルートディレクトリにあります。"
 
-#: ../../tutorials/create-python-package.md:103
+#: ../../tutorials/create-python-package.md:492
 msgid ""
 "The name of the root directory for the package is **pyospackage** which "
 "is the name of the package. This is not a requirement but you will often "
@@ -1726,11 +1905,11 @@ msgstr ""
 "パッケージのルートディレクトリの名前は、パッケージ名である **pyospackage** です。これは必須ではありませんが、GitHub / "
 "GitLabのリポジトリ名とルートディレクトリ名がパッケージ名と同じであることをよく見かけます。"
 
-#: ../../tutorials/create-python-package.md:105
+#: ../../tutorials/create-python-package.md:494
 msgid "What is an `__init__.py` file?"
 msgstr "`__init__.py` ファイルとは何ですか？"
 
-#: ../../tutorials/create-python-package.md:107
+#: ../../tutorials/create-python-package.md:496
 msgid ""
 "The `__init__.py` file tells Python that a directory should be treated as"
 " a Python package. As such, a directory with an `__init__.py` file can be"
@@ -1741,31 +1920,32 @@ msgstr ""
 "このように、`__init__.py` ファイルがあるディレクトリは Python に直接インポートすることができます。 Python "
 "に認識させるために `__init__.py` ファイルにコードを記述する必要はありません; 空であることもあります。"
 
-#: ../../tutorials/create-python-package.md:111
+#: ../../tutorials/create-python-package.md:500
 msgid ""
 "For example, following the file structure example above which has an "
 "`__init__.py` file within it, you can run:"
 msgstr "例えば、 `__init__.py` ファイルを持つ上記のファイル構造の例に従って、次のように実行します:"
 
-#: ../../tutorials/create-python-package.md:117 ../../tutorials/pyproject-toml.md:48
+#: ../../tutorials/create-python-package.md:506
+#: ../../tutorials/pyproject-toml.md:53
 msgid "What is a pyproject.toml file?"
 msgstr "pyproject.tomlファイルとは何ですか？"
 
-#: ../../tutorials/create-python-package.md:119
+#: ../../tutorials/create-python-package.md:508
 msgid "The **pyproject.toml** file is:"
 msgstr "**pyproject.toml** ファイルは:"
 
-#: ../../tutorials/create-python-package.md:121
+#: ../../tutorials/create-python-package.md:510
 msgid ""
 "Where you define your project's metadata (including its name, authors, "
 "license, etc)"
 msgstr "プロジェクトのメタデータ (名前、作者、ライセンスなど) を定義します。"
 
-#: ../../tutorials/create-python-package.md:122
+#: ../../tutorials/create-python-package.md:511
 msgid "Where you define dependencies (the packages that it depends on)"
 msgstr "依存関係 (依存するパッケージ) を定義します。"
 
-#: ../../tutorials/create-python-package.md:123
+#: ../../tutorials/create-python-package.md:512
 msgid ""
 "Used to specify and configure what build backend you want to use to "
 "[build your package](../package-structure-code/python-package-"
@@ -1774,7 +1954,7 @@ msgstr ""
 "[パッケージのビルド](../package-structure-code/python-package-distribution-files-"
 "sdist-wheel) に使用するビルドバックエンドを指定し、設定します。"
 
-#: ../../tutorials/create-python-package.md:125
+#: ../../tutorials/create-python-package.md:514
 msgid ""
 "After the `__init__.py` and `pyproject.toml` files have been added, your "
 "package can be built and distributed as an installable Python package "
@@ -1787,356 +1967,69 @@ msgstr ""
 "`pyproject.toml` "
 "ファイルには、パッケージをインストールするために、以下のようないくつかの基本的な項目が定義されている必要があることに注意してください:"
 
-#: ../../tutorials/create-python-package.md:131
+#: ../../tutorials/create-python-package.md:520
 msgid "The `build-backend` that you want to use,"
 msgstr "使用したい `build-backend` を指定します、"
 
-#: ../../tutorials/create-python-package.md:132
+#: ../../tutorials/create-python-package.md:521
 msgid "The project `name` and `version`."
 msgstr "プロジェクトの `name` と `version` を指定する。"
 
-#: ../../tutorials/create-python-package.md:134
+#: ../../tutorials/create-python-package.md:523
 msgid "Why the pyproject.toml file is important"
 msgstr "pyproject.tomlファイルが重要な理由"
 
-#: ../../tutorials/create-python-package.md:138
+#: ../../tutorials/create-python-package.md:526
+#, fuzzy
 msgid ""
 "The `pyproject.toml` file replaces some of the functionality of both the "
 "`setup.py` file and `setup.cfg` files. If you try to pip install a "
-"package with no `pyproject.toml` you will get the following error:"
+"package with no `pyproject.toml`, you will get the following error:"
 msgstr ""
 "`pyproject.toml` ファイルは `setup.py` ファイルと `setup.cfg` ファイルの機能の一部を置き換えます。 "
 "`pyproject.toml` がないパッケージをpipインストールしようとすると、以下のエラーが発生します:"
 
-#: ../../tutorials/create-python-package.md:150
-msgid "Note about `setup.py`"
-msgstr "`setup.py` についてのメモ"
-
-#: ../../tutorials/create-python-package.md:154
+#: ../../tutorials/create-python-package.md:536
+#, fuzzy
 msgid ""
-"If your project already defines a `setup.py` file, Hatch can be used to "
-"automatically create the `pyproject.toml`."
+"If your project already has a `setup.py` file, Hatch can be used to "
+"automatically create a `pyproject.toml`."
 msgstr ""
 "プロジェクトが既に `setup.py` ファイルを定義している場合、ハッチを使用して自動的に `pyproject.toml` "
 "を作成することができます。"
 
-#: ../../tutorials/create-python-package.md:155
+#: ../../tutorials/create-python-package.md:537
+#, fuzzy
 msgid ""
-"See [Using Hatch to Migrate setup.py to a pyproject.toml ](setup-py-to-"
+"See [Using Hatch to Migrate setup.py to a pyproject.toml](setup-py-to-"
 "pyproject-toml.md)"
 msgstr ""
 "[Hatchを使ってsetup.pyをpyproject.tomlに移行する ](setup-py-to-pyproject-toml.md) "
 "を参照"
 
-#: ../../tutorials/create-python-package.md:161
-msgid "Time to create your Python package!"
-msgstr "Pythonパッケージを作成しましょう！"
-
-#: ../../tutorials/create-python-package.md:163
+#: ../../tutorials/create-python-package.md:552
 msgid ""
-"Now that you understand the basics of the Python package directory "
-"structure, and associated key files (`__init__.py` and `pyproject.toml`),"
-" it's time to create your Python package! Below you will create a "
-"directory structure similar to the structure described above using Hatch."
+"Is it clear where to add commands? Bash vs. Python console Bash vs. Zsh "
+"is different"
+msgstr "コマンドを追加する場所は明確ですか？ BashとPythonのコンソールの違い BashとZshの違い"
+
+#: ../../tutorials/create-python-package.md:554
+msgid ""
+"ADD: note about what makes something \"package worthy\", with a common "
+"misconception being that a package should be production-ready code that's"
+" valuable to a broad audience. This may not be a pervasive misconception "
+"in Python, but a quick break-out with an explanation of what a package "
+"can consist of would be helpful."
 msgstr ""
-"Python パッケージのディレクトリ構造の基本を理解し、関連するキーファイル (`__init__.py` と "
-"`pyproject.toml`) を理解したところで、いよいよ Python パッケージを作成します！ "
-"以下では、Hatchを使って、上で説明したようなディレクトリ構造を作成します。"
+"追加: 何をもって \"パッケージに値する\" とするのかについて、 "
+"一般的な誤解は、パッケージは幅広いオーディエンスにとって価値のある、生産可能なコードであるべきだというものです。これはPythonに蔓延している誤解ではないかもしれませんが、パッケージがどのようなもので構成されるかを簡単に説明することは役に立つでしょう。"
 
-#: ../../tutorials/create-python-package.md:167
-msgid "Step 1: Set Up the Package Directory Structure"
-msgstr "ステップ1: パッケージのディレクトリ構造を設定する"
+#: ../../tutorials/create-python-package.md:555
+#, fuzzy
+msgid "They can use a codespace to complete this lesson too."
+msgstr "**このレッスンを完了するために必要なもの**"
 
-#: ../../tutorials/create-python-package.md:169
-msgid "Open your shell or preferred terminal."
-msgstr "シェルまたはお好みのターミナルを開きます。"
-
-#: ../../tutorials/create-python-package.md:170
-msgid ""
-"Use the shell `cd` command to navigate in your shell to the location "
-"where you'd like your package directory to live. Hatch will create the "
-"package directory for you"
-msgstr "シェルで `cd` コマンドを使い、パッケージのディレクトリを置く場所に移動します。 Hatchがパッケージディレクトリを作成してくれます。"
-
-#: ../../tutorials/create-python-package.md:171
-msgid "Choose a name for your package. The name should:"
-msgstr "パッケージの名前を決めてください。 名前は以下のようにします:"
-
-#: ../../tutorials/create-python-package.md:172
-msgid "Have no spaces (*Required*)"
-msgstr "スペースがない (*必須*)"
-
-#: ../../tutorials/create-python-package.md:173
-msgid ""
-"Use all lowercase characters (*Recommended*). For this tutorial we will "
-"use `pyospackage`."
-msgstr "すべて小文字を使用 (*推奨*)。 このチュートリアルでは `pyospackage` を使用します。"
-
-#: ../../tutorials/create-python-package.md:174
-msgid ""
-"Only use letter and the characters _ or - in the name. This means that "
-"the name `pyos*package` is not an acceptable name. However, the names "
-"`pyos_package` or `pyos-package` both are ok"
-msgstr ""
-"名前にはアルファベットと _ または - "
-"のみを使用してください。これは、`pyos*package`という名前は使えないことを意味します。しかし、 `pyos_package` または "
-"`pyos-package` という名前であれば、どちらでも構いません。"
-
-#: ../../tutorials/create-python-package.md:176
-msgid "Hatch and project names"
-msgstr "Hatchとプロジェクト名"
-
-#: ../../tutorials/create-python-package.md:177
-msgid ""
-"Hatch makes some decisions for your project's name when you run `hatch "
-"new`"
-msgstr "`hatch new` を実行したとき、 Hatch は、あなたのプロジェクトの名前を決定します。"
-
-#: ../../tutorials/create-python-package.md:179
-msgid "These include using:"
-msgstr "これには以下のようなものがあります:"
-
-#: ../../tutorials/create-python-package.md:180
-msgid "dashes for the top level directory"
-msgstr "最上位ディレクトリのダッシュ記号"
-
-#: ../../tutorials/create-python-package.md:181
-msgid "dashes for the project name in the pyproject.toml"
-msgstr "pyproject.tomlのプロジェクト名をダッシュで囲みます"
-
-#: ../../tutorials/create-python-package.md:182
-msgid "underscores for the package directory name"
-msgstr "パッケージディレクトリ名のアンダースコア"
-
-#: ../../tutorials/create-python-package.md:196
-msgid "If you use a name with underscores, Hatch will return the same thing:"
-msgstr "アンダースコア付きの名前を使っても、Hatchは同じものを返します:"
-
-#: ../../tutorials/create-python-package.md:209
-msgid ""
-"In both of the examples above the project name in the pyproject.toml file"
-" that hatch creates is `pyos-package`."
-msgstr "上記のどちらの例でも、hatchが作成するpyproject.tomlファイルのプロジェクト名は `pyos-package` です。"
-
-#: ../../tutorials/create-python-package.md:213
-msgid "Next run:"
-msgstr "次に実行するのは:"
-
-#: ../../tutorials/create-python-package.md:228
-msgid "Your final project directory structure should look like this:"
-msgstr "最終的なプロジェクトのディレクトリ構造は以下のようになるはずです:"
-
-#: ../../tutorials/create-python-package.md:243
-msgid "Step 2: Add module to your package"
-msgstr "ステップ 2: パッケージにモジュールを追加する"
-
-#: ../../tutorials/create-python-package.md:245
-msgid ""
-"A Python module refers to a `.py` file containing the code that you want "
-"your package to access and run. Within the `pyospackage` subdirectory, "
-"add at least one Python modules (.py files)."
-msgstr ""
-"Python モジュールとは、パッケージにアクセスさせ、実行させたいコードを含む `.py` ファイルを指します。 `pyospackage` "
-"サブディレクトリに、少なくとも1つのPythonモジュール (.py ファイル) を追加します。"
-
-#: ../../tutorials/create-python-package.md:247
-msgid ""
-"If you don't have code already and are just learning how to create a "
-"Python package, then create an empty `add_numbers.py` file. You will "
-"populate the `add_numbers.py` file with code provided below."
-msgstr ""
-"もしまだコードを持っておらず、Python パッケージの作成方法を学んでいるところなら、空の `add_numbers.py` "
-"ファイルを作成してください。 この `add_numbers.py` ファイルに以下に示すコードを入力します。"
-
-#: ../../tutorials/create-python-package.md:250
-msgid "Python modules and the `__init__.py` file"
-msgstr "Pythonモジュールと `__init__.py` ファイル"
-
-#: ../../tutorials/create-python-package.md:254
-msgid ""
-"When you see the word module, we are referring to a `.py` file containing"
-" Python code."
-msgstr "モジュールという言葉を目にしたとき、私たちはPythonのコードを含む `.py` ファイルを指しています。"
-
-#: ../../tutorials/create-python-package.md:257
-msgid ""
-"The `__init__.py`  allows Python to recognize that a directory contains "
-"at least one module that may be imported and used in your code. A package"
-" can have multiple modules[^python-modules]."
-msgstr ""
-"`__init__.py` は、Pythonがディレクトリに少なくとも1つのモジュールが含まれていることを認識できるようにします。 "
-"パッケージは複数のモジュール [^python-modules] を持つことができます。"
-
-#: ../../tutorials/create-python-package.md:261
-msgid "Your project directory should now look like this:"
-msgstr "プロジェクトディレクトリはこのようになっているはずです:"
-
-#: ../../tutorials/create-python-package.md:271
-msgid "Step 3: Add code to your module"
-msgstr "ステップ3: モジュールにコードを追加する"
-
-#: ../../tutorials/create-python-package.md:273
-msgid ""
-"If you are following along and making a Python package from scratch then "
-"you can add the code below to your `add_numbers.py` module. The function "
-"below adds two integers together and returns the result. Notice that the "
-"code below has a few features that we will review in future tutorials:"
-msgstr ""
-"Python のパッケージをゼロから作るのであれば、以下のコードを `add_numbers.py` モジュールに追加してください。 "
-"以下の関数は2つの整数を加算して結果を返します。以下のコードには、今後のチュートリアルで確認するいくつかの機能があることに注目してください:"
-
-#: ../../tutorials/create-python-package.md:275
-msgid "It has a [numpy-style docstring](numpy-docstring)"
-msgstr "これは [numpyスタイルのdocstring](numpy-docstring) を持っています。"
-
-#: ../../tutorials/create-python-package.md:276
-msgid "It uses [typing](type-hints)"
-msgstr "[typing](type-hints) を使用します。"
-
-#: ../../tutorials/create-python-package.md:278
-msgid ""
-"Python can support many different docstrings formats depending on the "
-"documentation build system you wish to use. The most popular supported "
-"formats for documenting Python objects are NumPy Style "
-"Docstring[^numpydoc], Google Style Docstring[^googledoc], and the Epytext"
-" Style Docstrings[^epytextdoc]."
-msgstr ""
-"Pythonは、使いたいドキュメントのビルドシステムに応じて、多くの異なるdocstringsフォーマットをサポートすることができます。 "
-"Pythonオブジェクトを文書化するために最もよくサポートされている形式は、NumPy Style "
-"Docstring[^numpydoc]、Google Style Docstring[^googledoc]、Epytext Style "
-"Docstring[^epytextdoc]です。"
-
-#: ../../tutorials/create-python-package.md:280
-msgid "**pyOpenSci recommends using the NumPy Docstring convention.**"
-msgstr "**pyOpenSciは、NumPyのDocstring規約を使用することを推奨します。**"
-
-#: ../../tutorials/create-python-package.md:282
-msgid ""
-"If you aren't familiar with docstrings or typing yet, that is ok. You can"
-" review [this page in the pyOpenSci packaging "
-"guide](https://www.pyopensci.org/python-package-guide/documentation"
-"/write-user-documentation/document-your-code-api-docstrings.html) for an "
-"overview of both topics."
-msgstr ""
-"もしあなたがまだdocstringsやタイピングに慣れていなくても大丈夫です。 両方のトピックの概要については、 "
-"[pyOpenSciパッケージングガイドのこのページ](https://www.pyopensci.org/python-package-"
-"guide/documentation/write-user-documentation/document-your-code-api-"
-"docstrings.html) を参照してください。"
-
-#: ../../tutorials/create-python-package.md:311
-msgid "Step 4: Modify metadata in your `pyproject.toml` file"
-msgstr "ステップ 4: `pyproject.toml` ファイルのメタデータを修正する"
-
-#: ../../tutorials/create-python-package.md:313
-msgid ""
-"Next, you will modify some of the metadata (information) that Hatch adds "
-"to your `pyproject.toml` file. You are are welcome to copy the file we "
-"have in our [example pyospackage GitHub "
-"repository](https://github.com/pyOpenSci/pyosPackage)."
-msgstr ""
-"次に、Hatchが `pyproject.toml` ファイルに追加するメタデータ (情報) の一部を変更します。私たちの [example "
-"pyospackage GitHubリポジトリ](https://github.com/pyOpenSci/pyosPackage) "
-"にあるファイルをコピーしてください。"
-
-#: ../../tutorials/create-python-package.md:317
-msgid "Brief overview of the TOML file"
-msgstr "TOMLファイルの概要"
-
-#: ../../tutorials/create-python-package.md:320
-msgid ""
-"[The TOML format](https://toml.io/en/) consists of tables and variables. "
-"Tables are sections of information denoted by square brackets:"
-msgstr "[TOMLフォーマット](https://toml.io/en/) は表と変数で構成されます。 表は角括弧で示される情報のセクションです:"
-
-#: ../../tutorials/create-python-package.md:322
-msgid "`[this-is-a-table]`."
-msgstr "`[this-is-a-table]`."
-
-#: ../../tutorials/create-python-package.md:324
-msgid ""
-"Tables can contain variables within them defined by an variable name and "
-"an `=` sign. For instance, a `build-system` table most often holds two "
-"(2) variables:"
-msgstr ""
-"テーブルには、変数名と `=` 記号で定義された変数を入れることができます。 例えば、`build-system` "
-"テーブルは以下の2(つの)変数を保持することが多いです:"
-
-#: ../../tutorials/create-python-package.md:327
-msgid ""
-"`requires = `, which tells a build tool what tools it needs to install "
-"prior to building your package. In this case "
-"[hatchling](https://pypi.org/project/hatchling/)"
-msgstr ""
-"`requires=` は、ビルドツールに対して、パッケージをビルドする前にインス トールする必要があるツールを指示します。 この場合 "
-"[hatchling](https://pypi.org/project/hatchling/)"
-
-#: ../../tutorials/create-python-package.md:329
-msgid ""
-"`build-backend = `, which is used to define the specific build-backend "
-"name, (in this example we are using `hatchling.build`)."
-msgstr ""
-"`build-backend = ` 、これは、特定のビルドバックエンド名を定義するために使われます、(この例では、 "
-"`hatchling.build` を使用しています)。"
-
-#: ../../tutorials/create-python-package.md:338
-msgid ""
-"TOML organizes data structures, defining relationships within a "
-"configuration file."
-msgstr "TOMLはデータ構造を整理し、設定ファイル内の関係を定義します。"
-
-#: ../../tutorials/create-python-package.md:341
-msgid ""
-"[Learn more about the pyproject.toml format here.](../package-structure-"
-"code/pyproject-toml-python-package-metadata)"
-msgstr ""
-"[pyproject.tomlフォーマットの詳細はこちら。](../package-structure-code/pyproject-toml-"
-"python-package-metadata)"
-
-#: ../../tutorials/create-python-package.md:345
-msgid ""
-"You will learn more about the `pyproject.toml` format in the [next lesson"
-" when you add additional metadata / information to this file.](pyproject-"
-"toml.md)"
-msgstr ""
-"`pyproject.toml` フォーマットについては、 [このファイルにメタデータや情報を追加する次のレッスン](pyproject-"
-"toml.md) で詳しく学びます。"
-
-#: ../../tutorials/create-python-package.md:348
-msgid ""
-"Open up the `pyproject.toml` file that Hatch created in your favorite "
-"text editor. It should look something like the example below."
-msgstr "Hatchが作成した `pyproject.toml` ファイルをお好みのテキストエディタで開いてください。 下の例のようになるはずです。"
-
-#: ../../tutorials/create-python-package.md:390
-msgid "Edit the file as follows:"
-msgstr "以下のようにファイルを編集します:"
-
-#: ../../tutorials/create-python-package.md:392
-msgid ""
-"Delete `dynamic = [\"version\"]`: This sets up dynamic versioning based "
-"on tags stored in your git commit history. We will walk through "
-"implementing this in a later lesson."
-msgstr ""
-"`dynamic = [\"version\"]` を削除する: これは、git "
-"のコミット履歴に保存されているタグに基づいて、動的なバージョン管理を設定します。後のレッスンでこの実装方法を説明します。"
-
-#: ../../tutorials/create-python-package.md:393
-msgid ""
-"Add `version = \"0.1\"` in the place of  `dynamic = [\"version\"]` which "
-"you just deleted. This sets up manual versioning."
-msgstr ""
-"先ほど削除した `dynamic = [\"version\"]` の場所に `version = \"0.1\"` "
-"を追加します。これで手動バージョン管理が設定されます。"
-
-#: ../../tutorials/create-python-package.md:394
-msgid "Fill in the description if it doesn't already exist."
-msgstr "説明文がなければ記入してください。"
-
-#: ../../tutorials/create-python-package.md:404
-msgid "Remove the `[tool.hatch.version]` table from the bottom of the file."
-msgstr "ファイルの一番下にある `[tool.hatch.version]` テーブルを削除します。"
-
-#: ../../tutorials/create-python-package.md:412
+#: ../../tutorials/create-python-package.md:559
 msgid ""
 "When this lesson exists, uncomment this admonition You will learn how to "
 "automate defining a package version using git tags in the version and "
@@ -2145,323 +2038,23 @@ msgstr ""
 "このレッスンが存在する場合、この戒めのコメントを解除します。 このレッスンでは、git "
 "タグを使ってパッケージのバージョン定義を自動化する方法と、パッケージのリリースについて学びます。"
 
-#: ../../tutorials/create-python-package.md:417
-msgid "OPTIONAL: Adjust project classifiers"
-msgstr "オプション: プロジェクトの分類子を調整する"
-
-#: ../../tutorials/create-python-package.md:419
-msgid ""
-"Hatch by default provides a list of classifiers that define what Python "
-"versions your package supports. These classifiers do not in any way "
-"impact your package's build and are primarily intended to be used when "
-"you publish your package to PyPI."
-msgstr "Hatchはデフォルトで、パッケージがサポートするPythonのバージョンを定義する分類子のリストを提供します。これらの分類子はパッケージのビルドには一切影響を与えず、主にパッケージをPyPIに公開するときに使用することを目的としています。"
-
-#: ../../tutorials/create-python-package.md:424
-msgid ""
-"If you don't plan on publishing to PyPI, you can skip this section. "
-"However, if you wish, you can clean it up a bit."
-msgstr "PyPIに公開する予定がなければ、このセクションは飛ばして構いません。しかし、もし望むなら、少しきれいにすることもできます。"
-
-#: ../../tutorials/create-python-package.md:427
-msgid "To begin:"
-msgstr "はじめに:"
-
-#: ../../tutorials/create-python-package.md:429
-msgid "Remove support for Python 3.8"
-msgstr "Python 3.8のサポートを削除"
-
-#: ../../tutorials/create-python-package.md:430
-msgid ""
-"Within the `[project]` table, update `requires-python = \">3.8\"` to "
-"`requires-python = \">3.9\"`"
-msgstr ""
-"`[project]` テーブル内で、 `requires-python = \">3.8\"` を `requires-python = "
-"\">3.9\"` に更新します。"
-
-#: ../../tutorials/create-python-package.md:432
-msgid ""
-"Since you are creating a pure Python package in this lesson, you can "
-"remove the following classifiers:"
-msgstr "このレッスンでは純粋な Python パッケージを作成するので、以下の分類子は削除してかまいません:"
-
-#: ../../tutorials/create-python-package.md:442
-msgid "Your new pyproject.toml file should now look something like this:"
-msgstr "新しいpyproject.tomlファイルは次のようになるはずです:"
-
-#: ../../tutorials/create-python-package.md:477
-msgid "The bare minimum needed in a pyproject.toml file"
-msgstr "pyproject.tomlファイルに最低限必要なもの"
-
-#: ../../tutorials/create-python-package.md:480
-msgid ""
-"The core information that you need in a `pyproject.toml` file in order to"
-" publish on PyPI is your **package's name**  and the **version**. "
-"However, we suggest that you flesh out your metadata early on in the "
-"`pyproject.toml` file."
-msgstr ""
-"PyPIで公開するために `pyproject.toml` ファイルに必要な情報は、 **パッケージ名** と **バージョン** です。 "
-"しかし、 `pyproject.toml` ファイルの早い段階でメタデータを具体化することをお勧めします。"
-
-#: ../../tutorials/create-python-package.md:482
-msgid ""
-"Once you have your project metadata in the pyproject.toml file, you will "
-"rarely update it. In the next lesson you'll add more metadata and "
-"structure to this file."
-msgstr "一度pyproject.tomlファイルにプロジェクトのメタデータがあれば、それを更新することはほとんどありません。次のレッスンでは、このファイルにさらにメタデータと構造を追加します。"
-
-#: ../../tutorials/create-python-package.md:486
-msgid "Step 5: Install your package locally"
-msgstr "ステップ 5: パッケージをローカルにインストールする"
-
-#: ../../tutorials/create-python-package.md:488
-msgid "At this point you should have:"
-msgstr "この時点であなたは以下を持っているはずです:"
-
-#: ../../tutorials/create-python-package.md:490
-msgid "A project directory structure with a `pyproject.toml` file at the root"
-msgstr "`pyproject.toml` ファイルをルートに持つプロジェクトのディレクトリ構造"
-
-#: ../../tutorials/create-python-package.md:491
-msgid "A package directory containing an empty `__init__.py` file and"
-msgstr "空の `__init__.py` ファイルを含むパッケージ・ディレクトリと"
-
-#: ../../tutorials/create-python-package.md:492
-msgid "At least one Python module (e.g. `add_numbers.py`)"
-msgstr "少なくとも1つのPythonモジュール (e.g. `add_numbers.py`)"
-
-#: ../../tutorials/create-python-package.md:494
-msgid "You are now ready to install (and build) your Python package!"
-msgstr "これで Python パッケージをインストール（ビルド）する準備ができました！"
-
-#: ../../tutorials/create-python-package.md:496
-msgid ""
-"While you can do this using hatch, we are going to use pip for this "
-"lesson, so you can see how to install your tool into your preferred "
-"environment."
-msgstr "hatchを使ってもできますが、このレッスンではpipを使います、そうすれば、あなたの好みの環境にツールをインストールする方法を見ることができます。"
-
-#: ../../tutorials/create-python-package.md:498
-msgid ""
-"First open your preferred shell (Windows users may be using something "
-"like gitbash) and `cd` into your project directory if you are not already"
-" there."
-msgstr ""
-"まず、お好みのシェルを開き (Windowsユーザーはgitbashのようなものを使っているかもしれません) "
-"、まだプロジェクトディレクトリにいなければ、 `cd` してください。"
-
-#: ../../tutorials/create-python-package.md:499
-msgid "Activate the Python environment that you wish to use."
-msgstr "使用したいPython環境をアクティブにします。"
-
-#: ../../tutorials/create-python-package.md:500
-msgid "Run `python -m pip install -e .`"
-msgstr "`python -m pip install -e .` を実行します。"
-
-#: ../../tutorials/create-python-package.md:503
-msgid "Add this back in when the lesson is published"
-msgstr "レッスンが公開されたら、これを追加してください。"
-
-#: ../../tutorials/create-python-package.md:504
-msgid ""
-"Activate the Python environment that you wish to use. If you need help "
-"with working with virtual environments check out this lesson (add link)."
-msgstr "使用したいPython環境をアクティブにします。 仮想環境での作業で助けが必要な場合は、このレッスンをチェックしてください（リンクを追加）。"
-
-#: ../../tutorials/create-python-package.md:530
-msgid "What does `python -m pip install -e .` do?"
-msgstr "`python -m pip install -e .` は何をしているのか？"
-
-#: ../../tutorials/create-python-package.md:533
-msgid "Let's break down `python -m pip install -e .`"
-msgstr "`python -m pip install -e .` を分解してみましょう"
-
-#: ../../tutorials/create-python-package.md:535
-msgid ""
-"`python -m pip install -e .` installs your package into the current "
-"active Python environment in **editable mode** (`-e`). Installing your "
-"package in editable mode, allows you to work on your code and then test "
-"the updates interactively in your favorite Python interface. One "
-"important caveat of editable mode is that every time you update your "
-"code, you may need to restart Python."
-msgstr ""
-"`python -m pip install -e .` は、 **編集可能モード** (`-e`) で、現在のアクティブな Python "
-"環境にパッケージをインストールします。 "
-"編集可能モードでパッケージをインストールすることで、あなたのコードで作業し、お気に入りのPythonインターフェースでインタラクティブに更新をテストすることができます。"
-" 編集可能モードの重要な注意点のひとつは、コードを更新するたびに、そのコードが更新されるということです、 "
-"その場合、Pythonを再起動する必要があるかもしれません。"
-
-#: ../../tutorials/create-python-package.md:540
-msgid ""
-"If you wish to install the package regularly (not in editable mode) you "
-"can use:"
-msgstr "(編集可能モードではなく) 定期的にパッケージをインストールしたい場合は、次のようにします:"
-
 #: ../../tutorials/create-python-package.md:543
-msgid "`python -m pip install . `"
-msgstr "`python -m pip install . `"
-
-#: ../../tutorials/create-python-package.md:545
-msgid "**Using `python -m` when calling `pip`**"
-msgstr "**`pip` を呼び出す際に `python -m` を使用する**"
-
-#: ../../tutorials/create-python-package.md:547
-msgid ""
-"Above, you use`python -m` to call the version of pip installed into your "
-"current active environment. `python -m` is important to ensure that you "
-"are calling the version of pip installed in your current environment."
-msgstr ""
-"上記では、 `python -m` を使用して、現在アクティブな環境にインストールされている pip のバージョンを呼び出します。 `python"
-" -m` は、現在の環境にインストールされているバージョンの pip を呼び出していることを確認するために重要です。"
-
-#: ../../tutorials/create-python-package.md:552
-msgid "Look for pyospackage in your environment"
-msgstr "あなたの環境でpyospackageを探す"
-
-#: ../../tutorials/create-python-package.md:554
-msgid ""
-"Once you have installed your package, you can view it in your current "
-"environment. If you are using `venv` or `conda`, `pip` list will allow "
-"you to see your current package installations."
-msgstr ""
-"パッケージをインストールしたら、現在の環境でそれを見ることができます。 `venv` または `conda` を使用している場合、 `pip` "
-"list で現在インストールされているパッケージを確認することができます。"
-
-#: ../../tutorials/create-python-package.md:558
-msgid ""
-"Note that because pyospackage is installed in editable mode (`-e`) pip "
-"will show you the directory path to your project's code"
-msgstr ""
-"pyospackageは編集可能モード (`-e`) "
-"でインストールされるため、pipはプロジェクトのコードへのディレクトリパスを表示することに注意してください。"
-
-#: ../../tutorials/create-python-package.md:586
-msgid "Step 6: Test out your new package"
-msgstr "ステップ 6: 新しいパッケージをテストする"
-
-#: ../../tutorials/create-python-package.md:588
-msgid ""
-"After installing your package, type “python” at the command prompt in "
-"your chosen terminal to start a Python session in your active Python "
-"environment."
-msgstr ""
-"パッケージをインストールしたら、選択したターミナルのコマンドプロンプトで \"python\" "
-"と入力し、アクティブなPython環境でPythonセッションを開始します。"
-
-#: ../../tutorials/create-python-package.md:591
-msgid "You can now import your package and access the `add_num` function."
-msgstr "これでパッケージをインポートして `add_num` 関数にアクセスできます。"
-
-#: ../../tutorials/create-python-package.md:603
-msgid "Installing packages from GitHub"
-msgstr "GitHubからパッケージをインストールする"
-
-#: ../../tutorials/create-python-package.md:605
-msgid ""
-"If you wish to share your code without publishing to PyPI you can always "
-"install packages directly from GitHub using the syntax:"
-msgstr "PyPIに公開せずにコードを共有したい場合は、いつでも構文を使ってGitHubから直接パッケージをインストールできます:"
-
-#: ../../tutorials/create-python-package.md:612
-msgid "To make your package GitHub installable, you can:"
-msgstr "GitHubのパッケージをインストール可能にするには、次のようにします:"
-
-#: ../../tutorials/create-python-package.md:614
-msgid "Create a new GitHub repository"
-msgstr "新しいGitHubリポジトリを作成する"
-
-#: ../../tutorials/create-python-package.md:615
-msgid ""
-"Push the contents of the project directory that you created above, to "
-"GitHub"
-msgstr "上記で作成したプロジェクトディレクトリの内容をGitHubにプッシュします"
-
-#: ../../tutorials/create-python-package.md:616
-msgid ""
-"Finally install the package from GitHub using the command above. When you"
-" use the command above, don't forget to substitute the user, repo, and "
-"branch_or_tag with your specific values."
-msgstr ""
-"最後に、上記のコマンドを使ってGitHubからパッケージをインストールします。 "
-"上記のコマンドを使用する際は、user、repo、branch_or_tag を特定の値に置き換えることをお忘れなく。"
-
-#: ../../tutorials/create-python-package.md:618
-msgid ""
-"For instance below you install the pyospackage from the main branch of "
-"the pyOpenSci repository."
-msgstr "例えば、以下のようにpyOpenSciリポジトリのmainブランチからpyospackageをインストールします。"
-
-#: ../../tutorials/create-python-package.md:621
-msgid "`python -m pip install git+https://github.com/user/repo.git@branch_or_tag`"
-msgstr "`python -m pip install git+https://github.com/user/repo.git@branch_or_tag`"
-
-#: ../../tutorials/create-python-package.md:625
-msgid "Congratulations! You created your first Python package"
-msgstr "おめでとうございます！ あなたは最初のPythonパッケージを作成しました"
-
-#: ../../tutorials/create-python-package.md:627
-msgid ""
-"You did it! You have now created a Python package that you can install "
-"into any Python environment."
-msgstr "やったね！ これでどんなPython環境にもインストールできるPythonパッケージができました。"
-
-#: ../../tutorials/create-python-package.md:630
-msgid "In the upcoming lessons you will:"
-msgstr "これからのレッスンではあなたは:"
-
-#: ../../tutorials/create-python-package.md:632
-msgid ""
-"Learn how to [build and publish your Python package to (test) PyPI"
-"](publish-pypi)"
-msgstr "[Python パッケージをビルドして (test) PyPI に公開する](publish-pypi) 方法を学びましょう。"
-
-#: ../../tutorials/create-python-package.md:633
-msgid "Add a README file and LICENSE to your package"
-msgstr "READMEファイルとLICENSEをパッケージに追加する。"
-
-#: ../../tutorials/create-python-package.md:634
-msgid ""
-"Add more metadata to your `pyproject.toml` file to support PyPI "
-"publication."
-msgstr "PyPI での公開をサポートするために `pyproject.toml` ファイルにメタデータを追加します。"
-
-#: ../../tutorials/create-python-package.md:635
-msgid "learn how to publish to **conda-forge** from **PyPI**."
-msgstr "**PyPI** から **conda-forge** に公開する方法を学んでください。"
-
-#: ../../tutorials/create-python-package.md:637
-msgid ""
-"Add a [README file](add-readme.md) and [LICENSE](add-license-coc.md) to "
-"your package"
-msgstr "[READMEファイル](add-readme.md) と [LICENSE](add-license-coc.md) をパッケージに追加する。"
-
-#: ../../tutorials/create-python-package.md:638
-msgid ""
-"[Add more metadata to your `pyproject.toml`](pyproject-toml.md) file to "
-"support PyPI publication."
-msgstr ""
-"PyPI での公開をサポートするために [ `pyproject.toml` ファイルにメタデータを追加します。](pyproject-"
-"toml.md)"
-
-#: ../../tutorials/create-python-package.md:639
-msgid ""
-"[Learn how to build your package distribution](publish-pypi) files "
-"(**sdist** and **wheel**) and publish to **test PyPI**."
-msgstr ""
-"[パッケージ配布ファイルをビルド](publish-pypi) して (**sdist** と **wheel**) 、 **test "
-"PyPI** に公開する方法を学びます。"
-
-#: ../../tutorials/create-python-package.md:640
-msgid ""
-"Finally you will learn how to [publish to **conda-forge**](publish-conda-"
-"forge) from **PyPI**."
-msgstr "**PyPI** から [**conda-forge**](publish-conda-forge)  に公開する方法を学んでください。"
-
-#: ../../tutorials/create-python-package.md:644
 msgid "[Carpentries shell lesson](https://swcarpentry.github.io/shell-novice/)"
 msgstr "[Carpentries shell lesson](https://swcarpentry.github.io/shell-novice/)"
 
-#: ../../tutorials/create-python-package.md:646
+#: ../../tutorials/create-python-package.md:547
+msgid "[Numpy style docs](https://numpydoc.readthedocs.io/en/latest/format.html)"
+msgstr "[Numpy style docs](https://numpydoc.readthedocs.io/en/latest/format.html)"
+
+#: ../../tutorials/create-python-package.md:546
+msgid "[Google docstring style](https://google.github.io/styleguide/pyguide.html)"
+msgstr "[Google docstring style](https://google.github.io/styleguide/pyguide.html)"
+
+#: ../../tutorials/create-python-package.md:548
+msgid "[epydoc](https://epydoc.sourceforge.net/epytext.html)"
+msgstr "[epydoc](https://epydoc.sourceforge.net/epytext.html)"
+
+#: ../../tutorials/create-python-package.md:545
 msgid ""
 "[Python module "
 "docs](https://docs.python.org/3/tutorial/modules.html#packages)"
@@ -2469,83 +2062,858 @@ msgstr ""
 "[Python module "
 "docs](https://docs.python.org/3/tutorial/modules.html#packages)"
 
-#: ../../tutorials/create-python-package.md:648
-msgid "[Numpy style docs](https://numpydoc.readthedocs.io/en/latest/format.html)"
-msgstr "[Numpy style docs](https://numpydoc.readthedocs.io/en/latest/format.html)"
+#: ../../tutorials/develop-python-package-hatch.md:7
+#, fuzzy
+msgid "Use Hatch environments with your pure Python package"
+msgstr "Pythonパッケージの要素"
 
-#: ../../tutorials/create-python-package.md:647
-msgid "[Google docstring style](https://google.github.io/styleguide/pyguide.html)"
-msgstr "[Google docstring style](https://google.github.io/styleguide/pyguide.html)"
+#: ../../tutorials/develop-python-package-hatch.md:13
+msgid ""
+"[In a previous lesson](create-pure-python-package), you learned how to "
+"create a Python package using the pyOpenSci copier template. In this "
+"lesson, you'll learn how to manage and use the Hatch environments set up "
+"by de **What you need to complete this lesson**"
+msgstr ""
 
-#: ../../tutorials/create-python-package.md:649
-msgid "[epydoc](https://epydoc.sourceforge.net/epytext.html)"
-msgstr "[epydoc](https://epydoc.sourceforge.net/epytext.html)"
+#: ../../tutorials/develop-python-package-hatch.md:16
+#, fuzzy
+msgid ""
+"To complete this lesson, you will need a local Python environment and "
+"shell on your computer.  You will need to have created a package using "
+"our pyOpenSci copier template. You should also have [Hatch installed"
+"](get-to-know-hatch)."
+msgstr ""
+"このレッスンを完了するには、あなたのコンピュータにローカルのPython環境とシェルが必要です。　[Hatchのインストール](get-to-"
+"know-hatch) も必要です。"
 
-#: ../../tutorials/intro.md:28 ../../tutorials/setup-py-to-pyproject-toml.md:24
+#: ../../tutorials/develop-python-package-hatch.md:20
+#, fuzzy
+msgid ""
+"If you are using Windows or are not familiar with Shell, you may want to "
+"check out the [Carpentries shell lesson](https://swcarpentry.github.io"
+"/shell-novice/). Windows users will likely need to configure a tool such "
+"as [GitBash](https://gitforwindows.org/) for any Shell and git-related "
+"steps."
+msgstr ""
+"Windowsを使用している、またはシェルに精通していない場合は、Carpentriesのシェルレッスン[^shell-lesson] "
+"をチェックアウトすることをお勧めします。 "
+"Windowsユーザーは、Shellやgitに関連するステップのためにツールを設定する必要があるでしょう。"
+
+#: ../../tutorials/develop-python-package-hatch.md:23
+msgid ""
+"Welcome to your shiny new package! This page will help you get started "
+"with using Hatch to run tests, build and check your package, and build "
+"your documentation."
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:25
+msgid ""
+"To begin, have a look at the `pyproject.toml` file in your package "
+"directory. This file contains the configuration for your package. This "
+"file is written using a .toml format. [You can learn more about toml "
+"here.](https://www.pyopensci.org/python-package-guide/package-structure-"
+"code/pyproject-toml-python-package-metadata.html) Here's the TL&DR:"
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:27
+msgid "Each `[]` section in the toml file is called a table."
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:28
+msgid "You can nest tables with double brackets like this`[[]]`"
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:29
+msgid ""
+"Tables contain information about a certain thing that you want to "
+"configure."
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:32
+msgid ""
+"You can configure Hatch to use UV by default for environment management. "
+"UV is a package manager built in Rust. It is fast and will significantly "
+"speed up environment creation."
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:34
+msgid ""
+"To use UV with Hatch, configure Hatch in the \"tools\" section of your "
+"`pyproject.toml` file."
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:42
+msgid ""
+"Using Hatch for developing, building, and maintaining your pure Python "
+"package"
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:44
+msgid ""
+"In the pyOpenSci Python package template, we have set up Hatch "
+"environments. You will notice at the bottom of the file, a [hatch "
+"environment](https://hatch.pypa.io/1.13/environment/) section, that looks"
+" like this:"
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:52
+msgid ""
+"Hatch allows you to configure and run environments and scripts similar to"
+" a workflow tool like tox or nox."
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:55
+msgid ""
+"Hatch defaults to using `venv` to manage environments. However, you can "
+"configure it to use other environment tools, such as conda or mamba."
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:57
+msgid ""
+"[Read the hatch documentation to learn more about environments. "
+"](https://hatch.pypa.io/1.13/tutorials/environment/basic-usage/)"
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:61
+msgid ""
+"Below is the Hatch environment used to build and test your package. "
+"Anytime you see: `tool.hatch.envs.test`, it tells Hatch:"
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:64
+msgid ""
+"\"Hey, Hatch, this is the definition for an environment.`test` is the "
+"name of the environment that I want you to create.\""
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:66
+msgid "So `tool.hatch.envs.build` will create an environment called `build`."
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:68
+msgid ""
+"Below the environment \"declaration,\" you can see the definition of what"
+" should be in that environment."
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:70
+#, fuzzy
+msgid "A Hatch environment to build your package"
+msgstr "パッケージのインストール"
+
+#: ../../tutorials/develop-python-package-hatch.md:72
+msgid ""
+"Below is a Hatch environment definition that you will find in your [new "
+"project's pyproject.toml file](create-python-package). It is set up to "
+"[build your package's](build-package) distribution files ([source "
+"distribution](python-source-distribution) and [wheel](python-wheel))."
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:74
+msgid ""
+"Notice that the environment definition declares two dependencies: `pip` "
+"and `twine`, which the environment needs to run successfully. This "
+"declaration is similar to declaring dependencies for your package at the "
+"top of your `pyproject.toml`. This section tells Hatch to create a new "
+"VENV with pip and twine installed."
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:86
+#, fuzzy
+msgid "Hatch will install your package in editable mode by default"
+msgstr "インタラクティブな開発のために編集可能モードでパッケージをインストールする方法"
+
+#: ../../tutorials/develop-python-package-hatch.md:87
+msgid ""
+"Notice the `detached = True` flag at the bottom of the environment. By "
+"default, hatch will install your package in editable mode into any "
+"environment it creates. `detached=True` tells it not to install your "
+"package into the environment."
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:91
+msgid "Hatch scripts"
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:93
+msgid "Hatch supports defining scripts that run in specific Hatch environments."
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:95
+msgid ""
+"Above, you have defined a new environment called 'build' that Hatch will "
+"create as a virtual environment (venv). Because `detached = True` in that"
+" environment, Hatch won't install your package into it."
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:97
+msgid ""
+"You can then use that environment to run \"scripts\". The definition "
+"below tells Hatch to run the following scripts in the build environment."
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:99
+msgid "`[tool.hatch.envs.build.scripts]`"
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:101
+msgid "You define this `scripts` to run using the following syntax, where:"
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:103
+msgid "`tool.hatch`: Alerts Hatch that this table is for Hatch to use"
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:104
+msgid "`envs.build`: Use the defined build environment."
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:105
+msgid ""
+"`scripts`: Define what scripts to run. In this case, Hatch will run shell"
+" scripts."
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:108
+msgid ""
+"Below is the `build.scripts` table that defines 3 shell commands to be "
+"run:"
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:110
+msgid "`pip check` # verifies your dependencies"
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:111
+#, fuzzy
+msgid "`hatch build --clean` # build your packages distribution files."
+msgstr "ステップ 2: パッケージのsdistとwheelディストリビューションをビルドする"
+
+#: ../../tutorials/develop-python-package-hatch.md:112
+msgid ""
+"`twine check dist/*` # use twine to check that your package's sdist "
+"(source distribution) is ok."
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:126
+msgid ""
+"Hatch, by default, will install your package in editable mode into any "
+"virtual environment (venv) that it creates. If `detached=True` is set, "
+"then it will skip that step."
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:129
+#, fuzzy
+msgid "Running the build script"
+msgstr "テストの実行"
+
+#: ../../tutorials/develop-python-package-hatch.md:131
+msgid "You can run the build script and build your package like this:"
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:133
+msgid "`hatch run build:check`"
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:135
+msgid ""
+"This step updates the build environment and then builds and checks the "
+"output distributions of your package."
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:137
+msgid "You can enter the build environment in your shell to check it out:"
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:143
+msgid "If you run `pip list` in the environment, twine will be there:"
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:149
+#: ../../tutorials/develop-python-package-hatch.md:207
+#, fuzzy
+msgid "To leave the environment use:"
+msgstr "環境設定"
+
+#: ../../tutorials/develop-python-package-hatch.md:155
+#, fuzzy
+msgid "Hatch, testing, and matrix environments"
+msgstr "Hatchと環境"
+
+#: ../../tutorials/develop-python-package-hatch.md:157
+msgid ""
+"It's always helpful to run your tests on the Python versions that you "
+"expect your users to be using. In this section, you'll explore the test "
+"environment setup in the pyOpenSci template package."
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:159
+msgid "Below, you see the Hatch environment test table."
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:161
+msgid ""
+"Similar to the above build environment, the environment below defines the"
+" dependencies that Hatch needs to install into the test environment "
+"(required to run your tests)."
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:175
+msgid "Your test environment has a matrix associated with it"
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:177
+msgid ""
+"If the environment has a matrix associated with it, that tells Hatch to "
+"run the tests across different Python versions. Below, you are running "
+"tests on versions 3.10 through 3.13."
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:180
+msgid ""
+"Hatch by default will install Python [using "
+"UV](https://docs.astral.sh/uv/guides/install-python/) both when you "
+"install Hatch and also when you declare a matrix environment like the one"
+" below"
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:188
+msgid ""
+"In your project, if you run `hatch shell test`, you will see the output "
+"below. This means that because there is a matrix of Python versions to "
+"choose from, you need to select the environment with the Python version "
+"you want to use."
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:201
+msgid ""
+"Pick the Python test environment that you want to use and enter it, like "
+"this (this will open Python 3.13):"
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:213
+#, fuzzy
+msgid "Hatch scripts for tests"
+msgstr "`hatch publish -r test` を実行します"
+
+#: ../../tutorials/develop-python-package-hatch.md:215
+msgid ""
+"In that same tests section, you will see a `tool.hatch.envs.test.scripts`"
+" section. Similar to what you saw above with the build steps, this is "
+"where the \"script\" to run your tests is defined."
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:218
+msgid ""
+"Notice that below, the script has a script called `run`. And that script "
+"runs pytest with a set of arguments, including generating code coverage."
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:225
+msgid "To run this script in your terminal, use the syntax:"
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:227
+msgid "`hatch run test:run`"
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:229
+#, fuzzy
+msgid "Reminder"
+msgstr "おすすめ"
+
+#: ../../tutorials/develop-python-package-hatch.md:232
+msgid ""
+"`hatch run`: this calls hatch and tells it that it will be running a "
+"command"
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:233
+msgid ""
+"`test:run` defines the environment you want it to run (`test`) in this "
+"case, and the script is defined as `run`"
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:236
+msgid ""
+"If you have a matrix setup for tests, then it will both install the "
+"needed Python version using UV and run your tests in each version of the "
+"Python environment. In this case, since there are four Python versions in"
+" the environment, your tests will be run four times, once in each Python "
+"version listed in the matrix table."
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:266
+msgid "Build your documentation with Hatch environments"
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:268
+msgid ""
+"Finally, you can build and serve your documentation using hatch. To build"
+" a static HTML version of the docs run:"
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:271
+msgid "`hatch run docs:build`"
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:273
+msgid ""
+"To run a local server with your docs updated as you update your markdown "
+"files, run:"
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:275
+msgid "`hatch run docs:serve`"
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:277
+msgid "To stop serving the docs use:"
+msgstr ""
+
+#: ../../tutorials/develop-python-package-hatch.md:279
+msgid "mac: <kbd>ctrl + c</kbd> windows:"
+msgstr ""
+
+#: ../../tutorials/get-to-know-hatch.md:6
+msgid "Get to Know Hatch"
+msgstr "Hatchを知る"
+
+#: ../../tutorials/get-to-know-hatch.md:8
+msgid ""
+"Our Python packaging tutorials use the tool "
+"[Hatch](https://hatch.pypa.io/latest/). While there are [many great "
+"packaging tools](/package-structure-code/python-package-build-tools) out "
+"there, we have selected Hatch because:"
+msgstr ""
+"私たちの Python パッケージングチュートリアルは [Hatch](https://hatch.pypa.io/latest/) "
+"というツールを使っています。 世の中には [たくさんの素晴らしいパッケージングツール](/package-structure-code"
+"/python-package-build-tools) があります、私たちはHatchを選ぶ理由は:"
+
+#: ../../tutorials/get-to-know-hatch.md:13
+msgid ""
+"It is an end-to-end tool that supports most of the steps required to "
+"create a quality Python package. Beginners will have fewer tools to learn"
+" if they use Hatch."
+msgstr "高品質なPythonパッケージを作成するために必要なステップのほとんどをサポートするエンドツーエンドのツールです。Hatchを使えば、初心者は覚えるツールが少なくて済みます。"
+
+#: ../../tutorials/get-to-know-hatch.md:16
+msgid ""
+"It supports different build back-ends if you ever need to compile code in"
+" other languages."
+msgstr "他の言語のコードをコンパイルする必要がある場合は、異なるビルドバックエンドをサポートします。"
+
+#: ../../tutorials/get-to-know-hatch.md:18
+msgid ""
+"As a community, pyOpenSci has decided that Hatch is a user-friendly tool "
+"that supports many different scientific Python use cases."
+msgstr "コミュニティとして、pyOpenSciはHatchが多くの異なる科学的なPythonの使用例をサポートするユーザーフレンドリーなツールであると決定しました。"
+
+#: ../../tutorials/get-to-know-hatch.md:21
+msgid ""
+"In this tutorial, you will install and get to know Hatch a bit more "
+"before starting to use it."
+msgstr "このチュートリアルでは、Hatchをインストールし、使い始める前にもう少しHatchについて知ってもらいます。"
+
+#: ../../tutorials/get-to-know-hatch.md:24
+msgid "You need two things to successfully complete this tutorial:"
+msgstr "このチュートリアルを成功させるために必要なものは2つあります:"
+
+#: ../../tutorials/get-to-know-hatch.md:26
+msgid "You need Python installed."
+msgstr "Pythonがインストールされている必要があります。"
+
+#: ../../tutorials/get-to-know-hatch.md:27
+msgid "You need Hatch installed."
+msgstr "Hatchをインストールする必要があります。"
+
+#: ../../tutorials/get-to-know-hatch.md:30
+msgid ""
+"If you don't already have Python installed on your computer, Hatch will "
+"do it for you when you install Hatch."
+msgstr "Pythonがまだインストールされていない場合は、Hatchをインストールする際にPythonがインストールされます。"
+
+#: ../../tutorials/get-to-know-hatch.md:34
+msgid "Install Hatch"
+msgstr "Hatchのインストール"
+
+#: ../../tutorials/get-to-know-hatch.md:36
+msgid ""
+"To begin, follow the operating-system-specific instructions below to "
+"install Hatch."
+msgstr "まず、以下のオペレーティングシステム別の説明に従ってHatchをインストールしてください。"
+
+#: ../../tutorials/get-to-know-hatch.md
+msgid "MAC"
+msgstr "MAC"
+
+#: ../../tutorials/get-to-know-hatch.md:43
+msgid ""
+"Follow the instructions "
+"[here](https://hatch.pypa.io/latest/install/#installers)."
+msgstr "[こちら](https://hatch.pypa.io/latest/install/#installers) の指示に従ってください。"
+
+#: ../../tutorials/get-to-know-hatch.md:45
+msgid ""
+"Download the latest GUI installer for MAC [hatch-"
+"universal.pkg](https://github.com/pypa/hatch/releases/latest/download"
+"/hatch-universal.pkg)."
+msgstr ""
+"MAC用最新GUIインストーラー [hatch-"
+"universal.pkg](https://github.com/pypa/hatch/releases/latest/download"
+"/hatch-universal.pkg) をダウンロードしてください。"
+
+#: ../../tutorials/get-to-know-hatch.md:46
+msgid "Run the installer and follow the setup instructions."
+msgstr "インストーラーを実行し、セットアップ手順に従ってください。"
+
+#: ../../tutorials/get-to-know-hatch.md:47
+msgid "If your terminal is open, then restart it."
+msgstr "ターミナルが開いている場合は、再起動してください。"
+
+#: ../../tutorials/get-to-know-hatch.md
+msgid "Windows"
+msgstr "Windows"
+
+#: ../../tutorials/get-to-know-hatch.md:53
+msgid ""
+"In your browser, download the correct `.msi` file for your system: "
+"[hatch-x64.msi](https://github.com/pypa/hatch/releases/latest/download/hatch-x64.msi)"
+msgstr ""
+"ブラウザで、お使いのシステムに合った `.msi` ファイルをダウンロードしてください: "
+"[hatch-x64.msi](https://github.com/pypa/hatch/releases/latest/download/hatch-x64.msi)"
+
+#: ../../tutorials/get-to-know-hatch.md:55
+msgid "Run your downloaded installer file and follow the on-screen instructions."
+msgstr "ダウンロードしたインストーラーファイルを実行し、画面の指示に従ってください。"
+
+#: ../../tutorials/get-to-know-hatch.md
+msgid "Linux"
+msgstr "Linux"
+
+#: ../../tutorials/get-to-know-hatch.md:61
+msgid ""
+"We suggest that you install Hatch using pipx on Linux. however, if you "
+"prefer another method, check out the [Hatch installation "
+"documentation](https://hatch.pypa.io/latest/install/) for other methods."
+msgstr ""
+"Linux上ではpipxを使用してHatchをインストールすることをお勧めしますが、他の方法をご希望の場合は、 "
+"[Hatchのインストールドキュメント](https://hatch.pypa.io/latest/install/) をご覧ください。"
+
+#: ../../tutorials/get-to-know-hatch.md:75
+msgid ""
+"Hatch can also be installed directly using "
+"[pip](https://hatch.pypa.io/latest/install/#pip) or "
+"[conda](https://hatch.pypa.io/latest/install/#conda). We encourage you to"
+" follow the instructions above because we have found that the Hatch "
+"installers for Windows and Mac are the easiest and most efficient."
+msgstr ""
+"Hatchは [pip](https://hatch.pypa.io/latest/install/#pip) や "
+"[conda](https://hatch.pypa.io/latest/install/#conda) "
+"を使って直接インストールすることもできる。WindowsとMac用のHatchインストーラーが最も簡単で効率的であることがわかりましたので、上記の指示に従うことをお勧めします。"
+
+#: ../../tutorials/get-to-know-hatch.md:79
+msgid ""
+"Our Linux users have found success installing Hatch with pipx if they "
+"already use apt install."
+msgstr "私たちのLinuxユーザーは、すでにapt installを使っている場合、pipxを使ってHatchをインストールすることに成功しています。"
+
+#: ../../tutorials/get-to-know-hatch.md:82
+msgid ""
+"Both approaches (using a graphical installer on Windows/Mac and pipx) "
+"ensure that you have Hatch installed globally. A global install means "
+"that Hatch is available across all of your Python environments on your "
+"computer."
+msgstr ""
+"どちらのアプローチ（Windows/Macでグラフィカルインストーラを使う方法とpipxを使う方法）も、Hatchがグローバルにインストールされていることを保証します。"
+" グローバルインストールとは、コンピュータ上の全てのPython環境でHatchが利用できることを意味します。"
+
+#: ../../tutorials/get-to-know-hatch.md:87
+msgid "Check that hatch installed correctly"
+msgstr "hatchが正しく取り付けられているか確認します"
+
+#: ../../tutorials/get-to-know-hatch.md:89
+msgid ""
+"Once you have completed the installation instructions above, you can open"
+" your terminal, and make sure that Hatch installed correctly using the "
+"command below:"
+msgstr "上記のインストール手順が完了したら、ターミナルを開き、以下のコマンドを使用してHatchが正しくインストールされたことを確認してください:"
+
+#: ../../tutorials/get-to-know-hatch.md:97
+msgid ""
+"*Note the version number output of `hatch --version` will likely  be "
+"different from the output above in this tutorial.*"
+msgstr "* `hatch --version` で出力されるバージョン番号は、このチュートリアルの上記の出力とは異なる可能性が高いことに注意してください。*"
+
+#: ../../tutorials/get-to-know-hatch.md:100
+msgid "Configure Hatch"
+msgstr "Hatchの設定"
+
+#: ../../tutorials/get-to-know-hatch.md:102
+msgid ""
+"Once you have installed Hatch, you can customize its configuration. This "
+"includes setting the default name and setup for every package you create."
+" While this step is not required, we suggest that you do it."
+msgstr ""
+"Hatchをインストールしたら、その設定をカスタマイズすることができます。 "
+"これには、作成するすべてのパッケージにデフォルト名とセットアップを設定することも含まれます。 "
+"このステップは必須ではありませんが、行うことをお勧めします。"
+
+#: ../../tutorials/get-to-know-hatch.md:106
+msgid ""
+"Hatch stores your configuration in a [`config.toml` "
+"file](https://hatch.pypa.io/latest/config/project-templates/)."
+msgstr ""
+"Hatchは設定を [`config.toml`ファイル](https://hatch.pypa.io/latest/config"
+"/project-templates/) に保存します。"
+
+#: ../../tutorials/get-to-know-hatch.md:108
+msgid ""
+"While you can update the `config.toml` file through the command line, it "
+"might be easier to look at and update it in a text editor if you are "
+"using it for the first time."
+msgstr ""
+"コマンドラインから `config.toml` ファイルを更新することができます, "
+"初めて使う場合は、テキストエディタで見て更新する方が簡単かもしれません。"
+
+#: ../../tutorials/get-to-know-hatch.md:112
+msgid "Step 1: Open and Edit Your `config.toml` File"
+msgstr "ステップ 1: `config.toml` ファイルを開いて編集する"
+
+#: ../../tutorials/get-to-know-hatch.md:114
+msgid ""
+"To open the config file in your file browser, run the following command "
+"in your shell:"
+msgstr "ファイルブラウザで設定ファイルを開くには、シェルで以下のコマンドを実行します:"
+
+#: ../../tutorials/get-to-know-hatch.md:117
+msgid "`hatch config explore`"
+msgstr "`hatch config explore`"
+
+#: ../../tutorials/get-to-know-hatch.md:119
+msgid ""
+"This will open up a directory window that allows you to double-click on "
+"the file and open it in your favorite text editor."
+msgstr "ディレクトリウィンドウが開き、ファイルをダブルクリックして好きなテキストエディタで開くことができます。"
+
+#: ../../tutorials/get-to-know-hatch.md:122
+msgid ""
+"You can also retrieve the location of the Hatch config file by running "
+"the following command in your shell:"
+msgstr "シェルで以下のコマンドを実行すれば、Hatchのコンフィグファイルの場所を取得することもできます:"
+
+#: ../../tutorials/get-to-know-hatch.md:130
+msgid "Step 2 - update your email and name"
+msgstr "ステップ2 - Eメールと名前を更新する"
+
+#: ../../tutorials/get-to-know-hatch.md:132
+msgid ""
+"Once the file is open, update the [template] table of the `config.toml` "
+"file with your name and email. This information will be used in any "
+"`pyproject.toml` metadata files that you create using Hatch."
+msgstr ""
+"ファイルを開いたら、 `config.toml` ファイルの[template]テーブルをあなたの名前とEメールで更新します。 "
+"この情報は、Hatchを使用して作成した `pyproject.toml` メタデータファイルに使用されます。"
+
+#: ../../tutorials/get-to-know-hatch.md:142
+msgid "Step 3"
+msgstr "ステップ3"
+
+#: ../../tutorials/get-to-know-hatch.md:144
+msgid "Next, set tests to false in the `[template.plugins.default]` table."
+msgstr "次に、 `[template.plugins.default]` テーブルでtestsをfalseに設定します。"
+
+#: ../../tutorials/get-to-know-hatch.md:146
+msgid ""
+"While tests are important, setting the tests configuration in Hatch to "
+"`true` will create a more complex `pyproject.toml` file. You won't need "
+"to use this feature in this beginner friendly tutorial series but we will"
+" introduce it in later tutorials."
+msgstr ""
+"テストは重要ですが、Hatchのtests設定を `true` にすると、より複雑な `pyproject.toml` "
+"ファイルが作成されます。この初心者向けチュートリアルシリーズではこの機能を使う必要はありませんが、後のチュートリアルで紹介します。"
+
+#: ../../tutorials/get-to-know-hatch.md:151
+msgid "Your `config.toml` file should look something like the one below."
+msgstr "あなたの `config.toml` ファイルは以下のようになるはずです。"
+
+#: ../../tutorials/get-to-know-hatch.md:189
+msgid ""
+"Also notice that the default license option is MIT. While we will discuss"
+" license in more detail in a later lesson, the MIT license is the "
+"recommended permissive license from "
+"[choosealicense.com](https://www.choosealicense.com) and as such we will "
+"use it for this tutorial series."
+msgstr ""
+"また、デフォルトのライセンスオプションがMITであることにも注目してください。 ライセンスについては後のレッスンで詳しく説明しますが、 "
+"MITライセンスは [choosealicense.com](https://www.choosealicense.com) "
+"が推奨する寛容なライセンスです、そしてこのチュートリアルシリーズではこれを使用します。"
+
+#: ../../tutorials/get-to-know-hatch.md:195
+msgid "You are of course welcome to select another license."
+msgstr "もちろん、他のライセンスを選択することも歓迎します。"
+
+#: ../../tutorials/get-to-know-hatch.md:198
+msgid ""
+"I think we'd need the SPDX license options here if they want to chose "
+"bsd-3 for instance"
+msgstr "例えばbsd-3を選びたいのであれば、SPDXライセンスのオプションが必要だと思います。"
+
+#: ../../tutorials/get-to-know-hatch.md:201
+msgid "Step 4: Close the config file and run `hatch config show`"
+msgstr "ステップ4: 設定ファイルを閉じて、 `hatch config show` を実行します。"
+
+#: ../../tutorials/get-to-know-hatch.md:203
+msgid ""
+"Once you have completed the steps above run the following command in your"
+" shell."
+msgstr "上記の手順が完了したら、シェルで以下のコマンドを実行します。"
+
+#: ../../tutorials/get-to-know-hatch.md:205
+msgid "`hatch config show`"
+msgstr "`hatch config show`"
+
+#: ../../tutorials/get-to-know-hatch.md:207
+msgid ""
+"`hatch config show` will print out the contents of your `config.toml` "
+"file in your shell. Look at the values and ensure that your name, email "
+"is set. Also make sure that `tests=false`."
+msgstr ""
+"`hatch config show` はシェルの `config.toml` ファイルの内容を出力します。 "
+"値を見て、あなたの名前とEメールが設定されていることを確認してください。また、 `tests=false` であることを確認すること。"
+
+#: ../../tutorials/get-to-know-hatch.md:211
+msgid "Hatch features"
+msgstr "Hatchの特徴"
+
+#: ../../tutorials/get-to-know-hatch.md:213
+msgid ""
+"Hatch offers a suite of features that will make creating, publishing and "
+"maintaining your Python package easier."
+msgstr "Hatchは、Pythonパッケージの作成、公開、保守を容易にする一連の機能を提供します。"
+
+#: ../../tutorials/get-to-know-hatch.md:216
+msgid "Comparison to other tools"
+msgstr "他のツールとの比較"
+
+#: ../../tutorials/get-to-know-hatch.md:218
+msgid ""
+"[We compared Hatch to several of the other popular packaging tools in the"
+" ecosystem including flit, pdm and poetry. Learn more here](package-"
+"features)"
+msgstr ""
+"[私たちはHatchを、flit、pdm、poetryなど、エコシステムで人気のある他のパッケージングツールと比較しました。 詳細はこちら"
+"](package-features)"
+
+#: ../../tutorials/get-to-know-hatch.md:221
+msgid "[More on Hatch here](hatch)"
+msgstr "[Hatchの詳細はこちら](hatch)"
+
+#: ../../tutorials/get-to-know-hatch.md:223
+msgid "A few features that Hatch offers"
+msgstr "Hatchが提供するいくつかの機能"
+
+#: ../../tutorials/get-to-know-hatch.md:225
+msgid ""
+"It will convert metadata stored in a `setup.py` or `setup.cfg` file to a "
+"pyproject.toml file for you (see [Migrating setup.py to pyproject.toml "
+"using Hatch](setup-py-to-pyproject-toml.md ))"
+msgstr ""
+"これは `setup.py` または `setup.cfg` ファイルに保存されたメタデータを pyproject.toml "
+"ファイルに変換します。 ([Hatchを使用してsetup.pyをpyproject.tomlに移行する](setup-py-to-"
+"pyproject-toml.md ) を参照)"
+
+#: ../../tutorials/get-to-know-hatch.md:227
+msgid ""
+"It will help you by storing configuration information for publishing to "
+"PyPI after you've entered it once."
+msgstr "PyPIに公開するための設定情報を、一度入力した後に保存してくれます。"
+
+#: ../../tutorials/get-to-know-hatch.md:229
+msgid "Use `hatch -h` to see all of the available commands."
+msgstr "利用可能なコマンドをすべて表示するには、 `hatch -h` を使用します。"
+
+#: ../../tutorials/get-to-know-hatch.md:231
+msgid "What's next"
+msgstr "次のレッスン"
+
+#: ../../tutorials/get-to-know-hatch.md:233
+msgid ""
+"In the next lesson you'll learn how to package and make your code "
+"installable using Hatch."
+msgstr "次のレッスンでは、Hatchを使ってコードをパッケージ化し、インストール可能にする方法を学びます。"
+
+#: ../../tutorials/intro.md:33 ../../tutorials/setup-py-to-pyproject-toml.md:29
 msgid "Get to know Hatch"
 msgstr "Hatchを知る"
 
-#: ../../tutorials/intro.md:28
+#: ../../tutorials/intro.md:33
 msgid "Python Packaging Tutorial Setup"
 msgstr "Pythonパッケージングチュートリアルのセットアップ"
 
-#: ../../tutorials/intro.md:35 ../../tutorials/intro.md:80
+#: ../../tutorials/intro.md:40 ../../tutorials/intro.md:86
 msgid "What is a Python package?"
 msgstr "Pythonパッケージとは何ですか？"
 
-#: ../../tutorials/intro.md:35
-msgid "Make your code installable"
-msgstr "コードをインストール可能にする"
+#: ../../tutorials/intro.md:40
+#, fuzzy
+msgid "Create a Python package"
+msgstr "なぜPythonパッケージを作るのか？"
 
-#: ../../tutorials/intro.md:35
+#: ../../tutorials/intro.md:40
 msgid "Publish to PyPI"
 msgstr "PyPIに公開する"
 
-#: ../../tutorials/intro.md:35
+#: ../../tutorials/intro.md:40
 msgid "Publish to conda-forge"
 msgstr "conda-forgeに公開する"
 
-#: ../../tutorials/intro.md:35
+#: ../../tutorials/intro.md:40
 msgid "Create and publish a Python Package"
 msgstr "Pythonパッケージの作成と公開"
 
-#: ../../tutorials/intro.md:45
+#: ../../tutorials/intro.md:50
+#, fuzzy
+msgid "Develop package (Hatch environments)"
+msgstr "Pythonのパッケージと環境"
+
+#: ../../tutorials/intro.md:50
 msgid "Add README file"
 msgstr "README ファイルを追加する"
 
-#: ../../tutorials/intro.md:45
+#: ../../tutorials/intro.md:50
 msgid "Add a license & code of conduct"
 msgstr "ライセンスと行動規範の追加"
 
-#: ../../tutorials/intro.md:45
+#: ../../tutorials/intro.md:50
 msgid "Update metadata in pyproject.toml"
 msgstr "pyproject.tomlのメタデータを更新する"
 
-#: ../../tutorials/intro.md:45
+#: ../../tutorials/intro.md:50
 msgid "Project information files & metadata"
 msgstr "プロジェクト情報ファイルとメタデータ"
 
-#: ../../tutorials/intro.md:54
+#: ../../tutorials/intro.md:60
 msgid "Reference Guides"
 msgstr "リファレンスガイド"
 
-#: ../../tutorials/intro.md:61
+#: ../../tutorials/intro.md:67
 msgid "Migrate setup.py to a pyproject.toml using Hatch"
 msgstr "Hatchを使ってsetup.pyをpyproject.tomlに移行する"
 
-#: ../../tutorials/intro.md:61
+#: ../../tutorials/intro.md:67
 msgid "Hatch for Existing Packages"
 msgstr "既存パッケージ用Hatch"
 
-#: ../../tutorials/intro.md:2
+#: ../../tutorials/intro.md:7
 msgid "Python packaging 101"
 msgstr "Pythonパッケージング 101"
 
-#: ../../tutorials/intro.md:4
+#: ../../tutorials/intro.md:9
 msgid "_A start to finish beginner-friendly tutorial_"
 msgstr "_初心者にやさしいチュートリアル_"
 
-#: ../../tutorials/intro.md:6
+#: ../../tutorials/intro.md:11
 msgid ""
 "Welcome to the pyOpenSci Python packaging tutorial series. The lessons on"
 " the upcoming pages walk you through the core steps needed to create a "
@@ -2554,7 +2922,7 @@ msgstr ""
 "pyOpenSci Pythonパッケージングチュートリアルシリーズへようこそ。 "
 "これからのページのレッスンは、Pythonパッケージを作成するために必要なコアステップを説明します。"
 
-#: ../../tutorials/intro.md:12
+#: ../../tutorials/intro.md:17
 msgid ""
 "Diagram showing the lessons in our packaging tutorial. There are 6 total "
 "- what is a Python package, make code pip installable, publish your "
@@ -2564,17 +2932,17 @@ msgstr ""
 "パッケージングチュートリアルのレッスンを示す図。Pythonパッケージとは何か、コードをpipでインストール可能にする、パッケージをPyPIに公開する、READMEとLICENSEファイルを追加する、PyPI用のメタデータを追加する、最後にconda"
 " forgeに公開する、の6つです。"
 
-#: ../../tutorials/intro.md:14
+#: ../../tutorials/intro.md:19
 msgid ""
 "This lesson is the first in a series of lessons to help you get started "
 "with Python packaging."
 msgstr "このレッスンは、Pythonのパッケージングを始めるのに役立つ一連のレッスンの最初のものです。"
 
-#: ../../tutorials/intro.md:17
+#: ../../tutorials/intro.md:22
 msgid "Who are these tutorials for?"
 msgstr "このチュートリアルは誰のためのものですか？"
 
-#: ../../tutorials/intro.md:19
+#: ../../tutorials/intro.md:24
 msgid ""
 "The content in this tutorial series is beginner friendly and assumes that"
 " you have not created a Python package before. However, the content will "
@@ -2584,7 +2952,7 @@ msgstr ""
 "このチュートリアルシリーズの内容は初心者に優しく、Pythonパッケージを作成したことがないことを前提としています。 "
 "しかし、Pythonパッケージの作成に関わるステップをよりよく理解することに興味があるのであれば、このコンテンツはまだ価値があるでしょう。"
 
-#: ../../tutorials/intro.md:24
+#: ../../tutorials/intro.md:29
 msgid ""
 "In this series you will learn about the core elements that you need to "
 "publish your package to the [Python Package Index "
@@ -2593,45 +2961,45 @@ msgstr ""
 "このシリーズでは、 [Python Package Index (PyPI)](https://pypi.org/) "
 "にパッケージを公開するために必要なコアな要素について学びます。"
 
-#: ../../tutorials/intro.md:26
+#: ../../tutorials/intro.md:31
 msgid ""
 "In the second series, you will learn about infrastructure and "
 "documentation needed to support package maintenance."
 msgstr "第2シリーズでは、パッケージのメンテナンスをサポートするために必要なインフラとドキュメントについて学びます。"
 
-#: ../../tutorials/intro.md:68 ../../tutorials/publish-conda-forge.md:15
-#: ../../tutorials/publish-pypi.md:13 ../../tutorials/pyproject-toml.md:19
-#: ../../tutorials/setup-py-to-pyproject-toml.md:12
+#: ../../tutorials/intro.md:74 ../../tutorials/publish-conda-forge.md:20
+#: ../../tutorials/publish-pypi.md:18 ../../tutorials/pyproject-toml.md:24
+#: ../../tutorials/setup-py-to-pyproject-toml.md:17
 msgid "Learning Objectives"
 msgstr "学習目標"
 
-#: ../../tutorials/intro.md:70
+#: ../../tutorials/intro.md:76
 msgid ""
 "This lesson introduces you to the basic components of a Python package. "
 "After reading this lesson you will:"
 msgstr "このレッスンでは Python パッケージの基本的な構成要素を紹介します。 このレッスンを読めば、次のことがわかります:"
 
-#: ../../tutorials/intro.md:73
+#: ../../tutorials/intro.md:79
 msgid "Understand what a Python package is"
 msgstr "Pythonパッケージとは何かを理解する"
 
-#: ../../tutorials/intro.md:74
+#: ../../tutorials/intro.md:80
 msgid "Be able to list the 5 core components of a Python package"
 msgstr "Pythonパッケージの5つのコアコンポーネントを列挙できます"
 
-#: ../../tutorials/intro.md:75
+#: ../../tutorials/intro.md:81
 msgid ""
 "Be able to explain the difference between generalizable code and code "
 "that supports a specific scientific application"
 msgstr "一般化可能なコードと特定の科学的アプリケーションをサポートするコードの違いを説明できます。"
 
-#: ../../tutorials/intro.md:82
+#: ../../tutorials/intro.md:88
 msgid ""
 "At a high level, you can think about a Python package as a toolbox that "
 "you can use to perform various tasks."
 msgstr "高レベルでは、Pythonパッケージは、様々なタスクを実行するために使用できるツールボックスと考えることができます。"
 
-#: ../../tutorials/intro.md:85
+#: ../../tutorials/intro.md:91
 msgid ""
 "A Python package is basically a directory with a specific file structure."
 " Within the package directory structure, there are modules which are "
@@ -2643,13 +3011,13 @@ msgstr ""
 "Pythonパッケージは基本的に特定のファイル構造を持つディレクトリです。 パッケージのディレクトリ構造の中に、`.py` "
 "で終わるファイル(Pythonスクリプトで見られるのと同じ拡張子)のモジュールがあります。これらのモジュールによって、Pythonコードをグループ化し、構造化することができます。各モジュールには関数とクラスが含まれており、それらはあなたの道具箱の中の道具だと考えることができます。"
 
-#: ../../tutorials/intro.md:94
+#: ../../tutorials/intro.md:100
 msgid ""
 "Diagram showing a sketch of a toolbox filled with different tools "
 "including a hammer and a saw."
 msgstr "ハンマーやノコギリなど、さまざまな工具が入った工具箱のスケッチを示す図。"
 
-#: ../../tutorials/intro.md:96
+#: ../../tutorials/intro.md:102
 msgid ""
 "You can think about a package as a toolbox filled with coding tools. A "
 "tool may be a function or a class. Each tool does a specific thing well."
@@ -2657,11 +3025,11 @@ msgstr ""
 "パッケージとは、コーディングツールが詰まった道具箱のようなものだと考えることができます。 ツールは関数かもしれないし、クラスかもしれません。 "
 "それぞれのツールは特定のことをよくします。"
 
-#: ../../tutorials/intro.md:101
+#: ../../tutorials/intro.md:107
 msgid "Python packages are installable"
 msgstr "Pythonパッケージはインストール可能"
 
-#: ../../tutorials/intro.md:103
+#: ../../tutorials/intro.md:109
 msgid ""
 "A package is installable, which means that you can add the functionality "
 "within the package's code to any Python environment and import that "
@@ -2669,7 +3037,7 @@ msgid ""
 "as NumPy or Matplotlib."
 msgstr "パッケージはインストール可能で、パッケージのコード内の機能をどのPython環境にも追加でき、NumPyやMatplotlibのような科学的なPythonのコアパッケージをインポートするように、その機能をインポートできます。"
 
-#: ../../tutorials/intro.md:112
+#: ../../tutorials/intro.md:118
 msgid ""
 "Installing a package into an environment makes it easier to manage and "
 "reuse your code across different projects. Structuring your code as a "
@@ -2677,15 +3045,15 @@ msgid ""
 "the toolbox you've created and let others build with it."
 msgstr "パッケージを環境にインストールすることで、異なるプロジェクト間でのコードの管理と再利用が容易になる。あなたのコードをパッケージとして構造化することは、あなたが作成したツールボックスのツールを共有し、他の人がそれを使って構築できるようにするために必要な最初のステップです。"
 
-#: ../../tutorials/intro.md:117
+#: ../../tutorials/intro.md:123
 msgid "Why create a Python package?"
 msgstr "なぜPythonパッケージを作るのか？"
 
-#: ../../tutorials/intro.md:119
+#: ../../tutorials/intro.md:125
 msgid "You might create a Python package because you want to:"
 msgstr "Pythonパッケージを作りたいから作るかもしれません:"
 
-#: ../../tutorials/intro.md:121
+#: ../../tutorials/intro.md:127
 msgid ""
 "**Use your code across different projects:** At its most basic level, "
 "creating a package allows you to install your code into a Python "
@@ -2696,7 +3064,7 @@ msgstr ""
 "最も基本的なレベルでは、パッケージを作成することで、あなたのコードをPython環境にインストールすることができます。 "
 "これにより、ローカルとクラウドの両方のワークフローに関数やクラスをインポートすることができます。"
 
-#: ../../tutorials/intro.md:122
+#: ../../tutorials/intro.md:128
 msgid ""
 "**Share your code:** If you publish a package on a public repository such"
 " as PyPI or conda, your package can be installed on any machine using pip"
@@ -2705,7 +3073,7 @@ msgstr ""
 "**Share your code:** PyPIやcondaのような公開リポジトリでパッケージを公開する場合、 "
 "あなたのパッケージは、pipやcondaを使ってどのマシンにもコマンドひとつでインストールできます。"
 
-#: ../../tutorials/intro.md:123
+#: ../../tutorials/intro.md:129
 msgid ""
 "**Build community around your code:** Packages make it easier for "
 "multiple people to work on the same project (particularly when published "
@@ -2720,7 +3088,7 @@ msgstr ""
 "のようなバージョン管理システムを使えば、コードベースへの長期的な変更を追跡するのがさらに簡単になる。 "
 "issueやプルリクエストのようなツールは、外部のユーザーがバグ修正に貢献したり、コードベースへの変更を受け入れるためのレビュープロセスを確立したりすることを容易にします。"
 
-#: ../../tutorials/intro.md:124
+#: ../../tutorials/intro.md:130
 msgid ""
 "**Organize your code:** Packages can be used to organize large code "
 "projects, dividing them into smaller, more manageable components. This "
@@ -2730,29 +3098,29 @@ msgstr ""
 "**コードを整理する:** パッケージは、大規模なコード・プロジェクトを整理し、より小さく管理しやすいコンポーネントに分割するために使用できます。"
 " この構造は、コードベースを維持する上でも、理解しやすくする上でも役立ちます。"
 
-#: ../../tutorials/intro.md:126
+#: ../../tutorials/intro.md:132
 msgid "What to consider before you create a package"
 msgstr "パッケージを作成する前に考慮すべきこと"
 
-#: ../../tutorials/intro.md:128
+#: ../../tutorials/intro.md:134
 msgid ""
 "Creating a Python package that others use takes considerable time and "
 "effort. Before you begin, think about your goals including:"
 msgstr "他の人が使うPythonパッケージを作るには、かなりの時間と労力がかかります。 始める前に、以下のような目標について考えてください:"
 
-#: ../../tutorials/intro.md:131
+#: ../../tutorials/intro.md:137
 msgid "Who you think will use your package"
 msgstr "あなたのパッケージを利用すると思われる人"
 
-#: ../../tutorials/intro.md:132
+#: ../../tutorials/intro.md:138
 msgid "How people might use your package and on what data (if data are relevant)"
 msgstr "人々があなたのパッケージをどのように使うか、またどのようなデータについて使うか（データが関連する場合）"
 
-#: ../../tutorials/intro.md:133
+#: ../../tutorials/intro.md:139
 msgid "Whether you have time to add things such as documentation and tests"
 msgstr "ドキュメントやテストなどを追加する時間があるかどうか"
 
-#: ../../tutorials/intro.md:134
+#: ../../tutorials/intro.md:140
 msgid ""
 "How long you might be able to maintain it: remember that once people "
 "begin using your package they will depend on your maintainer team to "
@@ -2761,21 +3129,21 @@ msgstr ""
 "メンテナンスできる可能性のある期間: "
 "いったん人々があなたのパッケージを使い始めると、彼らはそれを更新し、バグを修正し、質問に答えるために、あなたのメンテナチームに依存することになることを忘れないでください。"
 
-#: ../../tutorials/intro.md:136
+#: ../../tutorials/intro.md:142
 msgid ""
 "Before creating a user-facing package, it's important to consider all of "
 "the above."
 msgstr "ユーザー向けのパッケージを作成する前に、上記のすべてを考慮することが重要です。"
 
-#: ../../tutorials/intro.md:138
+#: ../../tutorials/intro.md:144
 msgid "The elements of a Python package"
 msgstr "Pythonパッケージの要素"
 
-#: ../../tutorials/intro.md:142 ../../tutorials/intro.md:220
+#: ../../tutorials/intro.md:148 ../../tutorials/intro.md:226
 msgid "Diagram showing .. more here if this stays."
 msgstr "図......これが残ればもっとここに。"
 
-#: ../../tutorials/intro.md:144
+#: ../../tutorials/intro.md:150
 msgid ""
 "The elements of a Python package include code, documentation, tests, an "
 "OSI-approved license and infrastructure. Maintainers are at the core "
@@ -2785,17 +3153,17 @@ msgstr ""
 "Pythonパッケージの要素には、コード、ドキュメント、テスト、OSIが承認したライセンス、インフラが含まれます。 "
 "メインテナーは、バグを修正し、ユーザーの懸念に対処しながら、すべてが機能し、最新であることを確認する中核を担っています。"
 
-#: ../../tutorials/intro.md:150
+#: ../../tutorials/intro.md:156
 msgid "The core elements of Python package include:"
 msgstr "Pythonパッケージの核となる要素は以下の通りです:"
 
-#: ../../tutorials/intro.md:152
+#: ../../tutorials/intro.md:158
 msgid ""
 "**Code:** Functions and classes that provide functionality for a user of "
 "your package"
 msgstr "**コード:** パッケージのユーザーに機能を提供する関数とクラス"
 
-#: ../../tutorials/intro.md:153
+#: ../../tutorials/intro.md:159
 msgid ""
 "**Documentation:** Installation instructions, tutorials, and examples "
 "that both help users get started using your package and contributors and "
@@ -2804,13 +3172,13 @@ msgstr ""
 "**ドキュメンテーション:** "
 "インストール手順、チュートリアル、サンプルは、ユーザがあなたのパッケージを使い始めるのを助け、貢献者やメンテナがバグを修正し、パッケージを保守するのを助けます。"
 
-#: ../../tutorials/intro.md:154
+#: ../../tutorials/intro.md:160
 msgid ""
 "Contributor Documentation in the form of a **CONTRIBUTING.md** file is "
 "useful to help people to contribute to your package."
 msgstr "**CONTRIBUTING.md** ファイル形式の貢献者ドキュメンテーションは、人々があなたのパッケージに貢献するのを助けるのに便利です。"
 
-#: ../../tutorials/intro.md:155
+#: ../../tutorials/intro.md:161
 msgid ""
 "Development Documentation helps both maintainers and contributors "
 "understand how to maintain a package's infrastructure."
@@ -2818,14 +3186,14 @@ msgstr ""
 "Development Documentation "
 "は、メンテナと貢献者の両方が、パッケージのインフラストラクチャをどのように保守するかを理解するのに役立ちます。"
 
-#: ../../tutorials/intro.md:156
+#: ../../tutorials/intro.md:162
 msgid ""
 "**Tests:** that make sure your code works as it should and makes it "
 "easier for you and others to contribute to, modify and update the code in"
 " the future"
 msgstr "**テスト:** これは、あなたのコードが本来の機能を発揮し、あなたや他の人が貢献しやすくなるようにするものです、 将来的にコードを修正更新します"
 
-#: ../../tutorials/intro.md:157
+#: ../../tutorials/intro.md:163
 msgid ""
 "**License:** An open source license, or license that is [OSI "
 "approved](https://opensource.org/licenses/), refers to an license that "
@@ -2835,7 +3203,7 @@ msgstr ""
 "**ライセンス:** オープンソースライセンス、あるいは [OSI認可](https://opensource.org/licenses/) "
 "ライセンスとは、他の人があなたのパッケージを使うことを許可するライセンスのことです。また、パッケージの要素をどのように再利用できるか、また再利用できないかに関する法的な方向性も示しています。"
 
-#: ../../tutorials/intro.md:158
+#: ../../tutorials/intro.md:164
 msgid ""
 "**Infrastructure** that automates updates, publication workflows and runs"
 " test suites. Infrastructure includes a suite of things such as platforms"
@@ -2846,11 +3214,11 @@ msgstr ""
 "**インフラ** 更新、公開ワークフロー、テストスイートの実行を自動化します。 "
 "インフラストラクチャーには、GitHubやGitLabのようなプラットフォーム、noxやtoxのようなローカルでテストやツールを実行するツール、パッケージメンテナンスのステップを自動化する継続的インテグレーションなど、一連のものが含まれます。"
 
-#: ../../tutorials/intro.md:160
+#: ../../tutorials/intro.md:166
 msgid "What pyOpenSci looks for in a package"
 msgstr "pyOpenSciがパッケージで探すもの"
 
-#: ../../tutorials/intro.md:163
+#: ../../tutorials/intro.md:169
 msgid ""
 "pyOpenSci performs an [initial set of editor "
 "checks](https://www.pyopensci.org/software-peer-review/how-to/editor-in-"
@@ -2862,11 +3230,11 @@ msgstr ""
 "/software-peer-review/how-to/editor-in-chief-guide.html#editor-checklist-"
 "template) を行います。 これらのチェックは、パッケージを作成する際に、パッケージが持つべきものの基準として役に立つかもしれません。"
 
-#: ../../tutorials/intro.md:169
+#: ../../tutorials/intro.md:175
 msgid "Packages are more than just code - Infrastructure"
 msgstr "パッケージは単なるコードではありません - インフラストラクチャー"
 
-#: ../../tutorials/intro.md:171
+#: ../../tutorials/intro.md:177
 msgid ""
 "A package in any language is more than just code. If you expect other "
 "people to use your package, besides yourself, you should consider not "
@@ -2876,11 +3244,11 @@ msgstr ""
 "どの言語でも、パッケージは単なるコードではありません。 "
 "自分以外の人があなたのパッケージを使うことを期待するのであれば、高品質のコードを書くだけでなく、パッケージが有用なコミュニティリソースとなるための様々な要素も考慮すべきです。"
 
-#: ../../tutorials/intro.md:176
+#: ../../tutorials/intro.md:182
 msgid "Version control and storing your package on GitHub or GitLab"
 msgstr "GitHubまたはGitLabでのバージョン管理とパッケージの保存"
 
-#: ../../tutorials/intro.md:178
+#: ../../tutorials/intro.md:184
 msgid ""
 "Most Python packages live in an online version control platform such as "
 "GitHub or GitLab. GitHub and GitLab both run [git](https://git-scm.com/) "
@@ -2893,7 +3261,7 @@ msgstr ""
 "GitHubとGitLabはどちらもバージョン管理のために [git](https://git-scm.com/) を実行しています。 "
 "ソフトウェアをバージョン管理下に置くことは、時間の経過に伴う変更を追跡する一方で、コードベースへの変更が予期せず何かを壊してしまった場合に、履歴をさかのぼって変更を取り消すことができるからです。"
 
-#: ../../tutorials/intro.md:183
+#: ../../tutorials/intro.md:189
 msgid ""
 "By publishing your package on GitHub or GitLab, you are making your code "
 "public facing. This means that others can both see your code and also "
@@ -2903,11 +3271,11 @@ msgstr ""
 "あなたのパッケージをGitHubやGitLabで公開することで、あなたはコードを公開することになります。 "
 "これは、他の人があなたのコードを見ることができ、プルリクエスト(GitHub)/マージリクエスト(GitLab)/コードレビューワークフローを使って貢献することもできることを意味します。"
 
-#: ../../tutorials/intro.md:185
+#: ../../tutorials/intro.md:191
 msgid "GitHub & GitLab vs. Git"
 msgstr "GitHub & GitLab vs. Git"
 
-#: ../../tutorials/intro.md:188
+#: ../../tutorials/intro.md:194
 msgid ""
 "GitHub and GitLab are online (cloud) platforms that run `git` (version "
 "control software) on the backend. Running git locally on your computer "
@@ -2918,35 +3286,35 @@ msgstr ""
 "プラットフォームです。 コンピュータ上でローカルに git を実行すると、GitHub や GitLab にファイルをアップロード (`git "
 "push`) したりダウンロード (`git pull`) したりすることができます。"
 
-#: ../../tutorials/intro.md:193
+#: ../../tutorials/intro.md:199
 msgid "Issues or Ticket Trackers"
 msgstr "issue かチケットトラッカー"
 
-#: ../../tutorials/intro.md:195
+#: ../../tutorials/intro.md:201
 msgid ""
 "GitHub and GitLab also both offer community features such as issues that "
 "allow:"
 msgstr "GitHubとGitLabは、どちらもissueのようなコミュニティ機能を提供しています："
 
-#: ../../tutorials/intro.md:197
+#: ../../tutorials/intro.md:203
 msgid "you to communicate with your maintainers and contributor community"
 msgstr "メンテナや貢献者コミュニティとのコミュニケーション"
 
-#: ../../tutorials/intro.md:198
+#: ../../tutorials/intro.md:204
 msgid "users to report bugs, ask questions and request new features"
 msgstr "ユーザーによるバグ報告、質問、新機能のリクエスト"
 
-#: ../../tutorials/intro.md:199
+#: ../../tutorials/intro.md:205
 msgid ""
 "you to publicly keep track of enhancements and features you want to work "
 "on for your package."
 msgstr "あなたのパッケージのために取り組みたい機能強化や機能を公的に追跡することができます。"
 
-#: ../../tutorials/intro.md:201
+#: ../../tutorials/intro.md:207
 msgid "Continuous integration and continuous deployment"
 msgstr "継続的インテグレーションと継続的デプロイメント"
 
-#: ../../tutorials/intro.md:203
+#: ../../tutorials/intro.md:209
 msgid ""
 "GitHub and GitLab also provide continuous integration and continuous "
 "deployment (CI/CD). Continuous integration (CI) refers to a platform that"
@@ -2958,29 +3326,29 @@ msgstr ""
 " とは、特定のイベントが発生したときに特定のジョブを自動的に実行するプラットフォームのことを指し、継続的デプロイメント "
 "(CD)とは、実行や構築だけでなく、最終的なアウトプットをどこかに公開することを指すCIの拡張です。"
 
-#: ../../tutorials/intro.md:205
+#: ../../tutorials/intro.md:211
 msgid "**An example of Continuous integration:**"
 msgstr "**継続的インテグレーションの例:**"
 
-#: ../../tutorials/intro.md:207
+#: ../../tutorials/intro.md:213
 msgid ""
 "When someone submits a change to your code, your tests will run across "
 "different operating systems and the code will be checked for format "
 "issues."
 msgstr "誰かがあなたのコードに変更を加えた場合、あなたのテストは異なるオペレーティングシステム上で実行され、コードはフォーマットの問題がないかチェックされます。"
 
-#: ../../tutorials/intro.md:209
+#: ../../tutorials/intro.md:215
 msgid "**An example of Continuous deployment:**"
 msgstr "**継続的デプロイの例:**"
 
-#: ../../tutorials/intro.md:211
+#: ../../tutorials/intro.md:217
 msgid ""
 "When you are ready to release your package to PyPI, a continuous "
 "deployment operation might be triggered on release to publish your "
 "package to PyPI."
 msgstr "PyPIにパッケージをリリースする準備ができたら、リリース時に継続的デプロイ操作をトリガーしてパッケージをPyPIに公開することがあります。"
 
-#: ../../tutorials/intro.md:213
+#: ../../tutorials/intro.md:219
 msgid ""
 "Integrated CI/CD will help you maintain your software, ensuring that "
 "changes to the code don't break things unexpectedly. They can also help "
@@ -2990,15 +3358,15 @@ msgstr ""
 "統合されたCI/CDは、コードの変更が予期せぬ事態を引き起こさないよう、ソフトウェアの保守を支援します。 "
 "また、コードに新しい変更が加えられるたびに、コードのスタイルや書式の一貫性を維持するのにも役立ちます。"
 
-#: ../../tutorials/intro.md:222
+#: ../../tutorials/intro.md:228
 msgid "The lifecycle of a scientific Python package."
 msgstr "科学的Pythonパッケージのライフサイクル。"
 
-#: ../../tutorials/intro.md:225
+#: ../../tutorials/intro.md:231
 msgid "When should you turn your code into a Python package?"
 msgstr "あなたのコードをPythonパッケージにするタイミングは？"
 
-#: ../../tutorials/intro.md:227
+#: ../../tutorials/intro.md:233
 msgid ""
 "You may be wondering, what types of code should become a Python package "
 "that is both on GitHub and published to PyPI and/or conda-forge."
@@ -3006,11 +3374,11 @@ msgstr ""
 "どのようなコードをPythonのパッケージにして、GitHubに置き、PyPIやconda-"
 "forgeに公開すればいいのか、疑問に思うかもしれません。"
 
-#: ../../tutorials/intro.md:229
+#: ../../tutorials/intro.md:235
 msgid "There are a few use cases to consider:"
 msgstr "考慮すべき使用例がいくつかあります:"
 
-#: ../../tutorials/intro.md:231
+#: ../../tutorials/intro.md:237
 msgid ""
 "**Creating a basic package for yourself:** Sometimes you want create a "
 "package for your own personal use. This might mean making your code "
@@ -3022,7 +3390,7 @@ msgstr ""
 "**自分用の基本パッケージを作ります:** 個人的に使用するためにパッケージを作成したいこともあるでしょう。 "
 "これは、コードをローカルにpipでインストールできるようにすることを意味するかもしれませんし、GitHubに公開したいと思うかもしれません。その場合、他の人があなたのコードを使うことを期待していないので、パッケージを更新する必要がある場合に、あなた自身と将来の自分のためのドキュメントしか用意できないかもしれません。"
 
-#: ../../tutorials/intro.md:233
+#: ../../tutorials/intro.md:239
 msgid ""
 "An example of this type of package might be a set of functions that you "
 "write that are useful across several of your projects. It could be useful"
@@ -3031,11 +3399,11 @@ msgstr ""
 "この種のパッケージの例としては、いくつかのプロジェクトにまたがって有用な関数のセットを書くことができます。 "
 "これらの機能をすべてのプロジェクトで利用できれば便利でしょう。"
 
-#: ../../tutorials/intro.md:236
+#: ../../tutorials/intro.md:242
 msgid "LINK to pip installable lesson when it's published - it's in review now"
 msgstr "レッスンが公開されたら、pipでインストールできるようにリンクします - 審査中になります"
 
-#: ../../tutorials/intro.md:239
+#: ../../tutorials/intro.md:245
 msgid ""
 "**Creating a package for the community:** In other cases, you may create "
 "some code that you soon realize might also be useful to not just you, but"
@@ -3051,7 +3419,7 @@ msgstr ""
 "その場合は、パッケージを作成してGitHubで公開し、他のユーザーもそれを使うかもしれないので、CI/CDパイプラインや課題トラッカーなどのGitHubのインフラを利用することも検討できるでしょう。あなたのパッケージを他の人たちにも使ってもらいたいので、LICENSE情報、ユーザーや貢献者のための文書、テストも含めておきたいです。"
 " このタイプのパッケージはPyPIに公開されることが多いです。"
 
-#: ../../tutorials/intro.md:242
+#: ../../tutorials/intro.md:248
 msgid ""
 "For example, all of the [pyOpenSci packages](https://www.pyopensci.org"
 "/python-packages.html) are public facing with an intended audience beyond"
@@ -3060,11 +3428,11 @@ msgstr ""
 "例えば、すべての [pyOpenSciパッケージ](https://www.pyopensci.org/python-packages.html)"
 " は、メンテナ以外の読者を想定して公開されています。"
 
-#: ../../tutorials/intro.md:244
+#: ../../tutorials/intro.md:250
 msgid "Packages that you expect others to use should be well-scoped"
 msgstr "他の人が使用することを想定しているパッケージは、十分なスコープを持つべきです。"
 
-#: ../../tutorials/intro.md:246
+#: ../../tutorials/intro.md:252
 msgid ""
 "Ideally the code in your Python package is focused on a specific theme or"
 " use case. This theme is important as it's a way to scope the content of "
@@ -3073,7 +3441,7 @@ msgstr ""
 "Pythonパッケージのコードは、特定のテーマやユースケースにフォーカスしているのが理想的です。 "
 "このテーマは、パッケージの内容に幅を持たせる方法として重要です。"
 
-#: ../../tutorials/intro.md:248
+#: ../../tutorials/intro.md:254
 msgid ""
 "It can be tricky to decide when your code becomes something that might be"
 " more broadly useful to others. But one question you can ask yourself is "
@@ -3084,11 +3452,11 @@ msgstr ""
 "自分のコードが、いつ他の人に広く役立つものになるかを決めるのは、難しいことです。 "
 "しかし、自分自身に問いかけることができる質問が一つあります。それは、あなたのコードは特定の研究プロジェクトのために書かれたものですか？あるいは、あなたのドメインにおける複数のプロジェクトにまたがるより広範な応用が可能でしょうか？"
 
-#: ../../tutorials/intro.md:250
+#: ../../tutorials/intro.md:256
 msgid "How does this relate to code for a research project?"
 msgstr "研究プロジェクトのコードとの関連は？"
 
-#: ../../tutorials/intro.md:253
+#: ../../tutorials/intro.md:259
 msgid ""
 "A [Research Compendium](https://the-turing-way.netlify.app/reproducible-"
 "research/compendia.html) is an organized set of code, data and "
@@ -3100,7 +3468,7 @@ msgstr ""
 "research/compendia.html) とは、特定の研究プロジェクトをサポートするコード、データ、文書を整理したものです。 "
 "研究で使用された方法、データ、分析の包括的な記録を提供することで、研究の再現性と透明性を高めることを目的としています。"
 
-#: ../../tutorials/intro.md:258
+#: ../../tutorials/intro.md:264
 msgid ""
 "A Python package is a collection of modules that can be used to perform a"
 " specific set of tasks. These tasks should be applicable to numerous "
@@ -3111,7 +3479,7 @@ msgstr ""
 "これらのタスクは、数多くのワークフローに適用できるはずです。 そのため、Pythonパッケージは、特定のプロジェクトをサポートするResearch"
 " Compendiumよりも汎用性が高いです。"
 
-#: ../../tutorials/intro.md:263
+#: ../../tutorials/intro.md:269
 msgid ""
 "[Read about `Good enough practices in scientific "
 "computing`](https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1005510)"
@@ -3119,7 +3487,7 @@ msgstr ""
 "[`科学的コンピューティングにおける十分なプラクティス` "
 "について読む](https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1005510)"
 
-#: ../../tutorials/intro.md:264
+#: ../../tutorials/intro.md:270
 msgid ""
 "[Learn more about research compendia (also called repo-packs) in this "
 "blog post.](https://lorenabarba.com/blog/how-repro-packs-can-save-your-"
@@ -3129,11 +3497,11 @@ msgstr ""
 "については、こちらのブログ記事で詳しくご紹介しています。](https://lorenabarba.com/blog/how-repro-"
 "packs-can-save-your-future-self/)"
 
-#: ../../tutorials/intro.md:267
+#: ../../tutorials/intro.md:273
 msgid "Below are a few examples well scoped pyOpenSci packages:"
 msgstr "以下はよくスコープされたpyOpenSciパッケージの例です:"
 
-#: ../../tutorials/intro.md:269
+#: ../../tutorials/intro.md:275
 msgid ""
 "[Crowsetta](https://crowsetta.readthedocs.io/en/latest/): is a package "
 "designed to work with annotating animal vocalizations and bioacoustics "
@@ -3144,7 +3512,7 @@ msgstr ""
 "[Crowsetta](https://crowsetta.readthedocs.io/en/latest/): "
 "は、動物の発声や生物音響データの注釈付けを行うために設計されたパッケージです。このパッケージは、ユーザー固有の研究ワークフローに関連する特定の個々の研究アプリケーションに焦点を当てるのではなく、科学者がさまざまなタイプの生体音響データを処理するのを支援します。"
 
-#: ../../tutorials/intro.md:270
+#: ../../tutorials/intro.md:276
 msgid ""
 "[Pandera](https://www.union.ai/pandera) is another more broadly used "
 "Python package. Pandera supports data testing and thus also has a broader"
@@ -3153,21 +3521,21 @@ msgstr ""
 "[Pandera](https://www.union.ai/pandera) もまた、より広く使われているPythonパッケージです。 "
 "Panderaはデータの検査をサポートしているため、広範な研究用途にも使用できます。"
 
-#: ../../tutorials/intro.md:272
+#: ../../tutorials/intro.md:278
 msgid "Matplotlib as an example"
 msgstr "例としてのMatplotlib"
 
-#: ../../tutorials/intro.md:274
+#: ../../tutorials/intro.md:280
 msgid ""
 "At the larger end of the user spectrum, Matplotlib is a great example. "
 "Matplotlib does one thing really well:"
 msgstr "大規模なユーザーでは、Matplotlibが良い例です。 Matplotlibは一つのことをとてもよくやってくれます:"
 
-#: ../../tutorials/intro.md:277
+#: ../../tutorials/intro.md:283
 msgid "_It creates visual plots of data._"
 msgstr "_データの視覚的なプロットを作成します。_"
 
-#: ../../tutorials/intro.md:279
+#: ../../tutorials/intro.md:285
 msgid ""
 "Thousands of people use Matplotlib for different plotting applications "
 "using different types of data. While few scientific packages will have "
@@ -3177,17 +3545,17 @@ msgstr ""
 "Matplotlibは、何千人もの人々が、様々な種類のデータを使った様々なプロットアプリケーションに利用しています。 "
 "Matplotlibのような広範なアプリケーションと大規模なユーザーベースを持つ科学パッケージはほとんどないでしょうが、自分のパッケージが何をするのかを調べるという考え方は依然として重要です。"
 
-#: ../../tutorials/intro.md:285
+#: ../../tutorials/intro.md:291
 msgid "Code should also be clean & readable & documented"
 msgstr "コードはまた、クリーンで読みやすく、文書化されていなければなりません。"
 
-#: ../../tutorials/intro.md:287
+#: ../../tutorials/intro.md:293
 msgid ""
 "The code in your package should also be clean, readable, and well "
 "documented."
 msgstr "パッケージ内のコードもまた、クリーンで読みやすく、十分に文書化されていなければなりません。"
 
-#: ../../tutorials/intro.md:289
+#: ../../tutorials/intro.md:295
 msgid ""
 "**Clean code:** Clean code refers to code that uses expressive variable "
 "names, is concise and doesn't repeat itself. You can learn about best "
@@ -3196,7 +3564,7 @@ msgstr ""
 "**クリーンコード:** "
 "クリーンなコードとは、表現力豊かな変数名を使い、簡潔で、繰り返しのないコードを指す。きれいなコードのためのベストプラクティスについては、今後のpyOpenSciチュートリアルで学ぶことができます。"
 
-#: ../../tutorials/intro.md:293
+#: ../../tutorials/intro.md:299
 msgid ""
 "**Readable code:** readable code is code written with a consistent style."
 " You can use linters and code formatters such as black and flake8 to "
@@ -3209,7 +3577,7 @@ msgstr ""
 " [コードフォーマッタの詳細はこちらです。](../package-structure-code/code-style-linting-"
 "format)"
 
-#: ../../tutorials/intro.md:297
+#: ../../tutorials/intro.md:303
 msgid ""
 "**Documented code:** documented code is written using docstrings that "
 "help a user understand both what the functions and methods in your code "
@@ -3222,15 +3590,15 @@ msgstr ""
 " [docstringsについては、こちらのガイドで詳しく説明しています。](../documentation/write-user-"
 "documentation/document-your-code-api-docstrings)"
 
-#: ../../tutorials/intro.md:301
+#: ../../tutorials/intro.md:307
 msgid "Making your package installable - publishing to PyPI & conda-forge"
 msgstr "パッケージをインストール可能にします - PyPIとconda-forgeに公開します"
 
-#: ../../tutorials/intro.md:303
+#: ../../tutorials/intro.md:309
 msgid "Python packages and environments"
 msgstr "Pythonのパッケージと環境"
 
-#: ../../tutorials/intro.md:305
+#: ../../tutorials/intro.md:311
 msgid ""
 "You can install a Python package into a Python environment in the same "
 "way you might install NumPy or Pandas. Installing your package into an "
@@ -3240,7 +3608,7 @@ msgstr ""
 "NumPyやPandasをインストールするのと同じように、PythonパッケージをPython環境にインストールすることができます。 "
 "パッケージを環境にインストールすることで、特定のPython環境を有効にして実行したコードからそのパッケージにアクセスできるようになります。"
 
-#: ../../tutorials/intro.md:311
+#: ../../tutorials/intro.md:317
 msgid ""
 "Diagram showing the steps associated with creating a package and then "
 "installing it. The first arrow says your package and the second says pip "
@@ -3253,7 +3621,7 @@ msgstr ""
 "packageと書かれています。2つ目の矢印は、PandasやNumPyなどのいくつかのパッケージがすでにインストールされているPython環境を表すボックスにつながります。あなたのパッケージも、pip"
 " installしたときに同じ環境にインストールされます。"
 
-#: ../../tutorials/intro.md:313
+#: ../../tutorials/intro.md:319
 msgid ""
 "You don't have to publish to PyPI to make your code installable. With the"
 " correct file structure and project metadata you can make your code "
@@ -3266,11 +3634,11 @@ msgstr ""
 "正しいファイル構造とプロジェクトのメタデータがあれば、PyPIに公開することなく、コードをローカルにインストールし、作業中のプロジェクトに使用することができます。"
 " PyPIへの公開は、自分のコードを公開し、他の人と共有したいときに便利です。"
 
-#: ../../tutorials/intro.md:320
+#: ../../tutorials/intro.md:326
 msgid "Publishing a package to PyPI / Conda-Forge"
 msgstr "PyPI / Conda-Forgeへのパッケージの公開"
 
-#: ../../tutorials/intro.md:322
+#: ../../tutorials/intro.md:328
 msgid ""
 "If you want to make your package directly installable without having to "
 "download the code to your computer locally then you need to publish it in"
@@ -3279,13 +3647,13 @@ msgstr ""
 "コードをローカルにダウンロードすることなく、パッケージを直接インストールできるようにしたい場合は、 **PyPI** や **conda-"
 "forge** のようなリポジトリで公開する必要があります。"
 
-#: ../../tutorials/intro.md:326
+#: ../../tutorials/intro.md:332
 msgid ""
 "Learn [how to publish your package to PyPI in this tutorial.](publish-"
 "pypi.md)"
 msgstr "[このチュートリアルでは、パッケージをPyPIに公開する方法](publish-pypi.md) を学びます。"
 
-#: ../../tutorials/intro.md:328
+#: ../../tutorials/intro.md:334
 msgid ""
 "Then you can create a conda-forge recipe using the "
 "[Grayskull](https://github.com/conda/grayskull) tool. You can then submit"
@@ -3294,13 +3662,13 @@ msgstr ""
 "その後、 [Grayskull](https://github.com/conda/grayskull) ツールを使ってconda-"
 "forgeレシピを作成することができます。 このレシピをconda-forgeに投稿することができます。"
 
-#: ../../tutorials/intro.md:330
+#: ../../tutorials/intro.md:336
 msgid ""
 "[You will learn more about the conda-forge publication process here"
 ".](publish-conda-forge.md)"
 msgstr "[conda-forgeの公開プロセスについてはこちらをご覧ください。](publish-conda-forge.md)"
 
-#: ../../tutorials/intro.md:333
+#: ../../tutorials/intro.md:339
 msgid ""
 "Graphic showing the high level packaging workflow. On the left you see a "
 "graphic with code, metadata and tests in it. Those items all go into your"
@@ -3314,7 +3682,7 @@ msgstr ""
 "ハイレベルなパッケージングのワークフローを示すグラフィックです。左側には、コード、メタデータ、テストが入ったグラフィックがあります。ドキュメンテーションやデータは、通常、パッケージホイールの配布物には掲載されないため、そのボックスの下にあります。右の矢印は、ビルド配布ファイルのボックスに移動します。このボックスは、TestPyPIか本物のPyPIのどちらかに公開するように導きます"
 "。PyPIからconda-forgeに接続し、ディストリビューションをPyPIからconda-forgeに送る自動ビルドを行うことができます。"
 
-#: ../../tutorials/intro.md:335
+#: ../../tutorials/intro.md:341
 msgid ""
 "In the image above, you can see the steps associated with publishing your"
 " package on PyPI and conda-forge. Note that the distribution files that "
@@ -3333,11 +3701,11 @@ msgstr ""
 "forgeレシピリポジトリでprを開きます。このプロセスについては、 [conda-forgeのレッスン](/tutorials/publish-"
 "conda-forge) で詳しく学びます。"
 
-#: ../../tutorials/intro.md:339
+#: ../../tutorials/intro.md:345
 msgid "Yay, your package has users! Now what?"
 msgstr "やった、あなたのパッケージにはユーザーがいます! さて、どうしますか？"
 
-#: ../../tutorials/intro.md:341
+#: ../../tutorials/intro.md:347
 msgid ""
 "As the community using your package grows, you may also find yourself "
 "managing users, contributors, and others who want to interact with your "
@@ -3349,11 +3717,11 @@ msgstr ""
 "あなたのパッケージを使うコミュニティが大きくなるにつれて、あなたはユーザーや貢献者、その他あなたのパッケージと交流したい人たちを管理することになるかもしれません。開発に飛び込む前に、これらすべてを考慮することが重要です。"
 " コミュニティーの中にユーザーベースができれば、人々はあなたのコードに依存するようになり、その使い方の指示を必要とするようになります。"
 
-#: ../../tutorials/intro.md:343
+#: ../../tutorials/intro.md:349
 msgid "To support your community, you'll want to add things like:"
 msgstr "コミュニティをサポートするために、以下のようなものを追加したいです:"
 
-#: ../../tutorials/intro.md:345
+#: ../../tutorials/intro.md:351
 msgid ""
 "[a development guide that documents your maintainer workflow process "
 "](/documentation/repository-files/development-guide.md)"
@@ -3361,7 +3729,7 @@ msgstr ""
 "[メンテナーのワークフロープロセスを文書化した開発ガイド](/documentation/repository-files"
 "/development-guide.md)"
 
-#: ../../tutorials/intro.md:346
+#: ../../tutorials/intro.md:352
 msgid ""
 "[a code of conduct to defines community interaction standards and "
 "expectations](/documentation/repository-files/code-of-conduct-file.md)"
@@ -3369,7 +3737,7 @@ msgstr ""
 "[コミュニティとの交流の基準と期待を定める行動規範](/documentation/repository-files/code-of-"
 "conduct-file.md)"
 
-#: ../../tutorials/intro.md:347
+#: ../../tutorials/intro.md:353
 msgid ""
 "[a contributing guide that helps users understand expectations associated"
 " with making contributions to your project](/documentation/repository-"
@@ -3378,11 +3746,11 @@ msgstr ""
 "[プロジェクトに貢献する際にユーザーが期待されることを理解するのに役立つ貢献ガイド](/documentation/repository-"
 "files/contributing-file.md)"
 
-#: ../../tutorials/intro.md:349
+#: ../../tutorials/intro.md:355
 msgid "Support for contributors and maintainers"
 msgstr "コントリビューターとメンテナーのサポート"
 
-#: ../../tutorials/intro.md:351
+#: ../../tutorials/intro.md:357
 msgid ""
 "If you intend for others to use and contribute to your code, consider who"
 " will maintain it over time. You will want a **contributing and "
@@ -3395,7 +3763,7 @@ msgstr ""
 " **貢献と開発** ガイドと、コミュニティの交流があなたにとっても貢献者やメンテナチームにとっても健全であり続けるようにするための "
 "**行動規範** が欲しいでしょう。"
 
-#: ../../tutorials/intro.md:353
+#: ../../tutorials/intro.md:359
 msgid ""
 "The elements above are also important for future maintenance of your "
 "package. In the case that you are no long able to maintain it or simply "
@@ -3405,11 +3773,11 @@ msgstr ""
 "上記の要素は、今後のパッケージのメンテナンスにおいても重要です。 "
 "メンテナンスができなくなった場合、あるいは単に追加的な助けが欲しい場合、開発、そしてドキュメントの貢献は、新しいメンテナへの参加を支援します。"
 
-#: ../../tutorials/intro.md:358
+#: ../../tutorials/intro.md:364
 msgid "What's next?"
 msgstr "次のレッスン"
 
-#: ../../tutorials/intro.md:360
+#: ../../tutorials/intro.md:366
 msgid ""
 "In future lessons you will learn more about the infrastructure around a "
 "published Python package that makes it both easier to maintain, easier "
@@ -3418,7 +3786,7 @@ msgid ""
 "Python package."
 msgstr "今後のレッスンでは、公開された、メンテナンスが容易になり、他の人が貢献しやすくなり、他の科学者が使いやすくなるPythonパッケージのインフラについて学びます。しかし、まずはPythonパッケージを公開するという最初のゴールに到達してもらいたいと思います。"
 
-#: ../../tutorials/intro.md:362
+#: ../../tutorials/intro.md:368
 msgid ""
 "In this next lesson you will learn how to create a basic installable "
 "Python package. Make your code pip installable <create-python-package>"
@@ -3426,31 +3794,32 @@ msgstr ""
 "この次のレッスンでは、インストール可能な Python パッケージの基本的な作り方を学びます。コードをpipインストール可能にします "
 "<create-python-package>"
 
-#: ../../tutorials/publish-conda-forge.md:1
+#: ../../tutorials/publish-conda-forge.md:6
 msgid "Publish your Python package that is on PyPI to conda-forge"
 msgstr "PyPIにあるPythonパッケージをconda-forgeに公開する"
 
-#: ../../tutorials/publish-conda-forge.md:3
+#: ../../tutorials/publish-conda-forge.md:8
 msgid "In the previous lessons, you've learned:"
 msgstr "前回のレッスンであなたは以下のことを学びました:"
 
-#: ../../tutorials/publish-conda-forge.md:5
+#: ../../tutorials/publish-conda-forge.md:10
+#, fuzzy
 msgid ""
-"How to [create the most basic version of a Python package](installable-"
-"code.md). This entailed making your code installable."
+"How to [create the most basic version of a Python package](create-python-"
+"package.md). This entailed making your code installable."
 msgstr ""
 "[Pythonパッケージの最も基本的なバージョンの作り方](create-python-package.md) 。 "
 "これは、あなたのコードをインストール可能にすることが必要でした。"
 
-#: ../../tutorials/publish-conda-forge.md:6
+#: ../../tutorials/publish-conda-forge.md:11
 msgid "[How to publish your Python package to PyPI](publish-pypi)"
 msgstr "[PythonパッケージをPyPIに公開する方法](publish-pypi)"
 
-#: ../../tutorials/publish-conda-forge.md:7
+#: ../../tutorials/publish-conda-forge.md:12
 msgid "How to add a `README` and `LICENSE` file to your package"
 msgstr "パッケージに `README` と `LICENSE` ファイルを追加する方法"
 
-#: ../../tutorials/publish-conda-forge.md:8
+#: ../../tutorials/publish-conda-forge.md:13
 msgid ""
 "How to setup your `pyproject.toml` file with all of the metadata that "
 "PyPI requires and also metadata that will be helpful for users to find "
@@ -3459,13 +3828,13 @@ msgstr ""
 "どのように `pyproject.toml` ファイルに PyPI "
 "が要求するすべてのメタデータと、ユーザがあなたのパッケージを見つけるのに役立つメタデータをセットアップするかです。"
 
-#: ../../tutorials/publish-conda-forge.md:10
+#: ../../tutorials/publish-conda-forge.md:15
 msgid ""
 "If you have gone through all of the above lessons, you are now ready to "
 "publish your package on conda-forge."
 msgstr "上記のレッスンをすべて終えたなら、conda-forgeでパッケージを公開する準備が整いました。"
 
-#: ../../tutorials/publish-conda-forge.md:13
+#: ../../tutorials/publish-conda-forge.md:18
 msgid ""
 "**IMPORTANT:** Please do not practice publishing your package to conda-"
 "forge. You should only publish to conda-forge when you have a package on "
@@ -3474,27 +3843,27 @@ msgstr ""
 "**重要:** パッケージをconda-forgeに公開する練習はしないでください。 conda-"
 "forgeに公開するのは、pypi.orgにメンテナンスする予定のパッケージがあるときだけにしてください。"
 
-#: ../../tutorials/publish-conda-forge.md:19 ../../tutorials/publish-pypi.md:17
+#: ../../tutorials/publish-conda-forge.md:24 ../../tutorials/publish-pypi.md:22
 msgid "In this lesson you will learn how to:"
 msgstr "このレッスンで学ぶこと:"
 
-#: ../../tutorials/publish-conda-forge.md:21
+#: ../../tutorials/publish-conda-forge.md:26
 msgid "Create a conda-forge yaml recipe for your package using Grayskull"
 msgstr "Grayskullを使用してパッケージのconda-forge yamlレシピを作成します。"
 
-#: ../../tutorials/publish-conda-forge.md:22
+#: ../../tutorials/publish-conda-forge.md:27
 msgid ""
 "Submit the recipe (yaml file) to the conda-forge staged recipes "
 "repository as a pull request"
 msgstr "レシピ(yamlファイル)をconda-forge staged recipesリポジトリにプルリクエストとして提出します。"
 
-#: ../../tutorials/publish-conda-forge.md:23
+#: ../../tutorials/publish-conda-forge.md:28
 msgid ""
 "Maintain your conda-forge package by creating new releases for your "
 "package on PyPI"
 msgstr "PyPIでパッケージの新しいリリースを作成することで、conda-forgeパッケージを維持します。"
 
-#: ../../tutorials/publish-conda-forge.md:26
+#: ../../tutorials/publish-conda-forge.md:31
 msgid ""
 "Once your package is on PyPI you can then easily publish it to conda-"
 "forge using the [grayskull](https://conda.github.io/grayskull/) tool. You"
@@ -3505,7 +3874,7 @@ msgstr ""
 "ツールを使って簡単にconda-forgeに公開することができます。conda専用のパッケージをビルドする必要はない、conda-"
 "forgeはPyPIのソース配布ファイル (sdist) からビルドします。"
 
-#: ../../tutorials/publish-conda-forge.md:33
+#: ../../tutorials/publish-conda-forge.md:38
 msgid ""
 "Image showing the progression of creating a Python package, building it "
 "and then publishing to PyPI and conda-forge. You take your code and turn "
@@ -3518,7 +3887,7 @@ msgstr ""
 "forgeへの公開の流れを示す画像です。あなたのコードをPyPIが受け付ける配布ファイル(sdistとwheel)に変換します。そして、両方のディストリビューションを公開しているPyPIリポジトリへの矢印があります"
 "。PyPIからconda-forgeのレシピを作成し、conda-forgeに公開することができます。"
 
-#: ../../tutorials/publish-conda-forge.md:35
+#: ../../tutorials/publish-conda-forge.md:40
 msgid ""
 "Once you have published both package distributions (the source "
 "distribution and the wheel) to PyPI, you can then publish to conda-forge."
@@ -3530,11 +3899,11 @@ msgstr ""
 "forgeでパッケージをビルドするには、PyPIでのソース配布が必要です。conda-"
 "forgeに公開するためにパッケージをリビルドする必要はありません。"
 
-#: ../../tutorials/publish-conda-forge.md:38
+#: ../../tutorials/publish-conda-forge.md:43
 msgid "What is conda-forge?"
 msgstr "conda-forgeとは何ですか？"
 
-#: ../../tutorials/publish-conda-forge.md:40
+#: ../../tutorials/publish-conda-forge.md:45
 msgid ""
 "conda is an open source package and environment management tool that can "
 "be used to install tools from the different channels on Anaconda.org."
@@ -3542,7 +3911,7 @@ msgstr ""
 "conda はオープンソースのパッケージと環境管理ツールで、Anaconda.org "
 "のさまざまなチャンネルからツールをインストールするために使用できます。"
 
-#: ../../tutorials/publish-conda-forge.md:43
+#: ../../tutorials/publish-conda-forge.md:48
 msgid ""
 "You can think about a channel as a specific location where a group of "
 "packages are stored and can be installed from using a command such as "
@@ -3563,11 +3932,11 @@ msgstr ""
 "recipesのGitHubリポジトリ](https://github.com/conda-forge/staged-recipes) "
 "での技術レビューに合格しなければなりません。"
 
-#: ../../tutorials/publish-conda-forge.md:46
+#: ../../tutorials/publish-conda-forge.md:51
 msgid "[Learn more about conda channels here.](#about-conda)"
 msgstr "[condaチャンネルについて詳しくはこちら。](#about-conda)"
 
-#: ../../tutorials/publish-conda-forge.md:50
+#: ../../tutorials/publish-conda-forge.md:55
 msgid ""
 "Graphic with the title Python package repositories. Below it says "
 "anything hosted on PyPI can be installed using pip install. Packaging "
@@ -3585,7 +3954,7 @@ msgstr ""
 "チームによって管理されているものです。 その下にPyPIサーバーという行があります。 PyPI - 誰でもPyPIに公開することができます、と "
 "test PyPI (PyPIをテストするためのテストベッドサーバ)。"
 
-#: ../../tutorials/publish-conda-forge.md:52
+#: ../../tutorials/publish-conda-forge.md:57
 msgid ""
 "Conda channels represent various repositories that you can install "
 "packages from. Because conda-forge is community maintained, anyone can "
@@ -3598,11 +3967,11 @@ msgstr ""
 "誰でもPyPIにパッケージを投稿し、PyPIをテストすることができます。 conda-forge とは異なり、PyPI "
 "に投稿されたパッケージを手動でチェックすることはありません。"
 
-#: ../../tutorials/publish-conda-forge.md:55
+#: ../../tutorials/publish-conda-forge.md:60
 msgid "Why publish to conda-forge"
 msgstr "conda-forgeに公開する理由"
 
-#: ../../tutorials/publish-conda-forge.md:57
+#: ../../tutorials/publish-conda-forge.md:62
 msgid ""
 "There are many users, especially in the scientific Python ecosystem that "
 "use conda as their primary package manager / environment tool. Thus, "
@@ -3615,11 +3984,11 @@ msgstr ""
 "したがって、conda-forgeチャンネルでこれらのユーザーがパッケージを利用できるようにすることは有用です。 場合によっては、conda-"
 "forge上のパッケージは、pipとcondaを混ぜてインストールする際に起こりうる依存関係の衝突を最小限に抑えることができます。これは空間生態系にとって特に重要です。"
 
-#: ../../tutorials/publish-conda-forge.md:59
+#: ../../tutorials/publish-conda-forge.md:64
 msgid "How publishing to conda-forge works"
 msgstr "conda-forgeへの公開の仕組み"
 
-#: ../../tutorials/publish-conda-forge.md:61
+#: ../../tutorials/publish-conda-forge.md:66
 msgid ""
 "Once you have built and published your package to PyPI, you have "
 "everything that you need to publish to conda-forge. There is no "
@@ -3628,7 +3997,7 @@ msgstr ""
 "パッケージをビルドしてPyPIに公開したら、conda-forgeに公開するために必要なものはすべて揃っています。 conda-"
 "forgeに公開するための追加のビルドステップは必要ありません。"
 
-#: ../../tutorials/publish-conda-forge.md:63
+#: ../../tutorials/publish-conda-forge.md:68
 msgid ""
 "Conda-forge will build your package from the source distribution which "
 "you [published to PyPI in the previous lesson](publish-pypi) using the "
@@ -3637,17 +4006,17 @@ msgstr ""
 "Conda-forgeは、 [前のレッスンでPyPIに公開した](publish-pypi) "
 "ソースディストリビューションから、以下で作成するレシピを使ってパッケージをビルドします。"
 
-#: ../../tutorials/publish-conda-forge.md:65
+#: ../../tutorials/publish-conda-forge.md:70
 msgid "Conda-forge publication steps"
 msgstr "Conda-forgeの公開手順"
 
-#: ../../tutorials/publish-conda-forge.md:68
+#: ../../tutorials/publish-conda-forge.md:73
 msgid ""
 "Image showing the steps associated with publishing to conda-forge. Check "
 "out the caption below for a detailed description."
 msgstr "conda-forgeへの公開に関連する手順を示す画像です。 詳しい説明は以下のキャプションをご覧ください。"
 
-#: ../../tutorials/publish-conda-forge.md:70
+#: ../../tutorials/publish-conda-forge.md:75
 msgid ""
 "The steps for publishing to conda-forge begin with publishing your Python"
 " package to PyPI. Once you have published to PyPI you can then create a "
@@ -3660,15 +4029,15 @@ msgstr ""
 "recipesリポジトリに投稿してレビューを受けることができます。 レシピが承認されると、あなたのパッケージはconda-"
 "forge上のリポジトリ（フィードストックと呼ばれます）に登録されます。"
 
-#: ../../tutorials/publish-conda-forge.md:73
+#: ../../tutorials/publish-conda-forge.md:78
 msgid "The steps to publish to conda-forge are:"
 msgstr "conda-forgeに公開する手順は以下の通りです:"
 
-#: ../../tutorials/publish-conda-forge.md:75
+#: ../../tutorials/publish-conda-forge.md:80
 msgid "Publish your Python package distribution files (sdist & wheel) to PyPI"
 msgstr "Pythonパッケージの配布ファイル (sdistとwheel) をPyPIに公開する"
 
-#: ../../tutorials/publish-conda-forge.md:76
+#: ../../tutorials/publish-conda-forge.md:81
 msgid ""
 "Create a conda-forge recipe, which is a yaml file with instructions on "
 "how to build your package on conda-forge, using the grayskull[^grayskull]"
@@ -3677,7 +4046,7 @@ msgstr ""
 "これは、 grayskull[^grayskull] パッケージを使用して、conda-"
 "forge上でパッケージをビルドする方法を説明したyamlファイルです。"
 
-#: ../../tutorials/publish-conda-forge.md:77
+#: ../../tutorials/publish-conda-forge.md:82
 msgid ""
 "Submit the recipe (yaml file) to the conda-forge staged recipes "
 "repository as a pull request for review. [Click here for an example "
@@ -3689,7 +4058,7 @@ msgstr ""
 "[pyOpenSciからの投稿例はこちらをクリックしてください](https://github.com/conda-forge/staged-"
 "recipes/pull/25173)"
 
-#: ../../tutorials/publish-conda-forge.md:79
+#: ../../tutorials/publish-conda-forge.md:84
 msgid ""
 "Once someone from the conda-forge team reviews your pull request, you may"
 " need to make some changes. Eventually the pull request will be approved "
@@ -3698,27 +4067,27 @@ msgstr ""
 "conda-"
 "forgeチームの誰かがあなたのプルリクエストをレビューしたら、いくつかの変更が必要になるかもしれません。最終的にプルリクエストは承認され、マージされます。"
 
-#: ../../tutorials/publish-conda-forge.md:81
+#: ../../tutorials/publish-conda-forge.md:86
 msgid ""
 "Once your recipe is accepted and merged on conda-forge, users can install"
 " your package using:"
 msgstr "あなたのレシピがconda-forgeで承認され、マージされると、ユーザーはあなたのパッケージをインストールできます:"
 
-#: ../../tutorials/publish-conda-forge.md:83
+#: ../../tutorials/publish-conda-forge.md:88
 msgid "`conda install -c conda-forge your-package`"
 msgstr "`conda install -c conda-forge your-package`"
 
-#: ../../tutorials/publish-conda-forge.md:85
+#: ../../tutorials/publish-conda-forge.md:90
 msgid ""
 "You only create the recipe once. Once the recipe is accepted and merged, "
 "you only need to maintain the repository."
 msgstr "レシピを作成するのは一度だけです。 レシピが受け入れられマージされたら、リポジトリを管理するだけです。"
 
-#: ../../tutorials/publish-conda-forge.md:87
+#: ../../tutorials/publish-conda-forge.md:92
 msgid "Maintaining a conda-forge package"
 msgstr "conda-forge パッケージのメンテナンス"
 
-#: ../../tutorials/publish-conda-forge.md:89
+#: ../../tutorials/publish-conda-forge.md:94
 msgid ""
 "Once your package is on conda-forge, the repository will track release "
 "activity on the package's PyPI repository. Any time you make a new PyPI "
@@ -3729,25 +4098,25 @@ msgstr ""
 "新しいソースディストリビューションで新しい PyPI リリースを作成すると、conda-forge はあなたの conda-forge "
 "リポジトリ（フィードストックとも呼ばれます）をビルドして更新します。"
 
-#: ../../tutorials/publish-conda-forge.md:91
+#: ../../tutorials/publish-conda-forge.md:96
 msgid ""
 "When the update is processed, the friendly conda-forge bot will create a "
 "new pull request with an updated distribution recipe in your feedstock."
 msgstr "アップデートが処理されると、フレンドリーなconda-forgeボットがフィードストックの配布レシピを更新した新しいプルリクエストを作成します。"
 
-#: ../../tutorials/publish-conda-forge.md:93
+#: ../../tutorials/publish-conda-forge.md:98
 msgid ""
 "You can review that pull request and then merge it once all of the "
 "continuous integration tests pass."
 msgstr "そのプルリクエストをレビューし、継続的インテグレーションのテストがすべてパスしたら、それをマージすることができます。"
 
-#: ../../tutorials/publish-conda-forge.md:95
+#: ../../tutorials/publish-conda-forge.md:100
 msgid ""
 "<i class=\"fa-regular fa-pen-to-square\"></i> How to Publish your package"
 " on conda-forge"
 msgstr "<i class=\"fa-regular fa-pen-to-square\"></i> conda-forgeでパッケージを公開する方法"
 
-#: ../../tutorials/publish-conda-forge.md:97
+#: ../../tutorials/publish-conda-forge.md:102
 msgid ""
 "It's time to add your package to the conda-forge channel. Remember that "
 "your package needs to be on PyPI before the steps below will work. And "
@@ -3757,19 +4126,19 @@ msgstr ""
 "以下の手順が動作する前に、あなたのパッケージがPyPI上にある必要があることを覚えておいてください。また、conda-"
 "forgeを管理しているチームはすべてボランティアであることを忘れないでください。"
 
-#: ../../tutorials/publish-conda-forge.md:100
+#: ../../tutorials/publish-conda-forge.md:105
 msgid ""
 "Be sure that your package is on PyPI.org (not test.pypi.org) before you "
 "attempt to publish to conda-forge."
 msgstr "conda-forgeに公開する前に、あなたのパッケージが（test.pypi.orgではなく）PyPI.orgにあることを確認してください。"
 
-#: ../../tutorials/publish-conda-forge.md:103
+#: ../../tutorials/publish-conda-forge.md:108
 msgid ""
 "Only submit your package to conda-forge if you intend to maintain it over"
 " time."
 msgstr "パッケージをconda-forgeに投稿するのは、長期的にメンテナンスするつもりである場合だけにしてください。"
 
-#: ../../tutorials/publish-conda-forge.md:106
+#: ../../tutorials/publish-conda-forge.md:111
 msgid ""
 "Note - this is a tutorial aimed to help you get your package onto conda-"
 "forge. The official conda documentation for this processed [is "
@@ -3779,11 +4148,11 @@ msgstr ""
 "forgeに載せる手助けをすることを目的としています。この処理に関するcondaの公式ドキュメントは [こちら](https://conda-"
 "forge.org/docs/maintainer/adding_pkgs.html) 。"
 
-#: ../../tutorials/publish-conda-forge.md:108
+#: ../../tutorials/publish-conda-forge.md:113
 msgid "Step 1: Install grayskull"
 msgstr "ステップ1: grayskullをインストールする"
 
-#: ../../tutorials/publish-conda-forge.md:110
+#: ../../tutorials/publish-conda-forge.md:115
 msgid ""
 "First, [install "
 "grayskull](https://conda.github.io/grayskull/user_guide.html). You can "
@@ -3793,17 +4162,17 @@ msgstr ""
 "[grayskullをインストールします](https://conda.github.io/grayskull/user_guide.html) "
 "。 pip を使用してインストールできます:"
 
-#: ../../tutorials/publish-conda-forge.md:116
+#: ../../tutorials/publish-conda-forge.md:121
 msgid "or conda"
 msgstr "それともconda"
 
-#: ../../tutorials/publish-conda-forge.md:122
+#: ../../tutorials/publish-conda-forge.md:127
 msgid ""
 "To run this command, use the same shell / terminal that you have been "
 "using to run hatch commands in the previous tutorials."
 msgstr "このコマンドを実行するには、前のチュートリアルでhatchコマンドを実行するのに使ったのと同じシェル/ターミナルを使います。"
 
-#: ../../tutorials/publish-conda-forge.md:127
+#: ../../tutorials/publish-conda-forge.md:132
 msgid ""
 "You can also install grayskull using pipx[^pipx]. pipx is a tool that "
 "allows you to install commonly used tools that you might want to have "
@@ -3813,17 +4182,17 @@ msgstr ""
 "pipx[^pipx] を使用してgrayskullをインストールすることもできます。 "
 "pipxは、作成したPython環境すべてにパッケージをインストールするのではなく、複数のPython環境で利用できるようにしたい、よく使われるツールをインストールできるツールです。"
 
-#: ../../tutorials/publish-conda-forge.md:130
+#: ../../tutorials/publish-conda-forge.md:135
 msgid "Step 2: Fork and clone the conda-forge staged-recipes repository"
 msgstr "ステップ 2: conda-forge staged-recipes リポジトリをフォークしてクローンします。"
 
-#: ../../tutorials/publish-conda-forge.md:132
+#: ../../tutorials/publish-conda-forge.md:137
 msgid ""
 "Next, open your shell and `cd` to a location where you want to clone the "
 "**conda-forge/staged-recipes** repository."
 msgstr "次に、シェルを開き、 **conda-forge/staged-recipes** リポジトリをクローンしたい場所に `cd` します。"
 
-#: ../../tutorials/publish-conda-forge.md:133
+#: ../../tutorials/publish-conda-forge.md:138
 msgid ""
 "fork and clone the [conda-forge/staged-recipes GitHub "
 "repository](https://github.com/conda-forge/staged-recipes)."
@@ -3831,21 +4200,21 @@ msgstr ""
 "[conda-forge/staged-recipes GitHubリポジトリ](https://github.com/conda-forge"
 "/staged-recipes) をフォークしてクローンしてください。"
 
-#: ../../tutorials/publish-conda-forge.md:134
+#: ../../tutorials/publish-conda-forge.md:139
 msgid ""
 "Create a new branch in your fork rather than submitting from the main "
 "branch of your fork. We suggest naming the branch your package's name."
 msgstr "フォークのメインブランチから投稿するのではなく、フォークに新しいブランチを作成してください。ブランチにパッケージ名をつけることをお勧めします。"
 
-#: ../../tutorials/publish-conda-forge.md:136
+#: ../../tutorials/publish-conda-forge.md:141
 msgid "`git checkout -b your-package-name `"
 msgstr "`git checkout -b your-package-name `"
 
-#: ../../tutorials/publish-conda-forge.md:138
+#: ../../tutorials/publish-conda-forge.md:143
 msgid "In bash, `cd` into the `staged-recipes/recipes` folder"
 msgstr "bashで `cd` を `staged-recipes/recipes` フォルダに入れる。"
 
-#: ../../tutorials/publish-conda-forge.md:146
+#: ../../tutorials/publish-conda-forge.md:151
 msgid ""
 "Next, create a new branch in your `conda-forge/staged-recipes` cloned "
 "repository. You might want to make that branch the same name as your "
@@ -3854,69 +4223,69 @@ msgstr ""
 "次に、クローンした `conda-forge/staged-recipes` リポジトリに新しいブランチを作成します。 "
 "そのブランチを、あなたのパッケージと同じ名前にしたいかもしれません。"
 
-#: ../../tutorials/publish-conda-forge.md:157
+#: ../../tutorials/publish-conda-forge.md:162
 msgid "Step 3: Create your conda-forge recipe"
 msgstr "ステップ3: conda-forgeレシピの作成"
 
-#: ../../tutorials/publish-conda-forge.md:159
+#: ../../tutorials/publish-conda-forge.md:164
 msgid "Next, navigate to the recipes directory"
 msgstr "次に、レシピディレクトリに移動します。"
 
-#: ../../tutorials/publish-conda-forge.md:161
+#: ../../tutorials/publish-conda-forge.md:166
 msgid ""
 "If you run `ls` here, you will notice there is an example directory with "
 "an example recipe for you to look at."
 msgstr "ここで `ls` を実行すると、レシピ例のあるexampleディレクトリがあることに気づくでしょう。"
 
-#: ../../tutorials/publish-conda-forge.md:173
+#: ../../tutorials/publish-conda-forge.md:178
 msgid "Next, run `grayskull pypi your-package-name` to generate a recipe."
 msgstr "次に、 `grayskull pypi your-package-name` を実行してレシピを生成します。"
 
-#: ../../tutorials/publish-conda-forge.md:217
+#: ../../tutorials/publish-conda-forge.md:222
 msgid ""
 "Grayskull will pull metadata about your package from PyPI. It does not "
 "use your local installation of the package."
 msgstr "Grayskull はあなたのパッケージのメタデータを PyPI から取得します。ローカルにインストールしたパッケージは使用しません。"
 
-#: ../../tutorials/publish-conda-forge.md:218
+#: ../../tutorials/publish-conda-forge.md:223
 msgid ""
 "An internet connection is needed to run the `grayskull pypi your-package-"
 "name` step."
 msgstr "`grayskull pypi your-package-name` のステップを実行するにはインターネット接続が必要です。"
 
-#: ../../tutorials/publish-conda-forge.md:221
+#: ../../tutorials/publish-conda-forge.md:226
 msgid ""
 "When you run grayskull, it will grab the latest distribution of your "
 "package from PyPI and will use that to create a new recipe."
 msgstr "grayskullを実行すると、PyPIからあなたのパッケージの最新のディストリビューションを取得し、それを使って新しいレシピを作成します。"
 
-#: ../../tutorials/publish-conda-forge.md:223
+#: ../../tutorials/publish-conda-forge.md:228
 msgid ""
 "The recipe will be saved in a directory named after your package's name, "
 "wherever you run the command."
 msgstr "レシピは、コマンドを実行した場所の、あなたのパッケージ名にちなんだ名前のディレクトリに保存されます。"
 
-#: ../../tutorials/publish-conda-forge.md:225
+#: ../../tutorials/publish-conda-forge.md:230
 msgid "`recipes/packagename/meta.yaml`"
 msgstr "`recipes/packagename/meta.yaml`"
 
-#: ../../tutorials/publish-conda-forge.md:227
+#: ../../tutorials/publish-conda-forge.md:232
 msgid ""
 "At the very bottom of the grayskull output, it will also tell you where "
 "it saved the recipe file."
 msgstr "grayskull 出力の一番下にある、レシピファイルの保存場所も教えてくれます。"
 
-#: ../../tutorials/publish-conda-forge.md:230
+#: ../../tutorials/publish-conda-forge.md:235
 msgid ""
 "Open the meta.yaml file. The finished `meta.yaml` file that grayskull "
 "creates should look like the example below:"
 msgstr "meta.yaml ファイルを開きます。 grayskullが作成する完成した `meta.yaml` ファイルは、以下の例のようになるはずです:"
 
-#: ../../tutorials/publish-conda-forge.md:277
+#: ../../tutorials/publish-conda-forge.md:282
 msgid "Step 3b: Bug fix - add a home url to the about: section"
 msgstr "ステップ 3b: バグフィクス - about:セクションにホームURLを追加します"
 
-#: ../../tutorials/publish-conda-forge.md:279
+#: ../../tutorials/publish-conda-forge.md:284
 msgid ""
 "There is currently a small bug in Grayskull where it doesn't populate the"
 " home: element of the recipe. If you don't include this, [you will "
@@ -3928,19 +4297,19 @@ msgstr ""
 "forge linter bot から [エラーメッセージが表示されます](https://github.com/conda-forge"
 "/staged-recipes/pull/25173#issuecomment-1917916528) 。"
 
-#: ../../tutorials/publish-conda-forge.md:293
+#: ../../tutorials/publish-conda-forge.md:298
 msgid "to fix this, open your meta.yaml file in your favorite text editor."
 msgstr "これを修正するには、meta.yamlファイルをお好みのテキストエディタで開いてください。"
 
-#: ../../tutorials/publish-conda-forge.md:294
+#: ../../tutorials/publish-conda-forge.md:299
 msgid "and add a home: element to the about section"
 msgstr "そして、aboutセクションに home: 要素を追加します"
 
-#: ../../tutorials/publish-conda-forge.md:296
+#: ../../tutorials/publish-conda-forge.md:301
 msgid "The about section will look like this after you create your recipe."
 msgstr "レシピを作成すると、aboutセクションはこのようになります。"
 
-#: ../../tutorials/publish-conda-forge.md:306
+#: ../../tutorials/publish-conda-forge.md:311
 msgid ""
 "Below you add a home: element. If you have a project home page / website "
 "you can use that url. Otherwise, you can also use your PyPI landing page."
@@ -3948,11 +4317,11 @@ msgstr ""
 "以下で home: element "
 "を追加します。プロジェクトのホームページやウェブサイトがあれば、そのURLを使うことができます。そうでなければ、PyPIのランディングページを使うこともできます。"
 
-#: ../../tutorials/publish-conda-forge.md:317
+#: ../../tutorials/publish-conda-forge.md:322
 msgid "Step 4: tests for conda-forge"
 msgstr "ステップ 4: conda-forgeのテスト"
 
-#: ../../tutorials/publish-conda-forge.md:319
+#: ../../tutorials/publish-conda-forge.md:324
 msgid ""
 "Next, have a look at the tests section in your **meta.yaml** file. At a "
 "minimum you should import your package or the main modules associated "
@@ -3961,35 +4330,35 @@ msgstr ""
 "次に、 **meta.yaml** ファイルのtestsセクションを見てください。 "
 "最低限、自分のパッケージか、そのパッケージに関連する主要なモジュールをインポートして `pip check` を実行する必要があります。"
 
-#: ../../tutorials/publish-conda-forge.md:321
+#: ../../tutorials/publish-conda-forge.md:326
 msgid ""
 "`pip check` will ensure that your package installs properly with all of "
 "the proper dependencies."
 msgstr "`pip check` は、あなたのパッケージが適切な依存関係をすべて持って正しくインストールされることを保証します。"
 
-#: ../../tutorials/publish-conda-forge.md:333
+#: ../../tutorials/publish-conda-forge.md:338
 msgid ""
 "If you have more advanced tests that you wish to run, you can add them "
 "here. However, you can also simply leave the tests section as it is."
 msgstr "さらに高度なテストを実施したい場合は、ここに追加することができます。 しかし、テストセクションをそのままにしておくこともできます。"
 
-#: ../../tutorials/publish-conda-forge.md:335
+#: ../../tutorials/publish-conda-forge.md:340
 msgid "Step 4: Submit a pull request to the staged-recipes repository"
 msgstr "ステップ 4: staged-recipesリポジトリにプルリクエストを提出します"
 
-#: ../../tutorials/publish-conda-forge.md:337
+#: ../../tutorials/publish-conda-forge.md:342
 msgid ""
 "Once you have completed all of the above, you are ready to open up a pull"
 " request in the `conda-forge/staged-recipes repository`."
 msgstr "上記がすべて完了したら、 `conda-forge/staged-recipes repository` でプルリクエストを開く準備ができました。"
 
-#: ../../tutorials/publish-conda-forge.md:339
+#: ../../tutorials/publish-conda-forge.md:344
 msgid ""
 "Submit a pull request from your fork/branch of the staged-recipes "
 "repository."
 msgstr "staged-recipesリポジトリのフォーク/ブランチからプルリクエストを提出してください。"
 
-#: ../../tutorials/publish-conda-forge.md:340
+#: ../../tutorials/publish-conda-forge.md:345
 msgid ""
 "Remember that the conda-forge maintainers are volunteers. Be patient for "
 "someone to respond and supportive in your communication with them."
@@ -4001,25 +4370,25 @@ msgstr ""
 msgid "Conda-forge checklist help"
 msgstr "Conda-forgeチェックリストヘルプ"
 
-#: ../../tutorials/publish-conda-forge.md:346
+#: ../../tutorials/publish-conda-forge.md:351
 msgid "Conda-forge Staged-recipes Pull Request Checklist"
 msgstr "Conda-forge Staged-recipes プルリクエストチェックリスト"
 
-#: ../../tutorials/publish-conda-forge.md:348
+#: ../../tutorials/publish-conda-forge.md:353
 msgid ""
 "When you submit your package to conda-forge, the pull request template "
 "includes a list of checks that you want to ensure you have covered."
 msgstr "conda-forgeにパッケージを投稿する際、プルリクエストテンプレートには、あなたが確実にカバーしたいチェックリストが含まれています。"
 
-#: ../../tutorials/publish-conda-forge.md:350
+#: ../../tutorials/publish-conda-forge.md:355
 msgid "Below we break down each element of that list."
 msgstr "以下では、そのリストの各要素を分解します。"
 
-#: ../../tutorials/publish-conda-forge.md:352
+#: ../../tutorials/publish-conda-forge.md:357
 msgid "Pull request template checklist tips"
 msgstr "プルリクエストテンプレートのチェックリストのヒント"
 
-#: ../../tutorials/publish-conda-forge.md:355
+#: ../../tutorials/publish-conda-forge.md:360
 msgid ""
 "-[x] Title of this PR is meaningful: e.g. \"Adding my_nifty_package\", "
 "not \"updated meta.yaml\"."
@@ -4027,7 +4396,7 @@ msgstr ""
 "-[x] このPRのタイトルは意味があります: 例 \"updated meta.yaml\" ではなく \"Adding "
 "my_nifty_package\" 。"
 
-#: ../../tutorials/publish-conda-forge.md:357
+#: ../../tutorials/publish-conda-forge.md:362
 msgid ""
 "**Translation:** Make sure that your pull request title is specific. We "
 "suggest something like: `Add recipe for <your package name>`"
@@ -4035,7 +4404,7 @@ msgstr ""
 "**翻訳:** プルリクエストのタイトルが具体的であることを確認してください。 我々は次のようなものを提案します: `<your package "
 "name> のレシピを追加`"
 
-#: ../../tutorials/publish-conda-forge.md:360
+#: ../../tutorials/publish-conda-forge.md:365
 msgid ""
 "-[x] License file is packaged (see [here](https://github.com/conda-forge"
 "/staged-"
@@ -4047,7 +4416,7 @@ msgstr ""
 "recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73"
 " を参照)) 。"
 
-#: ../../tutorials/publish-conda-forge.md:362
+#: ../../tutorials/publish-conda-forge.md:367
 msgid ""
 "**Translation:** You should have a LICENSE file included in your "
 "package's source distribution. If you have followed the pyOpenSci "
@@ -4061,11 +4430,11 @@ msgstr ""
 "build` を実行すると、conda-forge がパッケージのビルドに使用する出力 [ソースディストリビューションファイル(tar.gz "
 "ファイル) ](python-source-distribution) にそのファイルがバンドルされます。"
 
-#: ../../tutorials/publish-conda-forge.md:364
+#: ../../tutorials/publish-conda-forge.md:369
 msgid "[x] Source is from official source."
 msgstr "[x] ソースは公式ソースより。"
 
-#: ../../tutorials/publish-conda-forge.md:366
+#: ../../tutorials/publish-conda-forge.md:371
 msgid ""
 "**Translation:** If your package is on PyPI as you learned in the "
 "[previous lesson on publishing your Python package](publish-pypi) then "
@@ -4076,7 +4445,7 @@ msgstr ""
 "で学んだように、あなたのパッケージがPyPI上にあるのであれば、問題はありません。 conda-"
 "forgeはディストリビューションを既知のリポジトリに公開することを推奨します。"
 
-#: ../../tutorials/publish-conda-forge.md:368
+#: ../../tutorials/publish-conda-forge.md:373
 msgid ""
 "-[x] Package does not vendor other packages. (If a package uses the "
 "source of another package, they should be separate packages or the "
@@ -4085,7 +4454,7 @@ msgstr ""
 "-[x] パッケージは他のパッケージをベンダリングしません。 "
 "(あるパッケージが他のパッケージのソースを使用している場合、これらは別々のパッケージにするか、すべてのパッケージのライセンスをパッケージ化する必要があります)。"
 
-#: ../../tutorials/publish-conda-forge.md:370
+#: ../../tutorials/publish-conda-forge.md:375
 msgid ""
 "**Translation:** If the code base in your package is your own and it all "
 "shares the same LICENSE then you are in good shape. If you have code "
@@ -4096,13 +4465,13 @@ msgstr ""
 "**翻訳:** "
 "あなたのパッケージのコードベースがあなた自身のものであり、それがすべて同じライセンスを共有しているのであれば、問題はありません。他のパッケージから取得したコードがある場合は、そのコードを宣言し、異なる場合はそのライセンスも含める必要があるかもしれません。これらのチュートリアルに従ったのであれば、あなたはベンダーのコードを持っていません。"
 
-#: ../../tutorials/publish-conda-forge.md:372
+#: ../../tutorials/publish-conda-forge.md:377
 msgid ""
 "-[x] If static libraries are linked in, the license of the static library"
 " is packaged."
 msgstr "-[x] スタティックライブラリーがリンクされている場合、スタティックライブラリーのライセンスがパッケージされます。"
 
-#: ../../tutorials/publish-conda-forge.md:374
+#: ../../tutorials/publish-conda-forge.md:379
 msgid ""
 "-[x] Package does not ship static libraries. If static libraries are "
 "needed, [follow CFEP-18](https://github.com/conda-"
@@ -4111,7 +4480,7 @@ msgstr ""
 "-[x] パッケージには静的ライブラリは同梱されていません。静的ライブラリーが必要な場合、 [CFEP-18 "
 "に従います](https://github.com/conda-forge/cfep/blob/main/cfep-18.md)."
 
-#: ../../tutorials/publish-conda-forge.md:376
+#: ../../tutorials/publish-conda-forge.md:381
 msgid ""
 "**Translation:** A static library refers to a copy of a package built "
 "into your package. If your package is a pure Python package, then you can"
@@ -4121,21 +4490,21 @@ msgstr ""
 "**翻訳:** "
 "スタティックライブラリーは、パッケージに組み込まれたパッケージのコピーを指します。もしあなたのパッケージが純粋なPythonパッケージであれば、スタティックライブラリが同梱されていないことを確認してください。"
 
-#: ../../tutorials/publish-conda-forge.md:378
+#: ../../tutorials/publish-conda-forge.md:383
 msgid ""
 "The pyOpenSci tutorials are all pure Python and as such do not use static"
 " libraries in a linked or shipped (included in the package distribution) "
 "format."
 msgstr "pyOpenSciチュートリアルはすべて純粋なPythonであり、リンクされた、あるいは出荷された(パッケージ配布に含まれる)形式の静的ライブラリは使用しません。"
 
-#: ../../tutorials/publish-conda-forge.md:380
+#: ../../tutorials/publish-conda-forge.md:385
 msgid ""
 "If your package has a more complex build that includes links to "
 "extensions written in other languages such as C++, then be sure to "
 "include the proper licenses for those extensions in your metadata."
 msgstr "あなたのパッケージが、C++のような他の言語で書かれた拡張機能へのリンクを含む、より複雑なビルドを持つ場合は、メタデータにそれらの拡張機能の適切なライセンスを含めるようにしてください。"
 
-#: ../../tutorials/publish-conda-forge.md:385
+#: ../../tutorials/publish-conda-forge.md:390
 msgid ""
 "If you want to learn more about static libraries, then [this "
 "overview](https://pypackaging-"
@@ -4146,11 +4515,11 @@ msgstr ""
 "native.github.io/background/compilation_concepts/#shared-vs-static-"
 "libraries) が役に立つかもしれません。"
 
-#: ../../tutorials/publish-conda-forge.md:388
+#: ../../tutorials/publish-conda-forge.md:393
 msgid "-[ ] Build number is 0."
 msgstr "-[ ] ビルド番号は0。"
 
-#: ../../tutorials/publish-conda-forge.md:390
+#: ../../tutorials/publish-conda-forge.md:395
 msgid ""
 "**Translation:** The build number in your recipe is right below the "
 "source location of your package's source distribution. `number: 0` is "
@@ -4159,7 +4528,7 @@ msgstr ""
 "**翻訳:** レシピのビルド番号は、パッケージのソース配布場所のすぐ下にあります。 `number: 0` "
 "は、レシピのそのセクションに表示されるべきものです。"
 
-#: ../../tutorials/publish-conda-forge.md:403
+#: ../../tutorials/publish-conda-forge.md:408
 msgid ""
 "[x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your"
 " recipe (see [here](https://conda-"
@@ -4168,7 +4537,7 @@ msgstr ""
 "[x] レシピでは、リポジトリ (例 `git_url` ) ではなく、tarball (`url`) を使用します。 (詳細は "
 "[こちら](https://conda-forge.org/docs/maintainer/adding_pkgs.html))。"
 
-#: ../../tutorials/publish-conda-forge.md:405
+#: ../../tutorials/publish-conda-forge.md:410
 msgid ""
 "**Translation:** Here conda wants you to provide a link to the source "
 "distribution on PyPI rather than a link to your GitHub repository "
@@ -4181,13 +4550,13 @@ msgstr ""
 " `url:` セクションがあり、tar.gzで終わるPyPIのURLを提供していることに注意してください。これは、conda-"
 "forgeが使用するソースディストリビューションへのリンクです。"
 
-#: ../../tutorials/publish-conda-forge.md:411
+#: ../../tutorials/publish-conda-forge.md:416
 msgid ""
 "[x] GitHub users listed in the maintainer section have posted a comment "
 "confirming they are willing to be listed there."
 msgstr "[x] GitHubのメンテナセクションに掲載されているユーザーは、掲載の意思を確認するコメントを投稿しています。"
 
-#: ../../tutorials/publish-conda-forge.md:413
+#: ../../tutorials/publish-conda-forge.md:418
 msgid ""
 "**Translation** Once you have submitted your recipe, be sure that all "
 "maintainers listed in your recipe respond acknowledging that they are ok "
@@ -4197,7 +4566,7 @@ msgstr ""
 "**Translation** レシピを提出したら、レシピに記載されているすべてのメンテナが、あなたのパッケージの conda-forge "
 "バージョンのメンテナとして記載されても構わないという返事をすることを確認してください。"
 
-#: ../../tutorials/publish-conda-forge.md:415
+#: ../../tutorials/publish-conda-forge.md:420
 msgid ""
 "[x] When in trouble, please check our [knowledge base "
 "documentation](https://conda-"
@@ -4206,7 +4575,7 @@ msgstr ""
 "[x] 問題が発生した場合は、チームに問い合わせる前に [ナレッジベースのドキュメント](https://conda-"
 "forge.org/docs/maintainer/knowledge_base.html) を確認してください。"
 
-#: ../../tutorials/publish-conda-forge.md:417
+#: ../../tutorials/publish-conda-forge.md:422
 msgid ""
 "**Translation** The conda team are volunteers who spend their time "
 "supporting our community. Please try to troubleshoot on your own first "
@@ -4215,13 +4584,13 @@ msgstr ""
 "**翻訳** コンダチームはボランティアで、私たちのコミュニティをサポートするために時間を費やしています。 "
 "彼らに助けを求める前に、まずは自分でトラブルシューティングを試みてください。"
 
-#: ../../tutorials/publish-conda-forge.md:419
+#: ../../tutorials/publish-conda-forge.md:424
 msgid ""
 "This is also why we don't suggest you publish to conda-forge as a "
 "practice run."
 msgstr "これが、練習としてconda-forgeに公開することをお勧めしない理由でもあります。"
 
-#: ../../tutorials/publish-conda-forge.md:423
+#: ../../tutorials/publish-conda-forge.md:428
 msgid ""
 "Once you create your pull request, a suite of CI actions will run that "
 "build and test the build of your package. A conda-forge maintainer will "
@@ -4230,13 +4599,13 @@ msgstr ""
 "プルリクエストを作成すると、一連のCIアクションがビルドを実行し、パッケージのビルドをテストします。 conda-"
 "forgeのメンテナーは、あなたのレシピを良い状態にしてマージするためにあなたと協力します。"
 
-#: ../../tutorials/publish-conda-forge.md:427
+#: ../../tutorials/publish-conda-forge.md:432
 msgid ""
 "Image showing the 5 CI tasks that will run against your package in the "
 "GitHub interface after you'ce created a pull request."
 msgstr "プルリクエストを作成した後、GitHubのインターフェイスであなたのパッケージに対して実行される5つのCIタスクを示す画像。"
 
-#: ../../tutorials/publish-conda-forge.md:429
+#: ../../tutorials/publish-conda-forge.md:434
 msgid ""
 "Wait until all of the CI steps in your pull request have run. At that "
 "point your pull request is ready for review by a conda-forge maintainer."
@@ -4244,7 +4613,7 @@ msgstr ""
 "プルリクエストのCIステップがすべて実行されるまで待ちます。 この時点で、あなたのプルリクエストはconda-"
 "forgeのメンテナによるレビューの準備が整いました。"
 
-#: ../../tutorials/publish-conda-forge.md:432
+#: ../../tutorials/publish-conda-forge.md:437
 msgid ""
 "In some cases getting all of the checks to run successfully in CI might "
 "take a bit of work. If you are struggling to get your recipe to build "
@@ -4253,15 +4622,15 @@ msgstr ""
 "場合によっては、CIですべてのチェックを成功させるには、少し手間がかかるかもしれません。 レシピがうまくビルドできない場合は、conda-"
 "forge メンテナチームに助けを求めてください。"
 
-#: ../../tutorials/publish-conda-forge.md:434
+#: ../../tutorials/publish-conda-forge.md:439
 msgid "Please be patient and wait for them to respond."
 msgstr "辛抱強く返答を待ってください。"
 
-#: ../../tutorials/publish-conda-forge.md:436
+#: ../../tutorials/publish-conda-forge.md:441
 msgid "conda-forge staged recipes and CI failures"
 msgstr "conda-forgeのステージレシピとCIの失敗"
 
-#: ../../tutorials/publish-conda-forge.md:439
+#: ../../tutorials/publish-conda-forge.md:444
 msgid ""
 "If your package is a pure Python package that can be installed on any "
 "type of computer (Windows, mac, linux) and has no architecture "
@@ -4273,7 +4642,7 @@ msgstr ""
 "Pythonまたはアーキテクチャの要求がないパッケージとして知られています) 、conda-forgeチームはLinux "
 "CI用のテストのみがパスすることを要求します。"
 
-#: ../../tutorials/publish-conda-forge.md:441
+#: ../../tutorials/publish-conda-forge.md:446
 msgid ""
 "So if tests for Windows and MAC OS fail, that is to be expected. In this "
 "case, don't worry about failing tests, the maintainer team can help you "
@@ -4282,7 +4651,7 @@ msgstr ""
 "そのため、WindowsとMAC OSのテストが失敗したとしても、それは予想されることです。 "
 "この場合、テストの失敗を心配する必要はありません。メンテナチームが、あなたのパッケージが公開されるよう手助けしてくれます。"
 
-#: ../../tutorials/publish-conda-forge.md:444
+#: ../../tutorials/publish-conda-forge.md:449
 msgid ""
 "Once you have submitted your recipe, you can wait for the CI build to "
 "pass. If it's not passing, and you aren't sure why, a conda-forge "
@@ -4291,7 +4660,7 @@ msgstr ""
 "レシピを提出したら、CIビルドが通過するのを待つことができます。 もしそれが通らず、その理由がわからない場合は、conda-"
 "forgeのメンテナーが解決してくれるでしょう。"
 
-#: ../../tutorials/publish-conda-forge.md:446
+#: ../../tutorials/publish-conda-forge.md:451
 msgid ""
 "Once your recipe is built and merged, the conda team will create a new "
 "package repository for you similar to [this one for the GemGIS "
@@ -4301,7 +4670,7 @@ msgstr ""
 "[GemGISパッケージ用のリポジトリ](https://github.com/conda-forge/gemgis-feedstock) "
 "と同じような新しいパッケージリポジトリを作成します。"
 
-#: ../../tutorials/publish-conda-forge.md:448
+#: ../../tutorials/publish-conda-forge.md:453
 msgid ""
 "<i class=\"fa-solid fa-wand-magic-sparkles\"></i> Congratulations - you "
 "have added your package to conda-forge.<i class=\"fa-solid fa-wand-magic-"
@@ -4310,17 +4679,17 @@ msgstr ""
 "<i class=\"fa-solid fa-wand-magic-sparkles\"></i> おめでとう - パッケージをconda-"
 "forgeに追加しました。<i class=\"fa-solid fa-wand-magic-sparkles\"></i>"
 
-#: ../../tutorials/publish-conda-forge.md:450
+#: ../../tutorials/publish-conda-forge.md:455
 msgid ""
 "The last part of this process is maintaining the repository. We cover "
 "that next."
 msgstr "このプロセスの最後の部分は、リポジトリの管理です。次はそれを取り上げます。"
 
-#: ../../tutorials/publish-conda-forge.md:453
+#: ../../tutorials/publish-conda-forge.md:458
 msgid "Maintaining your conda-forge feedstock"
 msgstr "conda-forgeフィードストックのメンテナンス"
 
-#: ../../tutorials/publish-conda-forge.md:455
+#: ../../tutorials/publish-conda-forge.md:460
 msgid ""
 "Every time you create a new release on PyPI, the conda-forge bots will "
 "recognize the release and will rebuild the newly released version of your"
@@ -4329,7 +4698,7 @@ msgstr ""
 "PyPIで新しいリリースを作成するたびに、conda-"
 "forgeボットはそのリリースを認識し、新しくリリースされたバージョンのパッケージをリビルドします。このプロセスには1-2日かかることがありますので、気長にお待ちください。"
 
-#: ../../tutorials/publish-conda-forge.md:457
+#: ../../tutorials/publish-conda-forge.md:462
 msgid ""
 "Once the conda-forge build is complete, all of the maintainers of your "
 "conda-forge feedstock will get a ping on GitHub that a new pull request "
@@ -4338,7 +4707,7 @@ msgstr ""
 "conda-forgeのビルドが完了すると、 conda-forge feedstock "
 "の全メンテナにGitHubで新しいプルリクエストが開かれたことが通知されます。"
 
-#: ../../tutorials/publish-conda-forge.md:459
+#: ../../tutorials/publish-conda-forge.md:464
 msgid ""
 "Review the pull request. If all tests are passing, you can merge it. "
 "Shortly after merging your pull request, the conda-forge release will be "
@@ -4347,39 +4716,39 @@ msgstr ""
 "プルリクエストを確認します。すべてのテストがパスすれば、マージできます。あなたのプルリクエストをマージした直後に、conda-forge "
 "リリースが利用可能になり、ユーザーはインストールできるようになります:"
 
-#: ../../tutorials/publish-conda-forge.md:461
+#: ../../tutorials/publish-conda-forge.md:466
 msgid "`conda install -c conda-forge yourpackage`"
 msgstr "`conda install -c conda-forge yourpackage`"
 
-#: ../../tutorials/publish-conda-forge.md:465
+#: ../../tutorials/publish-conda-forge.md:470
 msgid "If you have walked through this entire tutorial series you will now:"
 msgstr "このチュートリアルシリーズを一通りご覧になった方なら、もうお分かりでしょう:"
 
-#: ../../tutorials/publish-conda-forge.md:467
+#: ../../tutorials/publish-conda-forge.md:472
 msgid "Understand [what a Python package is ](intro.md)"
 msgstr "[Pythonパッケージとは何か](intro.md) を理解する"
 
-#: ../../tutorials/publish-conda-forge.md:468
+#: ../../tutorials/publish-conda-forge.md:473
 msgid ""
-"Know how to [make your code installable](create-python-package.md) into Python"
-" environments"
+"Know how to [make your code installable](create-python-package.md) into "
+"Python environments"
 msgstr "[コードをPython環境にインストール可能にする方法](create-python-package.md) を知る"
 
-#: ../../tutorials/publish-conda-forge.md:469
+#: ../../tutorials/publish-conda-forge.md:474
 msgid ""
 "Know how to create a `pyproject.toml` file, a `README` file, and a "
 "`LICENSE` and code of conduct."
 msgstr "`pyproject.toml` ファイル、 `README` ファイル、 `LICENSE` と行動規範の作成方法を知っている。"
 
-#: ../../tutorials/publish-conda-forge.md:470
+#: ../../tutorials/publish-conda-forge.md:475
 msgid "Know how to [publish your package to PyPI](publish-pypi.md) and"
 msgstr "[パッケージをPyPIに公開する](publish-pypi.md) 方法と"
 
-#: ../../tutorials/publish-conda-forge.md:471
+#: ../../tutorials/publish-conda-forge.md:476
 msgid "Know how to publish your package to conda-forge"
 msgstr "パッケージをconda-forgeに公開する方法を知ります"
 
-#: ../../tutorials/publish-conda-forge.md:473
+#: ../../tutorials/publish-conda-forge.md:478
 msgid ""
 "The above are the basic steps that you need to take to create and publish"
 " a Python package. In a future tutorial series we will cover that basics "
@@ -4388,19 +4757,19 @@ msgstr ""
 "以上が、Pythonパッケージを作成して公開するために必要な基本的な手順です。 "
 "今後のチュートリアルシリーズでは、パッケージのメンテナンスの基本について取り上げます。"
 
-#: ../../tutorials/publish-conda-forge.md:477
+#: ../../tutorials/publish-conda-forge.md:482
 msgid "[Grayskull blogpost](https://conda-forge.org/blog/2020/03/05/grayskull/)"
 msgstr "[Grayskull blogpost](https://conda-forge.org/blog/2020/03/05/grayskull/)"
 
-#: ../../tutorials/publish-conda-forge.md:478
+#: ../../tutorials/publish-conda-forge.md:483
 msgid "[Pipx documentation](https://pipx.pypa.io/stable/)"
 msgstr "[Pipx documentation](https://pipx.pypa.io/stable/)"
 
-#: ../../tutorials/publish-pypi.md:1
+#: ../../tutorials/publish-pypi.md:6
 msgid "Publish your Python package to PyPI"
 msgstr "PythonパッケージをPyPIに公開する"
 
-#: ../../tutorials/publish-pypi.md:4
+#: ../../tutorials/publish-pypi.md:9
 msgid ""
 "Make sure they add /dist to their .gitignore file. We have not discussed "
 "GitHub workflows anywhere yet. Where does that fit?"
@@ -4408,37 +4777,37 @@ msgstr ""
 ".gitignoreファイルに/distが追加されていることを確認してください。GitHubのワークフローについては、まだどこにも触れていません。"
 " それはどこに当てはまりますか？"
 
-#: ../../tutorials/publish-pypi.md:8
+#: ../../tutorials/publish-pypi.md:13
 msgid "In the previous Python packaging lessons, you've learned:"
 msgstr "これまでのPythonパッケージングレッスンで、あなたは次のことを学びました:"
 
-#: ../../tutorials/publish-pypi.md:10
+#: ../../tutorials/publish-pypi.md:15
 msgid "What a Python package is"
 msgstr "Pythonパッケージとは"
 
-#: ../../tutorials/publish-pypi.md:11
+#: ../../tutorials/publish-pypi.md:16
 msgid "How to make your code installable."
 msgstr "コードをインストール可能にします。"
 
-#: ../../tutorials/publish-pypi.md:19
+#: ../../tutorials/publish-pypi.md:24
 msgid "Build your package's source (sdist) and wheel distributions"
 msgstr "パッケージのソース (sdist) とwheelディストリビューションをビルドします。"
 
-#: ../../tutorials/publish-pypi.md:20
+#: ../../tutorials/publish-pypi.md:25
 msgid "Setup an account on TestPyPI (the process is similar for PyPI)"
 msgstr "TestPyPIにアカウントを設定する（PyPIでも同様の手順です）"
 
-#: ../../tutorials/publish-pypi.md:21
+#: ../../tutorials/publish-pypi.md:26
 msgid "Publish your package to TestPyPI and PyPI"
 msgstr "パッケージをTestPyPIとPyPIに公開する"
 
-#: ../../tutorials/publish-pypi.md:23
+#: ../../tutorials/publish-pypi.md:28
 msgid ""
 "You will do all of your development work in this lesson using "
 "[Hatch](https://hatch.pypa.io/latest/)."
 msgstr "このレッスンでは、すべての開発作業を [Hatch](https://hatch.pypa.io/latest/) を使って行います。"
 
-#: ../../tutorials/publish-pypi.md:25
+#: ../../tutorials/publish-pypi.md:30
 msgid ""
 "Once your package is on PyPI you can publish it to conda-forge (which is "
 "a channel on conda) using "
@@ -4447,13 +4816,13 @@ msgstr ""
 "パッケージがPyPIに載ったら、 [Grayskull](https://conda.github.io/grayskull/) "
 "を使ってconda-forge (condaのチャンネルです) に公開できます。"
 
-#: ../../tutorials/publish-pypi.md:28
+#: ../../tutorials/publish-pypi.md:33
 msgid ""
 "You will learn how to publish to conda-forge in the [next lesson"
 "](publish-conda-forge)."
 msgstr "conda-forgeに公開する方法は [次のレッスン](publish-conda-forge) で学びます。"
 
-#: ../../tutorials/publish-pypi.md:32
+#: ../../tutorials/publish-pypi.md:37
 msgid ""
 "Graphic showing the high level packaging workflow. On the left you see a "
 "graphic with code, metadata and tests in it. Those items all go into your"
@@ -4470,7 +4839,7 @@ msgstr ""
 "。PyPIからconda-forgeに接続することで、PyPIからconda-"
 "forgeにディストリビューションを送る自動ビルドを行うことができるからです。"
 
-#: ../../tutorials/publish-pypi.md:34
+#: ../../tutorials/publish-pypi.md:39
 msgid ""
 "You need to build your Python package in order to publish it to PyPI (or "
 "Conda). The build process organizes your code and metadata into a "
@@ -4480,17 +4849,17 @@ msgstr ""
 "PythonパッケージをPyPI（またはConda）に公開するには、ビルドする必要があります。ビルドプロセスは、あなたのコードとメタデータをPyPIにアップロードできる配布フォーマットに整理し、その後ユーザーがダウンロードしてインストールできるようにします。"
 " "
 
-#: ../../tutorials/publish-pypi.md:37
+#: ../../tutorials/publish-pypi.md:42
 msgid "TestPyPI vs PyPI"
 msgstr "TestPyPI vs PyPI"
 
-#: ../../tutorials/publish-pypi.md:39
+#: ../../tutorials/publish-pypi.md:44
 msgid ""
 "There are two repositories associated with PyPI to which you can upload "
 "your Python package."
 msgstr "PyPIには、Pythonパッケージをアップロードできる2つのリポジトリがあります。"
 
-#: ../../tutorials/publish-pypi.md:42
+#: ../../tutorials/publish-pypi.md:47
 msgid ""
 "**[TestPyPI](https://test.pypi.org):** TestPyPI is a package repository "
 "provided by PyPI that you can use for testing that your package can be "
@@ -4501,7 +4870,7 @@ msgstr ""
 "**[TestPyPI](https://test.pypi.org):** "
 "TestPyPIはPyPIが提供するパッケージリポジトリで、あなたのパッケージが正しくアップロード、ダウンロード、インストールできるかをテストするために使用できます。これは、実際のPyPIサービスに不完全なパッケージを公開することなく、パッケージを公開する方法を学び、練習するのに最適な場所です。"
 
-#: ../../tutorials/publish-pypi.md:43
+#: ../../tutorials/publish-pypi.md:48
 msgid ""
 "**[PyPI](https://pypi.org):** This is the live, production PyPI "
 "repository where you can officially publish your Python package, and from"
@@ -4515,17 +4884,17 @@ msgstr ""
 "PyPIにパッケージを公開するのは、それが他の人に使われる準備ができたとき、そして/またはそれがあなたが保守するパッケージになると確信したときだけにしてください。"
 " PyPIはPythonパッケージの公開方法を学ぶ練習の場ではありません。"
 
-#: ../../tutorials/publish-pypi.md:45
+#: ../../tutorials/publish-pypi.md:50
 msgid ""
 "The steps for publishing on TestPyPI vs. PyPI are similar with the "
 "exception of a different url. We will point out where they differ."
 msgstr "TestPyPIとPyPIで公開する手順は、URLが異なることを除いて似ています。両者の相違点を指摘します。"
 
-#: ../../tutorials/publish-pypi.md:48
+#: ../../tutorials/publish-pypi.md:53
 msgid "4 Steps for publishing a Python package on TestPyPI (or PyPI)"
 msgstr "TestPyPI (またはPyPI)でPythonパッケージを公開するための4つのステップ"
 
-#: ../../tutorials/publish-pypi.md:50
+#: ../../tutorials/publish-pypi.md:55
 msgid ""
 "In this lesson you will learn how to publish your package to TestPyPI "
 "using [Hatch](https://hatch.pypa.io/latest/). There are 4 things that you"
@@ -4535,11 +4904,11 @@ msgstr ""
 "を使ってパッケージをTestPyPIに公開する方法を学びます。 Pythonパッケージを公開するために必要なことは4つあります: "
 "TestPyPIでは。必要なのは:"
 
-#: ../../tutorials/publish-pypi.md:55
+#: ../../tutorials/publish-pypi.md:60
 msgid "**Create a package development environment**"
 msgstr "**パッケージ開発環境の構築**"
 
-#: ../../tutorials/publish-pypi.md:56
+#: ../../tutorials/publish-pypi.md:61
 msgid ""
 "[**Build your package using `hatch build`**](../package-structure-code"
 "/python-package-distribution-files-sdist-wheel). Building a package is "
@@ -4552,7 +4921,7 @@ msgstr ""
 "パッケージのビルドは、コードを2種類の配布ファイルに変換するプロセスです: sdistとwheel。wheel配布ファイルは、あなたのパッケージを"
 " `pip install` するユーザーにとって特に重要です。"
 
-#: ../../tutorials/publish-pypi.md:57
+#: ../../tutorials/publish-pypi.md:62
 msgid ""
 "**Create an account on TestPyPI (or PyPI)**: You will need to create a "
 "TestPyPI account and associated token which provides permissions for you "
@@ -4563,11 +4932,11 @@ msgstr ""
 "TestPyPIアカウントと、パッケージをアップロードするためのパーミッションを提供する関連トークンを作成する必要があります。 "
 "後でパッケージをPyPIに公開するときは、別のPyPIアカウントとトークンが必要になります。"
 
-#: ../../tutorials/publish-pypi.md:58
+#: ../../tutorials/publish-pypi.md:63
 msgid "**Publish to TestPyPI using `hatch publish`**"
 msgstr "** `hatch publish` を使用してTestPyPIにパブリッシュする**"
 
-#: ../../tutorials/publish-pypi.md:60
+#: ../../tutorials/publish-pypi.md:65
 msgid ""
 "In a future lesson, you will learn how to create an automated GitHub "
 "Actions workflow that publishes an updated version of your package to "
@@ -4576,11 +4945,11 @@ msgstr ""
 "今後のレッスンでは、GitHub リリースを作成するたびにパッケージの更新版を PyPI に公開する、自動化された GitHub Actions "
 "のワークフローを作成する方法を学びます。"
 
-#: ../../tutorials/publish-pypi.md:64
+#: ../../tutorials/publish-pypi.md:69
 msgid "Learn more about building Python packages in our guide"
 msgstr "Pythonパッケージのビルドについては、ガイドを参照してください。"
 
-#: ../../tutorials/publish-pypi.md:68
+#: ../../tutorials/publish-pypi.md:73
 msgid ""
 "[Learn more about what building a Python package is](../package-"
 "structure-code/python-package-distribution-files-sdist-wheel)"
@@ -4588,13 +4957,13 @@ msgstr ""
 "[Pythonパッケージのビルドについてもっと知る](../package-structure-code/python-package-"
 "distribution-files-sdist-wheel)"
 
-#: ../../tutorials/publish-pypi.md:69
+#: ../../tutorials/publish-pypi.md:74
 msgid ""
 "[Learn more about the package distribution file that PyPI needs called "
 "the wheel](#python-wheel)"
 msgstr "[PyPIが必要とするwheelと呼ばれるパッケージ配布ファイルについての詳細はこちら](#python-wheel)"
 
-#: ../../tutorials/publish-pypi.md:70
+#: ../../tutorials/publish-pypi.md:75
 msgid ""
 "[Learn more about the package distribution file that conda-forge will "
 "need on PyPI called the sdist (source distribution)](#python-source-"
@@ -4603,26 +4972,26 @@ msgstr ""
 "[PyPIでconda-forgeが必要とするsdist (ソースディストリビューション) "
 "と呼ばれるパッケージ配布ファイルについてはこちらを参照してください](#python-source-distribution)"
 
-#: ../../tutorials/publish-pypi.md:73
+#: ../../tutorials/publish-pypi.md:78
 msgid "Step 1: Create a Python package development environment"
 msgstr "ステップ1: Pythonパッケージ開発環境の構築"
 
-#: ../../tutorials/publish-pypi.md:75
+#: ../../tutorials/publish-pypi.md:80
 msgid ""
 "The first step in building your package is to create a development "
 "environment. The Python environment will contain all of the dependencies "
 "needed to both install and work on your package."
 msgstr "パッケージ構築の最初のステップは、開発環境を作ることだ。Python環境には、あなたのパッケージのインストールと作業の両方に必要な依存関係がすべて含まれています。"
 
-#: ../../tutorials/publish-pypi.md:77
+#: ../../tutorials/publish-pypi.md:82
 msgid "Use Hatch to create your environment."
 msgstr "Hatchを使って環境を整えましょう。"
 
-#: ../../tutorials/publish-pypi.md:85
+#: ../../tutorials/publish-pypi.md:90
 msgid "Then view all of the current environments that hatch has access to:"
 msgstr "次に、Hatchがアクセスできる現在の環境をすべて表示します:"
 
-#: ../../tutorials/publish-pypi.md:97
+#: ../../tutorials/publish-pypi.md:102
 msgid ""
 "Then activate the environment. Note that when you call a shell from a "
 "Hatch environment, it will automatically install your package into the "
@@ -4631,19 +5000,19 @@ msgstr ""
 "そして環境をアクティブにします。 "
 "Hatch環境からシェルを呼び出すと、開発モードまたは編集可能モードで、あなたのパッケージが自動的に環境にインストールされることに注意してください。"
 
-#: ../../tutorials/publish-pypi.md:107
+#: ../../tutorials/publish-pypi.md:112
 msgid "View what's in the environment using `pip list`:"
 msgstr "`pip list` を使って環境にあるものを見ます:"
 
-#: ../../tutorials/publish-pypi.md:123
+#: ../../tutorials/publish-pypi.md:128
 msgid "At any time you can exit the environment using `exit`."
 msgstr "いつでも `exit` を使って環境を終了することができます。"
 
-#: ../../tutorials/publish-pypi.md:137
+#: ../../tutorials/publish-pypi.md:142
 msgid "Hatch and environments"
 msgstr "Hatchと環境"
 
-#: ../../tutorials/publish-pypi.md:139
+#: ../../tutorials/publish-pypi.md:144
 msgid ""
 "Behind the scenes when hatch creates a new virtual environment, by "
 "default it uses venv[^venv] which is the default environment management "
@@ -4652,15 +5021,15 @@ msgstr ""
 "hatchが新しい仮想環境を作るときの裏側では、デフォルトではPythonのインストールに付属しているデフォルトの環境管理ツールである "
 "venv[^venv] を使います。"
 
-#: ../../tutorials/publish-pypi.md:142
+#: ../../tutorials/publish-pypi.md:147
 msgid "Hatch will:"
 msgstr "Hatch は:"
 
-#: ../../tutorials/publish-pypi.md:144
+#: ../../tutorials/publish-pypi.md:149
 msgid "Create a new virtualenv (venv) that is located on your computer."
 msgstr "コンピュータ上に新しい仮想環境 (venv) を作成します。"
 
-#: ../../tutorials/publish-pypi.md:145
+#: ../../tutorials/publish-pypi.md:150
 msgid ""
 "Install your package into the environment in editable mode (similar to "
 "`python -m pip install -e`). This means it installs both your project and"
@@ -4669,11 +5038,11 @@ msgstr ""
 "編集可能モードでパッケージを環境にインストールします ( `python -m pip install -e` と同様) 。 "
 "これは、pyproject.tomlファイルで宣言されているように、あなたのプロジェクトとプロジェクトの依存関係の両方をインストールすることを意味します。"
 
-#: ../../tutorials/publish-pypi.md:147
+#: ../../tutorials/publish-pypi.md:152
 msgid "Step 2: Build your package's sdist and wheel distributions"
 msgstr "ステップ 2: パッケージのsdistとwheelディストリビューションをビルドする"
 
-#: ../../tutorials/publish-pypi.md:149
+#: ../../tutorials/publish-pypi.md:154
 msgid ""
 "Once you have your development environment setup, you are ready to build "
 "your package using Hatch. Remember that building is the process of "
@@ -4682,7 +5051,7 @@ msgstr ""
 "開発環境のセットアップが完了したら、Hatchを使ってパッケージをビルドする準備ができました。 "
 "ビルドとは、Pythonパッケージのファイル構造を2つの配布ファイルにするプロセスであることを覚えておいてください:"
 
-#: ../../tutorials/publish-pypi.md:151
+#: ../../tutorials/publish-pypi.md:156
 msgid ""
 "The [wheel distribution](#python-wheel) is a pre-built version of your "
 "package. It useful for users as it can be directly installed using a tool"
@@ -4691,7 +5060,7 @@ msgstr ""
 "[wheelディストリビューション](#python-wheel) は、あなたのパッケージのビルド済みバージョンです。 `pip` "
 "などのツールを使って直接インストールできるので、ユーザーにとっては便利です。このファイルの拡張子は `.whl` です。"
 
-#: ../../tutorials/publish-pypi.md:152
+#: ../../tutorials/publish-pypi.md:157
 msgid ""
 "The [source distribution](#python-source-distribution) contains the files"
 " that make up your package in an unbuilt format. This file will have the "
@@ -4700,28 +5069,29 @@ msgstr ""
 "[ソースディストリビューション](#python-source-distribution) "
 "には、あなたのパッケージを構成するファイルが、ビルドされていない状態で含まれています。 このファイルの拡張子は `.tar.gz` となります。"
 
-#: ../../tutorials/publish-pypi.md:154
+#: ../../tutorials/publish-pypi.md:159
+#, fuzzy
 msgid ""
 "You will use Hatch as a **Front end** tool that builds your package's "
 "sdist and wheel using the [hatchling](https://hatch.pypa.io/latest/) "
 "build back-end. The hatchling build back-end is used because you declared"
-" it in your pyproject.toml file in the [previous lesson](installable-"
-"code)."
+" it in your pyproject.toml file in the [previous lesson](create-python-"
+"package)."
 msgstr ""
 "Hatchを **フロントエンド** "
 "ツールとして使い、hatchlingビルドバックエンドを使ってパッケージのsdistとwheelをビルドします。 "
 "[hatchling](https://hatch.pypa.io/latest/) ビルドバックエンドを使用するのは、 [前のレッスン"
 "](create-python-package)でpyproject.tomlファイルで宣言したからです。"
 
-#: ../../tutorials/publish-pypi.md:158
+#: ../../tutorials/publish-pypi.md:163
 msgid "To build your package run `hatch build`:"
 msgstr "パッケージをビルドするには `hatch build` を実行します:"
 
-#: ../../tutorials/publish-pypi.md:169
+#: ../../tutorials/publish-pypi.md:174
 msgid "Learn more about building a Python package"
 msgstr "Pythonパッケージのビルドについて"
 
-#: ../../tutorials/publish-pypi.md:171
+#: ../../tutorials/publish-pypi.md:176
 msgid ""
 "You can learn more about building in the [build page of our packaging "
 "guide](../package-structure-code/python-package-distribution-files-sdist-"
@@ -4730,7 +5100,7 @@ msgstr ""
 "ビルドについては、 [パッケージングガイドのビルドのページ](../package-structure-code/python-package-"
 "distribution-files-sdist-wheel) で詳しく説明しています。"
 
-#: ../../tutorials/publish-pypi.md:175
+#: ../../tutorials/publish-pypi.md:180
 msgid ""
 "The sdist is important if you wish to [publish your package to conda-"
 "forge](publish-conda-forge). You will learn about this in a later lesson."
@@ -4738,7 +5108,7 @@ msgstr ""
 "sdistは、conda-forgeにパッケージを [公開する場合に重要です](publish-conda-forge) "
 "。これについては後のレッスンで学びます。"
 
-#: ../../tutorials/publish-pypi.md:179
+#: ../../tutorials/publish-pypi.md:184
 msgid ""
 "➜ hatch build ────────────────────────────────────── sdist "
 "────────────────────────────────────── dist/pyospackage-0.1.tar.gz "
@@ -4752,7 +5122,7 @@ msgstr ""
 "────────────────────────────────────── dist/pyospackage-0.1-py3-none-"
 "any.whl"
 
-#: ../../tutorials/publish-pypi.md:186
+#: ../../tutorials/publish-pypi.md:191
 msgid ""
 "<i class=\"fa-solid fa-wand-magic-sparkles\"></i> Congratulations - "
 "you've created your Python package distribution files <i class=\"fa-solid"
@@ -4762,7 +5132,7 @@ msgstr ""
 "Pythonパッケージの配布ファイルを作成しました <i class=\"fa-solid fa-wand-magic-"
 "sparkles\"></i>"
 
-#: ../../tutorials/publish-pypi.md:188
+#: ../../tutorials/publish-pypi.md:193
 msgid ""
 "You've now built your Python package and created your package "
 "distribution files. The next step is to setup your account on TestPyPI so"
@@ -4771,11 +5141,11 @@ msgstr ""
 "これで Python "
 "パッケージをビルドし、パッケージ配布ファイルを作成しました。次のステップは、TestPyPIのアカウントをセットアップして、パッケージを公開できるようにすることです。"
 
-#: ../../tutorials/publish-pypi.md:191
+#: ../../tutorials/publish-pypi.md:196
 msgid "Step 3. Setup your TestPyPI account"
 msgstr "ステップ 3. TestPyPIアカウントをセットアップする"
 
-#: ../../tutorials/publish-pypi.md:193
+#: ../../tutorials/publish-pypi.md:198
 msgid ""
 "Next, you'll setup an account on TestPyPI. Remember that you are using "
 "TestPyPI here instead of the real PyPI as a way to safely learn how to "
@@ -4785,11 +5155,11 @@ msgstr ""
 "次に、TestPyPIのアカウントをセットアップします。 TestPyPIは本物のPyPIではなく、パッケージが準備できる前に誤ってパッケージを "
 "\"リリース\" することなく、安全にパッケージを公開する方法を学ぶ方法として使用していることを忘れないでください。"
 
-#: ../../tutorials/publish-pypi.md:197
+#: ../../tutorials/publish-pypi.md:202
 msgid "TestPyPI vs. PyPI"
 msgstr "TestPyPI vs. PyPI"
 
-#: ../../tutorials/publish-pypi.md:198
+#: ../../tutorials/publish-pypi.md:203
 msgid ""
 "If you have a package that you are confident belongs on PyPI, all of the "
 "steps below will also work for you. When you publish using Hatch, you "
@@ -4800,13 +5170,13 @@ msgstr ""
 "を使って公開する場合、TestPyPI に公開する `hatch publish -r test` ではなく、直接 PyPI に公開する "
 "`hatch publish` を呼び出します。"
 
-#: ../../tutorials/publish-pypi.md:201
+#: ../../tutorials/publish-pypi.md:206
 msgid ""
 "[Open up a web browser and go to the TestPyPI "
 "website](https://test.pypi.org/)."
 msgstr "[ウェブブラウザを開き、TestPyPIのウェブサイトにアクセスする](https://test.pypi.org/)."
 
-#: ../../tutorials/publish-pypi.md:202
+#: ../../tutorials/publish-pypi.md:207
 msgid ""
 "[Create an account](https://test.pypi.org/account/register/) if you don't"
 " already have one. Be sure to store your password in a safe place!"
@@ -4815,11 +5185,11 @@ msgstr ""
 "[アカウントを作成してください。](https://test.pypi.org/account/register/) "
 "パスワードは必ず安全な場所に保管してください！"
 
-#: ../../tutorials/publish-pypi.md:203
+#: ../../tutorials/publish-pypi.md:208
 msgid "Once you have an account setup, login to it."
 msgstr "アカウントを設定したら、ログインしてください。"
 
-#: ../../tutorials/publish-pypi.md:204
+#: ../../tutorials/publish-pypi.md:209
 msgid ""
 "Search on [https://test.pypi.org/](https://test.pypi.org/) (and also on "
 "[https://pypi.org/](https://pypi.org/)) to ensure that the package name "
@@ -4832,19 +5202,21 @@ msgstr ""
 "、選択したパッケージ名がすでに存在しないことを確認してください。 "
 "テスト用のpyosPackageを使う場合は、一意であることを保証するために、パッケージ名の最後に自分の名前かGitHubのユーザー名を追加することをお勧めします。"
 
-#: ../../tutorials/publish-pypi.md:206
+#: ../../tutorials/publish-pypi.md:211
 msgid "Example: `pyosPackage_yourNameHere`."
 msgstr "例: `pyosPackage_yourNameHere`."
 
-#: ../../tutorials/publish-pypi.md
-msgid "Renaming your project before publishing"
-msgstr "公開前にプロジェクト名を変更する"
+#: ../../tutorials/publish-pypi.md:213
+msgid ""
+"How to rename your Python package if the name is already taken in (test) "
+"PyPI"
+msgstr ""
 
-#: ../../tutorials/publish-pypi.md:211
+#: ../../tutorials/publish-pypi.md:217
 msgid "Required"
 msgstr "要件"
 
-#: ../../tutorials/publish-pypi.md:213
+#: ../../tutorials/publish-pypi.md:219
 msgid ""
 "Search your publishing location(s) to make sure your new name isn't taken"
 " ([TestPyPI](https://test.pypi.org/), [PyPI](https://pypi.org/), [conda-"
@@ -4854,7 +5226,7 @@ msgstr ""
 "([TestPyPI](https://test.pypi.org/), [PyPI](https://pypi.org/), [conda-"
 "forge](https://conda-forge.org/packages/))"
 
-#: ../../tutorials/publish-pypi.md:214
+#: ../../tutorials/publish-pypi.md:220
 msgid ""
 "Update the project name in your pyproject.toml file (e.g. `name = "
 "\"pyospackage_yourNameHere\"`)"
@@ -4862,39 +5234,39 @@ msgstr ""
 "pyproject.toml ファイルのプロジェクト名を更新します (e.g. `name = "
 "\"pyospackage_yourNameHere\"`)"
 
-#: ../../tutorials/publish-pypi.md:215
+#: ../../tutorials/publish-pypi.md:221
 msgid ""
 "Update the module folder name to be the same (e.g. "
 "`src/pyospackage_yourNameHere`)"
 msgstr "モジュールフォルダ名を同じに更新します (例: `src/pyospackage_yourNameHere`)"
 
-#: ../../tutorials/publish-pypi.md:216
+#: ../../tutorials/publish-pypi.md:222
 msgid "Rebuild your project (`hatch build`)"
 msgstr "プロジェクトの再ビルド (`hatch build`)"
 
-#: ../../tutorials/publish-pypi.md:217
+#: ../../tutorials/publish-pypi.md:223
 msgid "Publish your package to capture the name (continue this tutorial!)"
 msgstr "パッケージを公開して名前を取得する(このチュートリアルを続けましょう!)"
 
-#: ../../tutorials/publish-pypi.md:219
+#: ../../tutorials/publish-pypi.md:225
 msgid "Recommended"
 msgstr "おすすめ"
 
-#: ../../tutorials/publish-pypi.md:221
+#: ../../tutorials/publish-pypi.md:227
 msgid "Update the GitHub repository name to align with the new package name"
 msgstr "GitHubリポジトリ名を新しいパッケージ名に合わせて更新します"
 
-#: ../../tutorials/publish-pypi.md:222
+#: ../../tutorials/publish-pypi.md:228
 msgid ""
 "Update your local project folder to match the new package name (e.g. "
 "`pyospackage_yourNameHere/src`)"
 msgstr "ローカルのプロジェクトフォルダを新しいパッケージ名に合わせて更新します (例: `pyospackage_yourNameHere/src` ）。"
 
-#: ../../tutorials/publish-pypi.md:223
+#: ../../tutorials/publish-pypi.md:229
 msgid "Update mentions of your repository name in other files (e.g. `README.md`)"
 msgstr "他のファイル (例えば `README.md` ) のリポジトリ名の記述を更新します。"
 
-#: ../../tutorials/publish-pypi.md:227
+#: ../../tutorials/publish-pypi.md:233
 msgid ""
 "This is a screenshot of the TestPyPI website. At the top in the search "
 "bar, you can see the search for pyosPackage. The search return says there"
@@ -4903,18 +5275,18 @@ msgstr ""
 "これはTestPyPIのウェブサイトのスクリーンショットです。 検索バーの一番上にpyosPackageの検索があります。pyosPackage "
 "の検索結果はありませんでした。 probpackageのことですか？"
 
-#: ../../tutorials/publish-pypi.md:229
+#: ../../tutorials/publish-pypi.md:235
 msgid ""
 "Before you try to upload to TestPyPI, check to see if the name of your "
 "package is already taken. You can do that using the search box at the top"
 " of the TestPyPI website."
 msgstr "TestPyPIにアップロードしようとする前に、あなたのパッケージの名前がすでに使われていないか確認してください。TestPyPIのウェブサイトの上部にある検索ボックスを使って検索することができます。"
 
-#: ../../tutorials/publish-pypi.md:233
+#: ../../tutorials/publish-pypi.md:239
 msgid "Setup 2-factor (2FA) authentication"
 msgstr "2ファクタ (2FA) 認証の設定"
 
-#: ../../tutorials/publish-pypi.md:235
+#: ../../tutorials/publish-pypi.md:241
 msgid ""
 "2-factor authentication is a secure login process that allows you to use "
 "a backup device that only you can access to validate that the person "
@@ -4923,7 +5295,7 @@ msgid ""
 "account."
 msgstr "2要素認証とは、自分だけがアクセスできるバックアップデバイスを使用して、ログインする人が本当に自分であることを確認できる安全なログインプロセスです。他人がパスワードにアクセスし、あなたのアカウントにログインできるようにするパスワードフィッシングの問題に対処します。"
 
-#: ../../tutorials/publish-pypi.md:238
+#: ../../tutorials/publish-pypi.md:244
 msgid ""
 "This matters on PyPI because someone could login to your account and "
 "upload a version of your package that has security issues. These issues "
@@ -4933,17 +5305,17 @@ msgstr ""
 "なぜなら、誰かがあなたのアカウントにログインして、セキュリティ上の問題があるバージョンのパッケージをアップロードする可能性があるからです。 "
 "これらの問題は、そのバージョンのパッケージをダウンロードしてインストールする際に、すべてのユーザーに影響を与えます。"
 
-#: ../../tutorials/publish-pypi.md:240
+#: ../../tutorials/publish-pypi.md:246
 msgid ""
 "2-factor authentication is required for PyPI authentication as of 1 "
 "January 2024."
 msgstr "2024年1月1日からPyPI認証に2要素認証が必要になりました。"
 
-#: ../../tutorials/publish-pypi.md:244
+#: ../../tutorials/publish-pypi.md:250
 msgid "Step 4. Create a package upload token"
 msgstr "ステップ4. パッケージアップロードトークンを作成する"
 
-#: ../../tutorials/publish-pypi.md:246
+#: ../../tutorials/publish-pypi.md:252
 msgid ""
 "To upload your package to TestPyPI (or PyPI), you will need to create a "
 "token for your account first, and should then create a package-specific "
@@ -4953,11 +5325,11 @@ msgstr ""
 "パッケージをTestPyPI (またはPyPI) にアップロードするには、まず自分のアカウントのトークンを作成する必要があります。 "
 "(以前にこのステップを完了した場合は、パッケージを再度アップロードするときにトークンを再利用できます。)"
 
-#: ../../tutorials/publish-pypi.md:248
+#: ../../tutorials/publish-pypi.md:254
 msgid "Why create package-specific tokens?"
 msgstr "なぜパッケージ固有のトークンを作るのか？"
 
-#: ../../tutorials/publish-pypi.md:250
+#: ../../tutorials/publish-pypi.md:256
 msgid ""
 "It's ideal to create a package-specific token. When you create an "
 "account-wide token this allows anyone with access to the account to then "
@@ -4970,60 +5342,60 @@ msgstr ""
 " (またはPyPI) のすべてのプロジェクトにアクセスできるようになります。 "
 "パッケージ固有のトークンを作成することで、トークンのスコープを特定のパッケージのみに限定することができます。これは、特にパッケージ開発で他の人と共同作業する場合に、安全な設定方法です。"
 
-#: ../../tutorials/publish-pypi.md:253
+#: ../../tutorials/publish-pypi.md:259
 msgid "Follow the steps below to create your token."
 msgstr "以下の手順に従ってトークンを作成してください。"
 
-#: ../../tutorials/publish-pypi.md:255
+#: ../../tutorials/publish-pypi.md:261
 msgid "Login to TestPyPI and go to your account settings"
 msgstr "TestPyPIにログインし、アカウント設定に進みます。"
 
-#: ../../tutorials/publish-pypi.md:256
+#: ../../tutorials/publish-pypi.md:262
 msgid "Scroll down to the **API tokens** section"
 msgstr "**APIトークン** のセクションまでスクロールダウンしてください"
 
-#: ../../tutorials/publish-pypi.md:257
+#: ../../tutorials/publish-pypi.md:263
 msgid "Click on the **Add API Token** button"
 msgstr "**APIトークンの追加** ボタンをクリックしてください"
 
-#: ../../tutorials/publish-pypi.md:258
+#: ../../tutorials/publish-pypi.md:264
 msgid ""
 "If you are new to using TestPyPI and don't have any packages there yet, "
 "OR if you have other packages on TestPyPI but are uploading a new "
 "package, you will need to create an account-wide token."
 msgstr "TestPyPIを使うのが初めてで、まだパッケージを持っていない場合、またはTestPyPIに他のパッケージを持っていて、新しいパッケージをアップロードする場合、アカウントワイドトークンを作成する必要があります。"
 
-#: ../../tutorials/publish-pypi.md:259
+#: ../../tutorials/publish-pypi.md:265
 msgid ""
 "When you create your token, be sure to copy the token value and store it "
 "in a secure place before closing that browser."
 msgstr "トークンを作成したら、ブラウザを閉じる前に必ずトークンの値をコピーし、安全な場所に保管してください。"
 
-#: ../../tutorials/publish-pypi.md:261
+#: ../../tutorials/publish-pypi.md:267
 msgid "Your token should look something like this:"
 msgstr "あなたのトークンは次のようになるはずです:"
 
-#: ../../tutorials/publish-pypi.md:263
+#: ../../tutorials/publish-pypi.md:269
 msgid "`pypi-abunchofrandomcharactershere...`"
 msgstr "`pypi-abunchofrandomcharactershere...`"
 
-#: ../../tutorials/publish-pypi.md:265
+#: ../../tutorials/publish-pypi.md:271
 msgid "It should start with `pypi` followed by a dash and a bunch of characters."
 msgstr "`pypi` で始まり、ダッシュとたくさんの文字が続くはずです。"
 
-#: ../../tutorials/publish-pypi.md:267
+#: ../../tutorials/publish-pypi.md:273
 msgid "Upload to TestPyPI using Hatch"
 msgstr "Hatchを使用してTestPyPIにアップロードする"
 
-#: ../../tutorials/publish-pypi.md:269
+#: ../../tutorials/publish-pypi.md:275
 msgid "Once you have your token, you are ready to publish to TestPyPI."
 msgstr "トークンを取得したら、TestPyPIに公開する準備ができました。"
 
-#: ../../tutorials/publish-pypi.md:272
+#: ../../tutorials/publish-pypi.md:278
 msgid "Run `hatch publish -r test`"
 msgstr "`hatch publish -r test` を実行します"
 
-#: ../../tutorials/publish-pypi.md:274
+#: ../../tutorials/publish-pypi.md:280
 msgid ""
 "`-r` stands for repository. In this case because you are publishing to "
 "TestPyPI you will use `-r test`. Hatch will then ask for a username and "
@@ -5032,17 +5404,17 @@ msgstr ""
 "`-r` はリポジトリを意味します。この場合、TestPyPIに公開するため、 `-r test` を使用します。 "
 "その後、Hatchはユーザー名と認証情報を要求します。"
 
-#: ../../tutorials/publish-pypi.md:276
+#: ../../tutorials/publish-pypi.md:282
 msgid ""
 "Add the word `__token__` for your username. This tells TestPyPI that you "
 "are using a token value rather than a username."
 msgstr "ユーザー名には `__token__` を追加してください。これはTestPyPIに、ユーザ名ではなくトークンの値を使用していることを伝えます。"
 
-#: ../../tutorials/publish-pypi.md:277
+#: ../../tutorials/publish-pypi.md:283
 msgid "Paste your TestPyPI token value in at the `Enter your credentials` prompt:"
 msgstr "`Enter your credentials` プロンプトで TestPyPI トークンの値を貼り付けます:"
 
-#: ../../tutorials/publish-pypi.md:288
+#: ../../tutorials/publish-pypi.md:294
 msgid ""
 "If your credentials are valid, and you have already run `hatch build` and"
 " thus have your 2 distribution files in a `dist/` directory then Hatch "
@@ -5051,24 +5423,24 @@ msgstr ""
 "あなたの認証情報が有効で、すでに `hatch build` を実行し、2つの配布ファイルが `dist/` ディレクトリにあれば、Hatch "
 "はあなたのパッケージを TestPyPI に公開します。"
 
-#: ../../tutorials/publish-pypi.md:292
+#: ../../tutorials/publish-pypi.md:298
 msgid ""
 "Hatch also has a caching system so once you enter your credentials it "
 "will remember them."
 msgstr "Hatchにはキャッシュシステムもあり、一度入力した認証情報は記憶されます。"
 
-#: ../../tutorials/publish-pypi.md:295
+#: ../../tutorials/publish-pypi.md:301
 msgid "Install your package from TestPyPI"
 msgstr "TestPyPIからパッケージをインストールする"
 
-#: ../../tutorials/publish-pypi.md:297
+#: ../../tutorials/publish-pypi.md:303
 msgid ""
 "Once your package upload is complete, you can install it from TestPyPI. "
 "You can find the installation instructions on the TestPyPI landing page "
 "for your newly uploaded package."
 msgstr "パッケージのアップロードが完了したら、TestPyPIからインストールできます。新しくアップロードしたパッケージのTestPyPIランディングページにインストール手順があります。"
 
-#: ../../tutorials/publish-pypi.md:302
+#: ../../tutorials/publish-pypi.md:308
 msgid ""
 "A screenshot of the TestPyPI page for pyosPackage. It says pyosPackage "
 "0.1.0 at the top with the pip install instructions below. The landing "
@@ -5078,7 +5450,7 @@ msgstr ""
 "0.1.0と書いてあり、その下にpipのインストール方法が書いてあります。 "
 "パッケージのランディングページには、パッケージのREADMEファイルからの情報があります。"
 
-#: ../../tutorials/publish-pypi.md:304
+#: ../../tutorials/publish-pypi.md:310
 msgid ""
 "This is an example landing page for the pyosPackage that was just "
 "uploaded. Notice at the top of the page there are instructions for how to"
@@ -5089,7 +5461,7 @@ msgstr ""
 "ページの一番上に、TestPyPIからパッケージをインストールする方法の説明があります。 "
 "そのコードをコピーし、それを使ってTestPyPIからパッケージをローカルにインストールするだけです。"
 
-#: ../../tutorials/publish-pypi.md:307
+#: ../../tutorials/publish-pypi.md:313
 msgid ""
 "As an example, [check out our pyOpenSci pyosPackage landing page on "
 "TestPyPI](https://test.pypi.org/project/pyosPackage/). Notice that the "
@@ -5100,11 +5472,11 @@ msgstr ""
 "pyosPackageランディングページをご覧ください](https://test.pypi.org/project/pyosPackage/) "
 "。 このページには、現在のパッケージのバージョンに関する情報と、次のようなインストール手順が記載されていることに注意してください:"
 
-#: ../../tutorials/publish-pypi.md:311
+#: ../../tutorials/publish-pypi.md:317
 msgid "`python -m pip install -i https://test.pypi.org/simple/ pyosPackage`"
 msgstr "`python -m pip install -i https://test.pypi.org/simple/ pyosPackage`"
 
-#: ../../tutorials/publish-pypi.md:314
+#: ../../tutorials/publish-pypi.md:320
 msgid ""
 "Publishing to TestPyPI vs PyPI While you can install from TestPyPI it's "
 "not recommended that you publish to TestPyPI as a permanent way to "
@@ -5117,17 +5489,17 @@ msgstr ""
 "TestPyPIへの公開 vs PyPI "
 "TestPyPIからインストールすることはできますが、パッケージをインストールする恒久的な方法としてTestPyPIに公開することはお勧めしません。なぜなら、TestPyPIは時間が経つとアカウントを削除するかもしれないからです。TestPyPIは、パッケージを公開し、インストールプロセスをテストする方法を学ぶのに最適な場所です。しかし、最終的なゴールは、ワークフローを把握し、パッケージがデプロイできる状態になったら、PyPIに公開することです。"
 
-#: ../../tutorials/publish-pypi.md:318
+#: ../../tutorials/publish-pypi.md:324
 msgid "Time to install your package"
 msgstr "パッケージのインストール"
 
-#: ../../tutorials/publish-pypi.md:320
+#: ../../tutorials/publish-pypi.md:326
 msgid ""
 "On your computer, activate the development environment that you wish to "
 "install your newly published package in."
 msgstr "お使いのコンピューターで、新しく公開するパッケージをインストールする開発環境をアクティブにします。"
 
-#: ../../tutorials/publish-pypi.md:322
+#: ../../tutorials/publish-pypi.md:328
 msgid "Run the installation instructions for your package from TestPyPI."
 msgstr "TestPyPIからパッケージのインストール手順を実行します。"
 
@@ -5139,11 +5511,11 @@ msgstr "Conda"
 msgid "venv Mac / Linux"
 msgstr "venv Mac / Linux"
 
-#: ../../tutorials/publish-pypi.md:346
+#: ../../tutorials/publish-pypi.md:352
 msgid "The value of end-to-end tools like hatch, flit and poetry"
 msgstr "hatch、flit、poetryといったエンドツーエンドツールの価値"
 
-#: ../../tutorials/publish-pypi.md:347
+#: ../../tutorials/publish-pypi.md:353
 msgid ""
 "In this lesson you are using Hatch and hatchling to create, build and "
 "publish your Python package. [Click here to learn about other packaging "
@@ -5154,7 +5526,7 @@ msgstr ""
 "[エコシステム内の他のパッケージングツールについては、こちらをクリックしてください。](../package-structure-code"
 "/python-package-build-tools.md)"
 
-#: ../../tutorials/publish-pypi.md:351
+#: ../../tutorials/publish-pypi.md:357
 msgid ""
 "teach them to setup trusted publisher for actions... in the actions "
 "lesson https://pypi.org/help/#twofa"
@@ -5162,7 +5534,7 @@ msgstr ""
 "actionsのレッスン https://pypi.org/help/#twofa "
 "で、信頼できるactionsのパブリッシャーを設定することを教えます..."
 
-#: ../../tutorials/publish-pypi.md:354
+#: ../../tutorials/publish-pypi.md:360
 msgid ""
 "from PyPI: https://pypi.org/help/#apitoken - You can create a token for "
 "an entire PyPI account, in which case, the token will work for all "
@@ -5173,17 +5545,17 @@ msgstr ""
 "PyPIアカウント全体に対してトークンを作成することができ、その場合、トークンはそのアカウントに関連付けられているすべてのプロジェクトで動作します。"
 " また、トークンの範囲を特定のプロジェクトに限定することもできます。"
 
-#: ../../tutorials/publish-pypi.md:357
+#: ../../tutorials/publish-pypi.md:363
 msgid "Package-specific token vs trusted publisher"
 msgstr "パッケージ固有のトークンと信頼できるパブリッシャー"
 
-#: ../../tutorials/publish-pypi.md:359
+#: ../../tutorials/publish-pypi.md:365
 msgid ""
 "For long run maintenance of your package, you have two options related to"
 " PyPI publication."
 msgstr "パッケージの長期的なメンテナンスのために、PyPI公開に関する2つのオプションがあります。"
 
-#: ../../tutorials/publish-pypi.md:362
+#: ../../tutorials/publish-pypi.md:368
 msgid ""
 "You can create a package-specific token which you will use to publish "
 "your package (manually) to PyPI. This is a great option if you don't wish"
@@ -5192,7 +5564,7 @@ msgstr ""
 "PyPIにパッケージを (手動で) "
 "公開する際に使用する、パッケージ固有のトークンを作成することができます。これはPyPI公開のワークフローを自動化したくない場合に最適なオプションです。"
 
-#: ../../tutorials/publish-pypi.md:363
+#: ../../tutorials/publish-pypi.md:369
 msgid ""
 "You can also create an automated publication workflow on GitHub using "
 "GitHub Actions. This is a great way to make the publication process "
@@ -5206,64 +5578,64 @@ msgstr ""
 "この場合、トークンのことは気にせず、リリース時にパッケージを公開する GitHub Actionsを設定することをお勧めします。 "
 "その後、PyPIで \"trusted publisher\" ワークフローを作成することができます。"
 
-#: ../../tutorials/publish-pypi.md:365
+#: ../../tutorials/publish-pypi.md:371
 msgid ""
 "You will learn how to create the automated trusted publisher workflow in "
 "a followup lesson."
 msgstr "自動化された信頼できるパブリッシャーワークフローの作成方法については、次のレッスンで学びます。"
 
-#: ../../tutorials/publish-pypi.md:368
+#: ../../tutorials/publish-pypi.md:374
 msgid "OPTIONAL: If you want to use a manual token-based publication workflow"
 msgstr "オプション: 手動トークンベースの発行ワークフローを使用する場合"
 
-#: ../../tutorials/publish-pypi.md:370
+#: ../../tutorials/publish-pypi.md:376
 msgid ""
 "If you plan to use your token regularly to publish to PyPI, we strongly "
 "recommend going through the above steps again to create a token specific "
 "to your new package."
 msgstr "トークンを定期的に使ってPyPIに公開する予定がある場合、新しいパッケージに固有のトークンを作成するために、上記の手順をもう一度行うことを強くお勧めします。"
 
-#: ../../tutorials/publish-pypi.md:373
+#: ../../tutorials/publish-pypi.md:379
 msgid "To do this:"
 msgstr "そのためには:"
 
-#: ../../tutorials/publish-pypi.md:374
+#: ../../tutorials/publish-pypi.md:380
 msgid "Go to TestPyPI."
 msgstr "TestPyPIに行きます。"
 
-#: ../../tutorials/publish-pypi.md:375
+#: ../../tutorials/publish-pypi.md:381
 msgid "Navigate to the \"Your Projects\" section of your account"
 msgstr "アカウントの \"Your Projects\" セクションに移動します"
 
-#: ../../tutorials/publish-pypi.md:376
+#: ../../tutorials/publish-pypi.md:382
 msgid ""
 "Click on the manage button for the project that you wish to add a token "
 "for"
 msgstr "トークンを追加したいプロジェクトの管理ボタンをクリックします"
 
-#: ../../tutorials/publish-pypi.md:377
+#: ../../tutorials/publish-pypi.md:383
 msgid "Go to settings"
 msgstr "設定に進む"
 
-#: ../../tutorials/publish-pypi.md:378
+#: ../../tutorials/publish-pypi.md:384
 msgid "Click on \"Create a token for your-package-name-here\""
 msgstr "\"パッケージ名のトークンを作成する\" をクリックします"
 
-#: ../../tutorials/publish-pypi.md:379
+#: ../../tutorials/publish-pypi.md:385
 msgid ""
 "Create the token and follow the steps above publish your package using "
 "the repository specific token."
 msgstr "トークンを作成し、上記の手順に従って、リポジトリ固有のトークンを使用してパッケージを公開します。"
 
-#: ../../tutorials/publish-pypi.md:381
+#: ../../tutorials/publish-pypi.md:387
 msgid "And you're all done!"
 msgstr "そして、すべて終わりました！"
 
-#: ../../tutorials/publish-pypi.md:383
+#: ../../tutorials/publish-pypi.md:389
 msgid "You have published your package to TestPyPI!"
 msgstr "あなたはTestPyPIにパッケージを公開しました!"
 
-#: ../../tutorials/publish-pypi.md:385
+#: ../../tutorials/publish-pypi.md:391
 msgid ""
 "Congratulations. You have now successfully published your package to "
 "TestPyPI. If you have a package that is ready for real-world use on the "
@@ -5273,7 +5645,7 @@ msgstr ""
 "おめでとうございます。これで、TestPyPIへのパッケージの公開が成功しました。実際のPyPIで利用できる準備が整ったパッケージがあれば、同じ手順で"
 " (上記の違いはありますが) PyPIに公開することができます。"
 
-#: ../../tutorials/publish-pypi.md:387
+#: ../../tutorials/publish-pypi.md:393
 msgid ""
 "Once you publish on PyPI, you can then easily add your package to the "
 "conda-forge ecosystem using the [grayskull](https://conda-"
@@ -5283,50 +5655,50 @@ msgstr ""
 "forge.org/blog/posts/2020-03-05-grayskull/) ツールを使って簡単にconda-"
 "forgeエコシステムにパッケージを追加できます。"
 
-#: ../../tutorials/publish-pypi.md:389
+#: ../../tutorials/publish-pypi.md:395
 msgid "You will learn how to do that in the next lesson."
 msgstr "その方法は次のレッスンで学習します。"
 
-#: ../../tutorials/publish-pypi.md:396
+#: ../../tutorials/publish-pypi.md:402
 msgid "https://docs.python.org/3/library/venv.html"
 msgstr "https://docs.python.org/3/library/venv.html"
 
-#: ../../tutorials/pyproject-toml.md:1
+#: ../../tutorials/pyproject-toml.md:6
 msgid "Make your Python package PyPI ready - pyproject.toml"
 msgstr "PythonパッケージをPyPIに対応させる - pyproject.toml"
 
-#: ../../tutorials/pyproject-toml.md:3
+#: ../../tutorials/pyproject-toml.md:8
 msgid ""
-"In [the installable code lesson](create-python-package), you learned how to "
-"add the bare minimum information to a `pyproject.toml` file to make it "
-"installable. You then learned how to [publish a bare minimum version of "
+"In [the installable code lesson](create-python-package), you learned how "
+"to add the bare minimum information to a `pyproject.toml` file to make it"
+" installable. You then learned how to [publish a bare minimum version of "
 "your package to PyPI](publish-pypi.md)."
 msgstr ""
 "[インストール可能なコードのレッスン](create-python-package) では、 `pyproject.toml` "
 "ファイルに最低限の情報を追加してインストール可能にする方法を学びました。その後、 [PyPIにパッケージの最小限のバージョンを公開する"
 "](publish-pypi.md) 方法を学びました。"
 
-#: ../../tutorials/pyproject-toml.md:5
+#: ../../tutorials/pyproject-toml.md:10
 msgid "Following that you learned how to add a:"
 msgstr "それに続いて、あなたは以下の追加方法を学びました:"
 
-#: ../../tutorials/pyproject-toml.md:6
+#: ../../tutorials/pyproject-toml.md:11
 msgid "[README.md](add-readme)"
 msgstr "[README.md](add-readme)"
 
-#: ../../tutorials/pyproject-toml.md:7
+#: ../../tutorials/pyproject-toml.md:12
 msgid "[LICENSE](add-license-coc) and"
 msgstr "[LICENSE](add-license-coc) と"
 
-#: ../../tutorials/pyproject-toml.md:8
+#: ../../tutorials/pyproject-toml.md:13
 msgid "[CODE_OF_CONDUCT](add-coc)"
 msgstr "[CODE_OF_CONDUCT](add-coc)"
 
-#: ../../tutorials/pyproject-toml.md:10
+#: ../../tutorials/pyproject-toml.md:15
 msgid "to the root of your project directory."
 msgstr "プロジェクトディレクトリのルートに。"
 
-#: ../../tutorials/pyproject-toml.md:12
+#: ../../tutorials/pyproject-toml.md:17
 msgid ""
 "To enhance the visibility of your package on PyPI and provide more "
 "information about its compatibility with Python versions, project "
@@ -5338,19 +5710,19 @@ msgstr ""
 "のバージョンとの互換性、プロジェクトの開発状況、プロジェクトのメンテナーについてより多くの情報を提供するために、 `pyproject.toml`"
 " ファイルに追加のメタデータを追加する必要があります。このレッスンでは、そのプロセスについて説明します。"
 
-#: ../../tutorials/pyproject-toml.md:24
+#: ../../tutorials/pyproject-toml.md:29
 msgid ""
 "More about the `pyproject.toml` file and how it's used to store different"
 " types of metadata about your package"
 msgstr "`pyproject.toml` ファイルの詳細と、パッケージに関するさまざまな種類のメタデータを格納するためにどのように使用されるかについて"
 
-#: ../../tutorials/pyproject-toml.md:25
+#: ../../tutorials/pyproject-toml.md:30
 msgid ""
 "How to declare information (metadata) about your project to help users "
 "find and understand it on PyPI."
 msgstr "ユーザーがPyPIでプロジェクトを見つけ、理解しやすくするために、プロジェクトに関する情報 (メタデータ) を宣言する方法。"
 
-#: ../../tutorials/pyproject-toml.md:27
+#: ../../tutorials/pyproject-toml.md:32
 msgid ""
 "If you wish to learn more about the `pyproject.toml` format, [check out "
 "this page. ](../package-structure-code/pyproject-toml-python-package-"
@@ -5363,25 +5735,25 @@ msgstr ""
 msgid "Click for lesson takeaways"
 msgstr "レッスンのポイントはこちら"
 
-#: ../../tutorials/pyproject-toml.md:34
+#: ../../tutorials/pyproject-toml.md:39
 msgid "When creating your pyproject.toml file, consider the following:"
 msgstr "pyproject.tomlファイルを作成する際、以下を考慮してください:"
 
-#: ../../tutorials/pyproject-toml.md:36
+#: ../../tutorials/pyproject-toml.md:41
 msgid ""
 "There are only two required metadata tables that you need to install and "
 "publish your Python package:"
 msgstr "Python パッケージをインストールして公開するために必要なメタデータテーブルは 2 つだけです:"
 
-#: ../../tutorials/pyproject-toml.md:37
+#: ../../tutorials/pyproject-toml.md:42
 msgid "**[build-system]**"
 msgstr "**[build-system]**"
 
-#: ../../tutorials/pyproject-toml.md:38
+#: ../../tutorials/pyproject-toml.md:43
 msgid "**[project]**."
 msgstr "**[project]**."
 
-#: ../../tutorials/pyproject-toml.md:39
+#: ../../tutorials/pyproject-toml.md:44
 msgid ""
 "The **[project]** table stores your package's metadata. Within the "
 "**[project]** table, There are only two _required_ fields:"
@@ -5389,15 +5761,15 @@ msgstr ""
 "**[project]** テーブルには、パッケージのメタデータが格納されます。 **[project]** テーブルの中で、 _必須_ "
 "フィールドは2つだけです:"
 
-#: ../../tutorials/pyproject-toml.md:40
+#: ../../tutorials/pyproject-toml.md:45
 msgid "**name=**"
 msgstr "**name=**"
 
-#: ../../tutorials/pyproject-toml.md:41
+#: ../../tutorials/pyproject-toml.md:46
 msgid "**version=**"
 msgstr "**version=**"
 
-#: ../../tutorials/pyproject-toml.md:42
+#: ../../tutorials/pyproject-toml.md:47
 msgid ""
 "You should add more metadata to the `[project]` table as it will make it "
 "easier for users to find your project on PyPI. And it will also make it "
@@ -5406,7 +5778,7 @@ msgstr ""
 "ユーザーがPyPIであなたのプロジェクトを見つけやすくなるので、 `[project]` "
 "テーブルにもっとメタデータを追加するべきです。また、インストーラがあなたのパッケージのインストール方法を理解しやすくなります。"
 
-#: ../../tutorials/pyproject-toml.md:43
+#: ../../tutorials/pyproject-toml.md:48
 msgid ""
 "When you are adding classifiers to the **[project]** table, only use "
 "valid values from [PyPI's classifier "
@@ -5417,7 +5789,7 @@ msgstr ""
 "[PyPIの分類ページ](https://PyPI.org/classifiers/) にある有効な値のみを使用してください。 "
 "ここで無効な値を指定すると、パッケージをビルドするときやPyPIに公開するときにエラーが発生します。"
 
-#: ../../tutorials/pyproject-toml.md:44
+#: ../../tutorials/pyproject-toml.md:49
 msgid ""
 "There is no specific order for tables in the `pyproject.toml` file. "
 "However, fields need to be placed within the correct tables. For example "
@@ -5426,29 +5798,29 @@ msgstr ""
 "`pyproject.toml` ファイル内のテーブルには特定の順番はありません。 しかし、フィールドは正しいテーブルに配置する必要があります。 "
 "例えば `requires =` は常に **[build-system]** テーブルにある必要があります。"
 
-#: ../../tutorials/pyproject-toml.md:45
+#: ../../tutorials/pyproject-toml.md:50
 msgid ""
 "We suggest that you include your **[build-system]** table at the top of "
 "your `pyproject.toml` file."
 msgstr "**[build-system]** テーブルを `pyproject.toml` ファイルの先頭に含めることをお勧めします。"
 
-#: ../../tutorials/pyproject-toml.md:50
+#: ../../tutorials/pyproject-toml.md:55
 msgid ""
 "The `pyproject.toml` file is a human and machine-readable file that "
 "serves as the primary configuration file for your Python package."
 msgstr "`pyproject.toml` ファイルは人間や機械が読めるファイルで、Pythonパッケージの主要な設定ファイルとして機能します。"
 
-#: ../../tutorials/pyproject-toml.md:54
+#: ../../tutorials/pyproject-toml.md:59
 msgid ""
 "[Building your package](build-package) is the step that created the "
 "distribution files that are required for you to publish to PyPI."
 msgstr "[パッケージのビルド](build-package) は、PyPIに公開するために必要な配布ファイルを作成するステップです。"
 
-#: ../../tutorials/pyproject-toml.md:58
+#: ../../tutorials/pyproject-toml.md:63
 msgid "About the .toml format"
 msgstr ".toml フォーマットについて"
 
-#: ../../tutorials/pyproject-toml.md:60
+#: ../../tutorials/pyproject-toml.md:65
 msgid ""
 "The **pyproject.toml** file is written in [TOML (Tom's Obvious, Minimal "
 "Language) format](https://toml.io/en/). TOML is an easy-to-read structure"
@@ -5463,13 +5835,13 @@ msgstr ""
 "が含まれています。TOMLフォーマットは、 `.json` "
 "などの他の構造化フォーマットと比較することができます。しかし、TOMLフォーマットは人間が読みやすいように設計されています。"
 
-#: ../../tutorials/pyproject-toml.md:62
+#: ../../tutorials/pyproject-toml.md:67
 msgid ""
 "Below you can see the `[build-system]` table. Within that table there are"
 " two required key/value pairs."
 msgstr "以下に `[build-system]` テーブルを示す。そのテーブルの中には、2つのキーと値のペアが必要です。"
 
-#: ../../tutorials/pyproject-toml.md:65
+#: ../../tutorials/pyproject-toml.md:70
 msgid ""
 "`requires =`  is the key and the value is `[\"hatchling\"]` within the "
 "`[build-system]` array specified by square brackets `[]`."
@@ -5477,15 +5849,15 @@ msgstr ""
 "`requires =` がキーで、値は角括弧 `[]` で指定された `[build-system]` 配列内の "
 "`[\"hatchling\"]` です。"
 
-#: ../../tutorials/pyproject-toml.md:75
+#: ../../tutorials/pyproject-toml.md:80
 msgid "What is the pyproject.toml used for?"
 msgstr "pyproject.tomlは何に使うのですか？"
 
-#: ../../tutorials/pyproject-toml.md:77
+#: ../../tutorials/pyproject-toml.md:82
 msgid "The pyproject.toml file tells your build tool:"
 msgstr "pyproject.tomlファイルは、ビルドツールに次のように指示します:"
 
-#: ../../tutorials/pyproject-toml.md:79
+#: ../../tutorials/pyproject-toml.md:84
 msgid ""
 "What build backend to use to build your package (we are using `hatchling`"
 " in this tutorial but there are [many others to choose from](/package-"
@@ -5494,29 +5866,29 @@ msgstr ""
 "パッケージのビルドに使用するビルドバックエンド (このチュートリアルでは `hatchling` を使用していますが、 [他にも多くの選択肢"
 "](/package-structure-code/python-package-build-tools) があります)。"
 
-#: ../../tutorials/pyproject-toml.md:80
+#: ../../tutorials/pyproject-toml.md:85
 msgid "How and where to retrieve your package's version:"
 msgstr "パッケージのバージョンの取得方法と場所:"
 
-#: ../../tutorials/pyproject-toml.md:81
+#: ../../tutorials/pyproject-toml.md:86
 msgid "**statically** where you declare the version `version = \"0.1.0\"` or"
 msgstr "**静的** ここで、バージョン `version = \"0.1.0\"` または"
 
-#: ../../tutorials/pyproject-toml.md:82
+#: ../../tutorials/pyproject-toml.md:87
 msgid ""
 "**dynamically** where the tool looks to the most recent tag in your "
 "history to determine the current version."
 msgstr "**動的** このツールは、現在のバージョンを決定するために、履歴の最新のタグを検索します。"
 
-#: ../../tutorials/pyproject-toml.md:83
+#: ../../tutorials/pyproject-toml.md:88
 msgid "What dependencies your package needs"
 msgstr "パッケージが必要とする依存関係"
 
-#: ../../tutorials/pyproject-toml.md:84
+#: ../../tutorials/pyproject-toml.md:89
 msgid "What versions of Python your package supports (important for your users)."
 msgstr "パッケージがサポートするPythonのバージョン (ユーザーにとって重要）。"
 
-#: ../../tutorials/pyproject-toml.md:86
+#: ../../tutorials/pyproject-toml.md:91
 msgid ""
 "The `pyproject.toml` file also makes it easy for anyone browsing your "
 "GitHub repository to quickly understand your package's structure such as:"
@@ -5524,23 +5896,23 @@ msgstr ""
 "また、 `pyproject.toml` ファイルを使うことで、GitHub "
 "リポジトリを閲覧している人が次のようなパッケージの構造をすぐに理解できるようになります:"
 
-#: ../../tutorials/pyproject-toml.md:89
+#: ../../tutorials/pyproject-toml.md:94
 msgid "How your package is built,"
 msgstr "パッケージの作り方、"
 
-#: ../../tutorials/pyproject-toml.md:90
+#: ../../tutorials/pyproject-toml.md:95
 msgid "What Python versions and operating systems it supports"
 msgstr "サポートするPythonのバージョンとオペレーティングシステム"
 
-#: ../../tutorials/pyproject-toml.md:91
+#: ../../tutorials/pyproject-toml.md:96
 msgid "What it does,"
 msgstr "何をするのか？"
 
-#: ../../tutorials/pyproject-toml.md:92
+#: ../../tutorials/pyproject-toml.md:97
 msgid "Who maintains it"
 msgstr "誰がメンテナンスするのか"
 
-#: ../../tutorials/pyproject-toml.md:94
+#: ../../tutorials/pyproject-toml.md:99
 msgid ""
 "Finally, the pyproject.toml file is also often used to configure tools "
 "such as static type checkers (e.g. mypy) and code formatters/linters "
@@ -5549,7 +5921,7 @@ msgstr ""
 "最後に、pyproject.tomlファイルは、静的タイプチェッカー (mypyなど) やコードフォーマッタ/リンタ (blackやruffなど)"
 " のようなツールを設定するためにもよく使われます。"
 
-#: ../../tutorials/pyproject-toml.md:97
+#: ../../tutorials/pyproject-toml.md:102
 msgid ""
 "Check out the [PyPA "
 "documentation](https://packaging.python.org/en/latest/tutorials"
@@ -5560,7 +5932,7 @@ msgstr ""
 "[PyPAのドキュメント](https://packaging.python.org/en/latest/tutorials/packaging-"
 "projects/#choosing-a-build-backend) をチェックしてください。"
 
-#: ../../tutorials/pyproject-toml.md:99
+#: ../../tutorials/pyproject-toml.md:104
 msgid ""
 "Note that some build tools may deviate in how they store project "
 "metadata. As such you may want to refer to their documentation if you "
@@ -5571,11 +5943,11 @@ msgstr ""
 "ビルドツールによっては、プロジェクトのメタデータを保存する方法が異なる場合があります。そのため、Hatch "
 "とhatchling以外のツールを使用する場合は、それらのドキュメントを参照することをお勧めします。このチュートリアルでは、PyPAのルールとガイドラインに準拠したツールであるhatchlingとhatchを選択しました。"
 
-#: ../../tutorials/pyproject-toml.md:103
+#: ../../tutorials/pyproject-toml.md:108
 msgid "How is pyproject.toml metadata used?"
 msgstr "pyproject.tomlのメタデータはどのように使用されますか？"
 
-#: ../../tutorials/pyproject-toml.md:105
+#: ../../tutorials/pyproject-toml.md:110
 msgid ""
 "The pyproject.toml file is the file that your build tool uses to populate"
 " a `METADATA` that is included in your Python distribution files that get"
@@ -5587,7 +5959,7 @@ msgstr ""
 "を生成するためにビルドツールが使用するファイルです。 この `METADATA` ファイルは、PyPI によってあなたのパッケージの PyPI "
 "ランディングページに入力され、そこで公開されている何万ものパッケージの中からユーザをフィルタリングするのに使われます。"
 
-#: ../../tutorials/pyproject-toml.md:108
+#: ../../tutorials/pyproject-toml.md:113
 msgid ""
 "Image showing the left side bar of PyPI for the package xclim. The "
 "section at the top says Classifier. Below there is a list of items "
@@ -5598,7 +5970,7 @@ msgstr ""
 "xclimパッケージのPyPI左サイドバーの画像です。一番上のセクションにはClassifierとあります。その下に、開発状況、対象読者、ライセンス、自然言語、オペレーティングシステム、プログラミング言語、トピックなどの項目があります。"
 " これらの各セクションの下には、さまざまな分類オプションがあります。 \" width=\"300px\">"
 
-#: ../../tutorials/pyproject-toml.md:113
+#: ../../tutorials/pyproject-toml.md:118
 msgid ""
 "When you add the classifier section to your pyproject.toml and your "
 "package is built, the build tool organizes the metadata into a format "
@@ -5609,11 +5981,11 @@ msgstr ""
 "pyproject.tomlにclassifierセクションを追加してパッケージがビルドされると、ビルドツールはメタデータをPyPIが理解できる形式に整理し、PyPIのランディングページに表示します。"
 " これらの分類子により、ユーザはサポートするpythonのバージョンやカテゴリなどでパッケージをソートすることもできます。"
 
-#: ../../tutorials/pyproject-toml.md:119
+#: ../../tutorials/pyproject-toml.md:124
 msgid "A more in-depth overview of pyproject.toml files"
 msgstr "pyproject.tomlファイルのより詳細な概要"
 
-#: ../../tutorials/pyproject-toml.md:121
+#: ../../tutorials/pyproject-toml.md:126
 msgid ""
 "[Our guidebook page has a more in depth overview of this file"
 "](../package-structure-code/pyproject-toml-python-package-metadata/)"
@@ -5621,31 +5993,31 @@ msgstr ""
 "[ガイドブックページでは、このファイルについてより詳しく説明しています](../package-structure-code/pyproject-"
 "toml-python-package-metadata/)"
 
-#: ../../tutorials/pyproject-toml.md:124
+#: ../../tutorials/pyproject-toml.md:129
 msgid "How to update your pyproject.toml file"
 msgstr "pyproject.tomlファイルを更新する方法"
 
-#: ../../tutorials/pyproject-toml.md:126
+#: ../../tutorials/pyproject-toml.md:131
 msgid ""
 "In the last lesson, you created a bare-bones pyproject.toml file that "
 "contained the core elements needed to build your package:"
 msgstr "最後のレッスンでは、パッケージのビルドに必要なコア要素を含む、素のpyproject.tomlファイルを作成しました:"
 
-#: ../../tutorials/pyproject-toml.md:130
+#: ../../tutorials/pyproject-toml.md:135
 msgid ""
 "A `[build-system]` table where you defined your project's backend build "
 "tool (`hatchling`)"
 msgstr "プロジェクトのバックエンドビルドツールを定義した `[build-system]` テーブル (`hatchling`)"
 
-#: ../../tutorials/pyproject-toml.md:131
+#: ../../tutorials/pyproject-toml.md:136
 msgid "A `[project]` table where you defined your project's version and name."
 msgstr "プロジェクトのバージョンと名前を定義した `[project]` テーブル。"
 
-#: ../../tutorials/pyproject-toml.md:133
+#: ../../tutorials/pyproject-toml.md:138
 msgid "The `pyproject.toml` file that you created, looked like this:"
 msgstr "あなたが作成した `pyproject.toml` ファイルは次のようなものです:"
 
-#: ../../tutorials/pyproject-toml.md:145
+#: ../../tutorials/pyproject-toml.md:150
 msgid ""
 "Your next step is to add additional recommended metadata fields that will"
 " both help users find your package on PyPI and also better describe the "
@@ -5658,19 +6030,19 @@ msgstr ""
 "一度このメタデータを追加すれば、もう二度と追加する必要はありません。 "
 "これらのメタデータ・フィールドが定期的に更新されるのは、あなたが次のようなことをしたときだけです:"
 
-#: ../../tutorials/pyproject-toml.md:148
+#: ../../tutorials/pyproject-toml.md:153
 msgid "drop a package dependency"
 msgstr "パッケージ依存の削除"
 
-#: ../../tutorials/pyproject-toml.md:149
+#: ../../tutorials/pyproject-toml.md:154
 msgid "modify what Python versions your package supports."
 msgstr "パッケージがサポートしているPythonのバージョンを変更します。"
 
-#: ../../tutorials/pyproject-toml.md:151
+#: ../../tutorials/pyproject-toml.md:156
 msgid "More on hatchling"
 msgstr "Hatchlingの詳細"
 
-#: ../../tutorials/pyproject-toml.md:154
+#: ../../tutorials/pyproject-toml.md:159
 msgid ""
 "The documentation for the hatchling back-end is "
 "[here](https://hatch.pypa.io/latest/config/metadata/)"
@@ -5678,53 +6050,53 @@ msgstr ""
 "Hatchlingのバックエンドのドキュメントは "
 "[こちら](https://hatch.pypa.io/latest/config/metadata/) です。"
 
-#: ../../tutorials/pyproject-toml.md:157
+#: ../../tutorials/pyproject-toml.md:162
 msgid "Step 1: Add Author, maintainer and project description"
 msgstr "ステップ1: 作者、メンテナ、プロジェクトの説明を追加する"
 
-#: ../../tutorials/pyproject-toml.md:159
+#: ../../tutorials/pyproject-toml.md:164
 msgid ""
-"After completing the [installable code tutorial](create-python-package), you "
-"should have a pyproject.toml file with a project name and a version in "
-"the `[project]` table."
+"After completing the [installable code tutorial](create-python-package), "
+"you should have a pyproject.toml file with a project name and a version "
+"in the `[project]` table."
 msgstr ""
 "[インストール可能なコードのチュートリアル](create-python-package) を完了すると、 `[project]` "
 "テーブルにプロジェクト名とバージョンを持つpyproject.tomlファイルができるはずです。"
 
-#: ../../tutorials/pyproject-toml.md:167
+#: ../../tutorials/pyproject-toml.md:172
 msgid "Add the following to your table:"
 msgstr "テーブルに以下を追加します:"
 
-#: ../../tutorials/pyproject-toml.md:169
+#: ../../tutorials/pyproject-toml.md:174
 msgid ""
 "A **description** of your package. This should be a single line and "
 "should briefly describe the goal of your package using non technical "
 "terms if as all possible!"
 msgstr "パッケージの**説明** これは1行で、可能な限り専門用語を使わず、あなたのパッケージの目標を簡潔に記述してください！"
 
-#: ../../tutorials/pyproject-toml.md:170
+#: ../../tutorials/pyproject-toml.md:175
 msgid "package **authors**"
 msgstr "パッケージ **著者**"
 
-#: ../../tutorials/pyproject-toml.md:171
+#: ../../tutorials/pyproject-toml.md:176
 msgid "package **maintainers**"
 msgstr "パッケージ **メンテナー**"
 
-#: ../../tutorials/pyproject-toml.md:173
+#: ../../tutorials/pyproject-toml.md:178
 msgid "The `description` is just a string like the other values you've set:"
 msgstr "`description` は、設定した他の値と同じように単なる文字列です:"
 
-#: ../../tutorials/pyproject-toml.md:184
+#: ../../tutorials/pyproject-toml.md:189
 msgid ""
 "When you add authors and maintainers you need to use a format that will "
 "look like a Python list with a dictionary within it:"
 msgstr "作者とメンテナを追加するときは、Pythonのリストに辞書を追加したような書式を使う必要があります:"
 
-#: ../../tutorials/pyproject-toml.md:198
+#: ../../tutorials/pyproject-toml.md:203
 msgid "Author names & emails"
 msgstr "著者名とEメール"
 
-#: ../../tutorials/pyproject-toml.md:202
+#: ../../tutorials/pyproject-toml.md:207
 msgid ""
 "There is a quirk with PyPI for authors that have names but not emails in "
 "the pyproject.toml. If you are missing the email for one or more authors "
@@ -5733,17 +6105,17 @@ msgstr ""
 "PyPIには、pyproject.tomlに名前があってもメールがない作者のための癖があります。 "
 "もし、1人以上の作者やメンテナのEメールが見つからない場合は、次のようにしてください:"
 
-#: ../../tutorials/pyproject-toml.md:211
+#: ../../tutorials/pyproject-toml.md:216
 msgid ""
 "Then we suggest that you only provide names in your list of names to "
 "ensure that everything renders properly on your PyPI page - like this:"
 msgstr "PyPIページですべてが正しく表示されるようにするために、名前のリストには名前のみを入力することをお勧めします - このように:"
 
-#: ../../tutorials/pyproject-toml.md:220
+#: ../../tutorials/pyproject-toml.md:225
 msgid "don't have emails for everyone, we suggest that you only add names."
 msgstr "全員のEメールを持っていない場合は、名前だけを追加することをお勧めします。"
 
-#: ../../tutorials/pyproject-toml.md:223
+#: ../../tutorials/pyproject-toml.md:228
 msgid ""
 "Your `pyproject.toml` file now should look like the example below. It is "
 "OK if you only have 1 author and the same author is also maintainer of "
@@ -5758,25 +6130,25 @@ msgid ""
 "source?"
 msgstr "さらに詳しく: オープンソースにおける作者とメンテナの違いは？"
 
-#: ../../tutorials/pyproject-toml.md:251
+#: ../../tutorials/pyproject-toml.md:256
 msgid ""
 "When adding maintainers and authors, you may want to think about the "
 "difference between the two."
 msgstr "メンテナと著者を追加する際には、この2つの違いについて考えてみるとよいでしょう。"
 
-#: ../../tutorials/pyproject-toml.md:253
+#: ../../tutorials/pyproject-toml.md:258
 msgid "Authors generally include people who:"
 msgstr "著者には一般的に以下のような人々が含まれます:"
 
-#: ../../tutorials/pyproject-toml.md:254
+#: ../../tutorials/pyproject-toml.md:259
 msgid "originally created / designed developed the package and"
 msgstr "もともとパッケージを作成 / デザイン開発して"
 
-#: ../../tutorials/pyproject-toml.md:255
+#: ../../tutorials/pyproject-toml.md:260
 msgid "people who add new functionality to the package."
 msgstr "パッケージに新しい機能を追加する人たち。"
 
-#: ../../tutorials/pyproject-toml.md:257
+#: ../../tutorials/pyproject-toml.md:262
 msgid ""
 "Whereas maintainers are the people that are currently, actively working "
 "on the project. It is often the case that there is overlap in authors and"
@@ -5785,7 +6157,7 @@ msgstr ""
 "一方、メンテナーは、現在、積極的にプロジェクトに取り組んでいる人々です。 作者とメンテナーが重なることはよくあることです。 "
 "そのため、これらのリストは似たり寄ったりかもしれません。"
 
-#: ../../tutorials/pyproject-toml.md:259
+#: ../../tutorials/pyproject-toml.md:264
 msgid ""
 "A good example of when the lists might diverge is sometimes you have a "
 "package where an initial author developed it and then stepped down as a "
@@ -5793,24 +6165,24 @@ msgid ""
 "considered an author but no longer actively maintains the package."
 msgstr "リストが分岐する可能性のある良い例としては、最初の作者が開発したパッケージが、他のことに移るためにメンテナを降りる場合があります。この人物は引き続き作者とみなされるかもしれないが、もはやそのパッケージを積極的に保守することはありません。"
 
-#: ../../tutorials/pyproject-toml.md:261
+#: ../../tutorials/pyproject-toml.md:266
 msgid ""
 "It is important to note that there are many ways to define author vs "
 "maintainer and we don't prescribe a single approach in this tutorial."
 msgstr "重要なのは、作者とメンテナを定義する方法はたくさんあるということです、そして、このチュートリアルでは、単一のアプローチを推奨するものではありません。"
 
-#: ../../tutorials/pyproject-toml.md:263
+#: ../../tutorials/pyproject-toml.md:268
 msgid ""
 "However, we encourage you to consider carefully, for PyPI publication, "
 "who you want to have listed as authors and maintainers on your PyPI "
 "landing page."
 msgstr "しかし、PyPIで公開する際には、PyPIのランディングページに作者やメンテナとして誰を掲載するか、慎重に検討することをお勧めします。"
 
-#: ../../tutorials/pyproject-toml.md:267
+#: ../../tutorials/pyproject-toml.md:272
 msgid "Step 2: Add README and license"
 msgstr "ステップ2: READMEとライセンスの追加"
 
-#: ../../tutorials/pyproject-toml.md:269
+#: ../../tutorials/pyproject-toml.md:274
 msgid ""
 "In the previous lessons, you added both a [README.md](add-readme) file "
 "and a [LICENSE](add-license-coc) to your package repository. Once you "
@@ -5820,11 +6192,11 @@ msgstr ""
 "前のレッスンでは、 [README.md](add-readme) ファイルと [LICENSE](add-license-coc) "
 "の両方をパッケージリポジトリーに追加しました。これらのファイルを手に入れたら、以下の例に従ってpyproject.tomlファイルにリンクとして追加します。"
 
-#: ../../tutorials/pyproject-toml.md:297
+#: ../../tutorials/pyproject-toml.md:302
 msgid "Step 3: Specify Python version with `requires-python`"
 msgstr "ステップ 3: `requires-python` でPythonのバージョンを指定します"
 
-#: ../../tutorials/pyproject-toml.md:299
+#: ../../tutorials/pyproject-toml.md:304
 msgid ""
 "Add the `requires-python` field to your `pyproject.toml` `[project]` "
 "table. The `requires-python` field helps pip identify which Python "
@@ -5844,11 +6216,40 @@ msgstr ""
 "metadata/#core-metadata-requires-python) では、 `requires-python` "
 "をバージョン指定の文字列として定義している。ほとんどのプロジェクトは、そのパッケージがサポートする最も古いPythonのバージョンを指定します。いくつかの高度なケースでは、どの将来のPythonバージョンがサポートされるかを示す上限が設定されます。"
 
-#: ../../tutorials/pyproject-toml.md:331
+#: ../../tutorials/pyproject-toml.md:309
+#, fuzzy
+msgid "But how do I figure out which Python versions I should support?"
+msgstr "パッケージがサポートしているPythonのバージョンを変更します。"
+
+#: ../../tutorials/pyproject-toml.md:311
+msgid ""
+"Good question. The Python developer guide provides a [status "
+"page](https://devguide.python.org/versions/) (and a handy visualization) "
+"that explains the status of each Python release. Python releases go "
+"through several different phases that are explained in [PEP "
+"602](https://peps.python.org/pep-0602/)."
+msgstr ""
+
+#: ../../tutorials/pyproject-toml.md:313
+msgid ""
+"We recommend that you use the latest Python release in the **bugfix** "
+"phase. If your Python release is in the **security** phase, we recommend "
+"migrating to a newer version of Python."
+msgstr ""
+
+#: ../../tutorials/pyproject-toml.md:315
+msgid ""
+"[SPEC 0](https://scientific-python.org/specs/spec-0000/) of the "
+"Scientific Python project suggests a common schedule for dependencies, "
+"including Python release versions, and is also worth considering for your"
+" project."
+msgstr ""
+
+#: ../../tutorials/pyproject-toml.md:344
 msgid "Step 4: Specify Dependencies"
 msgstr "ステップ4: 依存関係の指定"
 
-#: ../../tutorials/pyproject-toml.md:333
+#: ../../tutorials/pyproject-toml.md:346
 msgid ""
 "Next add your dependencies table to the project table. The `dependencies "
 "=` section contains a list (or array in the toml language) of the Python "
@@ -5860,11 +6261,11 @@ msgstr ""
 "セクションには、あなたのパッケージがPython環境で正しく動作するために必要なPythonパッケージのリスト（toml言語では配列）を記述します。"
 " 上記の `[build-system]` の表に記載されている要件と同様です:"
 
-#: ../../tutorials/pyproject-toml.md:341
+#: ../../tutorials/pyproject-toml.md:354
 msgid "dependencies are added in an array (similar to a Python list) structure."
 msgstr "依存関係は配列（Pythonのリストに似ている）構造で追加されます。"
 
-#: ../../tutorials/pyproject-toml.md:347
+#: ../../tutorials/pyproject-toml.md:360
 msgid ""
 "A dependency can be limited to specific versions using a **version "
 "specifier.** If the dependency has no version specifier after the "
@@ -5879,7 +6280,7 @@ msgstr ""
 "コードは時間の経過とともに変化し、バグが修正され、APIが変更されます。そのため、コードを書いた依存関係がどのバージョンと互換性があるのかを明確にしておくことは良いことです"
 " - あなたが今年書いたパッケージは、おそらくnumpy v0.0.1とは互換性がありません！"
 
-#: ../../tutorials/pyproject-toml.md:351
+#: ../../tutorials/pyproject-toml.md:364
 msgid ""
 "[Learn more about various ways to specify ranges of package versions "
 "here.](https://packaging.python.org/en/latest/specifications/version-"
@@ -5888,7 +6289,7 @@ msgstr ""
 "[パッケージバージョンの範囲を指定する様々な方法については、こちらをご覧ください。](https://packaging.python.org/en/latest/specifications"
 "/version-specifiers/#id5)"
 
-#: ../../tutorials/pyproject-toml.md:353
+#: ../../tutorials/pyproject-toml.md:366
 msgid ""
 "The most common version specifier is a **lower bound,** allowing any "
 "version higher than the specified version. Ideally you should set this to"
@@ -5900,11 +6301,11 @@ msgstr ""
 "で、指定されたバージョンより上位のバージョンを許可します。理想的には、あなたのパッケージとまだ互換性のある最も低いバージョンに設定すべきですが、実際には新しいパッケージの場合、パッケージが書かれた時点での最新バージョンに設定されることがよくあります"
 " [^lowerbound] 。"
 
-#: ../../tutorials/pyproject-toml.md:358
+#: ../../tutorials/pyproject-toml.md:371
 msgid "Lower bounds look like this:"
 msgstr "下限は次のようになります:"
 
-#: ../../tutorials/pyproject-toml.md:364
+#: ../../tutorials/pyproject-toml.md:377
 msgid ""
 "Commas are used to separate individual dependencies, and each package in "
 "your `dependencies` section can use different types of version "
@@ -5913,25 +6314,25 @@ msgstr ""
 "カンマは、個々の依存関係を区切るために使用します、 そして、`dependencies` "
 "セクションの各パッケージは異なるタイプのバージョン指定子を使うことができます:"
 
-#: ../../tutorials/pyproject-toml.md:375
+#: ../../tutorials/pyproject-toml.md:388
 msgid "Your `pyproject.toml` file will now look like this:"
 msgstr "これで `pyproject.toml` ファイルは次のようになります:"
 
-#: ../../tutorials/pyproject-toml.md:405
+#: ../../tutorials/pyproject-toml.md:418
 msgid "Pin dependencies with caution"
 msgstr "依存関係のピン止めは慎重に"
 
-#: ../../tutorials/pyproject-toml.md:406
+#: ../../tutorials/pyproject-toml.md:419
 msgid ""
 "\"Pinning\" a dependency means setting it to a specific version, like "
 "this:"
 msgstr "依存関係を \"Pinning\" することは、次のように特定のバージョンに設定することを意味します:"
 
-#: ../../tutorials/pyproject-toml.md:408
+#: ../../tutorials/pyproject-toml.md:421
 msgid "`numpy == 1.0`."
 msgstr "`numpy == 1.0` 。"
 
-#: ../../tutorials/pyproject-toml.md:410
+#: ../../tutorials/pyproject-toml.md:423
 msgid ""
 "If you are building a library package that other developers will depend "
 "upon, you must be cautious before pinning to a precise dependency "
@@ -5947,13 +6348,13 @@ msgstr ""
 "なぜなら、ユーザーはあなたのパッケージをさまざまな環境にインストールするからです。特定のバージョンに固定された依存関係は、Python環境の解決をより困難にします。"
 " そのため、依存関係を特定のバージョンに固定するのは、どうしても必要な場合に限られます。"
 
-#: ../../tutorials/pyproject-toml.md:418
+#: ../../tutorials/pyproject-toml.md:431
 msgid ""
 "Similarly, you should be cautious when specifying an upper bound on a "
 "package. These two specifications are equivalent:"
 msgstr "同様に、パッケージの上限を指定する場合にも注意が必要です。これら2つの仕様は同等です:"
 
-#: ../../tutorials/pyproject-toml.md:426
+#: ../../tutorials/pyproject-toml.md:439
 msgid ""
 "One build tool that you should be aware of that pins dependencies to an "
 "upper bound by default is Poetry. [Read more about how to safely add "
@@ -5962,11 +6363,11 @@ msgstr ""
 "依存関係をデフォルトで上限値に固定するビルドツールとして知っておくべきもののひとつに、Poetryがあります。 "
 "[Poetryで依存関係を安全に追加する方法については、こちらをお読みください。](challenges-with-poetry)"
 
-#: ../../tutorials/pyproject-toml.md:429
+#: ../../tutorials/pyproject-toml.md:442
 msgid "Step 5: Add PyPI classifiers"
 msgstr "ステップ5: PyPI classifiersを追加する"
 
-#: ../../tutorials/pyproject-toml.md:431
+#: ../../tutorials/pyproject-toml.md:444
 msgid ""
 "Next you will add classifiers to your `pyproject.toml` file. The value "
 "for each classifier that you add to your `pyproject.toml` file must come "
@@ -5978,11 +6379,11 @@ msgstr ""
 "[ここにあるPyPIで認められている分類子](https://PyPI.org/classifiers/) "
 "の一覧から選ぶ必要があります。スペルや書式に逸脱があると、PyPIに公開するときに問題が発生します。"
 
-#: ../../tutorials/pyproject-toml.md:433
+#: ../../tutorials/pyproject-toml.md:446
 msgid "What happens when you use incorrect classifiers?"
 msgstr "間違った分類子を使うとどうなりますか？"
 
-#: ../../tutorials/pyproject-toml.md:436
+#: ../../tutorials/pyproject-toml.md:449
 msgid ""
 "If you do not [use standard classifier "
 "values](https://PyPI.org/classifiers/), when you try to publish your "
@@ -5993,37 +6394,37 @@ msgstr ""
 "PyPIでパッケージを公開しようとすると拒否されます。  最初のトライでPyPIに拒否されても心配しないでください！ "
 "それは私たち全員に起こったことです。"
 
-#: ../../tutorials/pyproject-toml.md:439
+#: ../../tutorials/pyproject-toml.md:452
 msgid "Review that list and add items below to your `pyproject.toml` file:"
 msgstr "そのリストを見て、以下の項目を `pyproject.toml` ファイルに追加します:"
 
-#: ../../tutorials/pyproject-toml.md:441
+#: ../../tutorials/pyproject-toml.md:454
 msgid "development status"
 msgstr "開発状況"
 
-#: ../../tutorials/pyproject-toml.md:442
+#: ../../tutorials/pyproject-toml.md:455
 msgid "intended audiences"
 msgstr "対象読者"
 
-#: ../../tutorials/pyproject-toml.md:443
+#: ../../tutorials/pyproject-toml.md:456
 msgid "topic"
 msgstr "トピック"
 
-#: ../../tutorials/pyproject-toml.md:444
+#: ../../tutorials/pyproject-toml.md:457
 msgid "license and"
 msgstr "ライセンスと"
 
-#: ../../tutorials/pyproject-toml.md:445
+#: ../../tutorials/pyproject-toml.md:458
 msgid "programming language support"
 msgstr "プログラミング言語サポート"
 
-#: ../../tutorials/pyproject-toml.md:447
+#: ../../tutorials/pyproject-toml.md:460
 msgid ""
 "The classifier key should look something like the example below. A few "
 "notes:"
 msgstr "classifierのキーは、下の例のようになるはずです。 いくつか注意点があります:"
 
-#: ../../tutorials/pyproject-toml.md:449
+#: ../../tutorials/pyproject-toml.md:462
 msgid ""
 "Your classifier values might be different depending upon the license you "
 "have selected for your package, your intended audience, development "
@@ -6032,13 +6433,13 @@ msgstr ""
 "分類器の値は、パッケージに選択したライセンスによって異なる場合があります、 あなたの意図する読者、パッケージの開発状況とサポートしている "
 "Python のバージョンです。"
 
-#: ../../tutorials/pyproject-toml.md:450
+#: ../../tutorials/pyproject-toml.md:463
 msgid ""
 "You can add as many classifiers as you wish as long as you use the "
 "[designated PyPI classifier values](https://PyPI.org/classifiers/)."
 msgstr "[指定されたPyPIの分類子の値](https://PyPI.org/classifiers/) を使う限り、好きなだけ分類子を追加できます。"
 
-#: ../../tutorials/pyproject-toml.md:490
+#: ../../tutorials/pyproject-toml.md:503
 msgid ""
 "Note that while classifiers are not required in your `pyproject.toml` "
 "file, they will help users find your package. As such we strongly "
@@ -6047,21 +6448,21 @@ msgstr ""
 "分類子は `pyproject.toml` "
 "ファイルでは必須ではありませんが、ユーザーがあなたのパッケージを見つけるのに役立つことに注意してください。そのため、追加することを強くお勧めします。"
 
-#: ../../tutorials/pyproject-toml.md:492
+#: ../../tutorials/pyproject-toml.md:505
 msgid "Step 6: Add the `[project.urls]` table"
 msgstr "ステップ 6: `[project.urls]` テーブルを追加する"
 
-#: ../../tutorials/pyproject-toml.md:494
+#: ../../tutorials/pyproject-toml.md:507
 msgid "Finally, add the project.urls table to your pyproject.toml file."
 msgstr "最後に、pyproject.tomlファイルにproject.urlsテーブルを追加します。"
 
-#: ../../tutorials/pyproject-toml.md:496
+#: ../../tutorials/pyproject-toml.md:509
 msgid ""
 "`project.urls` contains links that are relevant for your project. You "
 "might want to include:"
 msgstr "`project.urls` には、プロジェクトに関連するリンクが含まれています。以下を含めるとよいでしょう:"
 
-#: ../../tutorials/pyproject-toml.md:498
+#: ../../tutorials/pyproject-toml.md:511
 msgid ""
 "**Homepage:** A link to your published documentation for your project. If"
 " you are working through this tutorial, then you may not have this link "
@@ -6070,17 +6471,17 @@ msgstr ""
 "**ホームページ:** プロジェクトの公開ドキュメントへのリンク。 "
 "このチュートリアルを進めているのであれば、このリンクはまだ持っていないかもしれません。 大丈夫、当分は飛ばしてもいいです。"
 
-#: ../../tutorials/pyproject-toml.md:499
+#: ../../tutorials/pyproject-toml.md:512
 msgid ""
 "**Bug reports:** a link to your issues / discussions or wherever you want"
 " users to report bugs."
 msgstr "**バグ報告:** 課題 / ディスカッションへのリンク、またはユーザーがバグを報告できる場所です。"
 
-#: ../../tutorials/pyproject-toml.md:500
+#: ../../tutorials/pyproject-toml.md:513
 msgid "**Source:** the GitHub / GitLab link for your project."
 msgstr "**ソース:** プロジェクトのGitHub / GitLabリンク。"
 
-#: ../../tutorials/pyproject-toml.md:546
+#: ../../tutorials/pyproject-toml.md:559
 msgid ""
 "There are many other urls that you can add here. Check out the [README "
 "file here for an overview](https://github.com/patrick91/links-demo)."
@@ -6089,11 +6490,11 @@ msgstr ""
 "[概要についてはこちらのREADMEファイル](https://github.com/patrick91/links-demo) "
 "をチェックしてください。"
 
-#: ../../tutorials/pyproject-toml.md:549
+#: ../../tutorials/pyproject-toml.md:562
 msgid "Putting it all together - your completed pyproject.toml file"
 msgstr "すべてをまとめます - 完成したpyproject.tomlファイル"
 
-#: ../../tutorials/pyproject-toml.md:551
+#: ../../tutorials/pyproject-toml.md:564
 msgid ""
 "Below is an example of a complete `pyproject.toml` file that is commented"
 " with all of the sections we discussed above."
@@ -6103,48 +6504,48 @@ msgstr "以下は、上で説明したすべてのセクションがコメント
 msgid "Appendix - Click for a fully commented pyproject.toml file"
 msgstr "付録 - 完全にコメントされたpyproject.tomlファイルを見るにはクリックしてください"
 
-#: ../../tutorials/pyproject-toml.md:601
+#: ../../tutorials/pyproject-toml.md:614
 msgid ""
 "Below is a fully commented pyproject.toml file if you want to use it for "
 "reference."
 msgstr "参考にしたいのであれば、以下は、完全にコメントされたpyproject.tomlファイルです。"
 
-#: ../../tutorials/pyproject-toml.md:666
+#: ../../tutorials/pyproject-toml.md:679
 msgid "Example `pyproject.toml` files"
 msgstr "例 `pyproject.toml` ファイル"
 
-#: ../../tutorials/pyproject-toml.md:668
+#: ../../tutorials/pyproject-toml.md:681
 msgid ""
 "Below are some examples of `pyproject.toml` files from various packages "
 "in the scientific and pyOpenSci ecosystem."
 msgstr "以下は、scientificとpyOpenSciエコシステムの様々なパッケージの `pyproject.toml` ファイルの例です。"
 
-#: ../../tutorials/pyproject-toml.md:669
+#: ../../tutorials/pyproject-toml.md:682
 msgid ""
 "[PyPA's fully documented example pyproject.toml "
 "file](https://github.com/pypa/sampleproject/blob/main/pyproject.toml)"
 msgstr "[PyPAの完全に文書化されたサンプルpyproject.tomlファイル](https://github.com/pypa/sampleproject/blob/main/pyproject.toml)"
 
-#: ../../tutorials/pyproject-toml.md:670
+#: ../../tutorials/pyproject-toml.md:683
 msgid ""
 "[taxpasta has a nicely organized pyproject.toml file and is a pyOpenSci "
 "approved "
 "package](https://github.com/taxprofiler/taxpasta/blob/f9f6eea2ae7dd08bb60a53dd49ad77e4cf143573/pyproject.toml)"
 msgstr "[taxpastaはきれいに整理されたpyproject.tomlファイルを持っており、pyOpenSci承認パッケージです](https://github.com/taxprofiler/taxpasta/blob/f9f6eea2ae7dd08bb60a53dd49ad77e4cf143573/pyproject.toml)"
 
-#: ../../tutorials/pyproject-toml.md:676
+#: ../../tutorials/pyproject-toml.md:689
 msgid "At this point you've created:"
 msgstr "この時点であなたは以下を作成しました:"
 
-#: ../../tutorials/pyproject-toml.md:678
+#: ../../tutorials/pyproject-toml.md:691
 msgid "A [README.md](add-readme) file for your package"
 msgstr "パッケージの [README.md](add-readme) ファイル"
 
-#: ../../tutorials/pyproject-toml.md:679
+#: ../../tutorials/pyproject-toml.md:692
 msgid "A [CODE_OF_CONDUCT.md](add-coc) file to support your user community"
 msgstr "ユーザーコミュニティをサポートする [CODE_OF_CONDUCT.md](add-coc) ファイル"
 
-#: ../../tutorials/pyproject-toml.md:680
+#: ../../tutorials/pyproject-toml.md:693
 msgid ""
 "And a [LICENSE](add-license-coc) file which provides legal boundaries "
 "around how people can and can't use your software"
@@ -6152,17 +6553,17 @@ msgstr ""
 "[LICENSE](add-license-coc) "
 "ファイルは、人々があなたのソフトウェアをどのように使用できるか、また使用できないかに関する法的な境界線を提供します。"
 
-#: ../../tutorials/pyproject-toml.md:682
+#: ../../tutorials/pyproject-toml.md:695
 msgid ""
 "You also learned [how to publish your package to (test)PyPI](publish-"
 "pypi)."
 msgstr "また、 [パッケージを(test)PyPIに公開する方法](publish-pypi) も学びました。"
 
-#: ../../tutorials/pyproject-toml.md:684
+#: ../../tutorials/pyproject-toml.md:697
 msgid "Publish a new version of your package to PyPI"
 msgstr "新しいバージョンのパッケージをPyPIに公開する"
 
-#: ../../tutorials/pyproject-toml.md:686
+#: ../../tutorials/pyproject-toml.md:699
 msgid ""
 "You are now ready to publish a new version of your Python package to "
 "(test) PyPI. When you do this you will see that the landing page for your"
@@ -6171,11 +6572,11 @@ msgstr ""
 "これで、Pythonパッケージの新しいバージョンを(test)PyPIに公開する準備ができました。 "
 "そうすると、パッケージのランディングページに、より多くの情報が掲載されていることがわかります。"
 
-#: ../../tutorials/pyproject-toml.md:688
+#: ../../tutorials/pyproject-toml.md:701
 msgid "Try to republish now."
 msgstr "今すぐ再公開を試みます。"
 
-#: ../../tutorials/pyproject-toml.md:690
+#: ../../tutorials/pyproject-toml.md:703
 msgid ""
 "First, update the version of your package in your pyproject toml file. "
 "Below version is updated from `0.1` to `0.1.1`."
@@ -6183,28 +6584,28 @@ msgstr ""
 "まず、pyprojectのtomlファイルでパッケージのバージョンを更新します。以下のバージョンが `0.1` から `0.1.1` "
 "に更新されました。"
 
-#: ../../tutorials/pyproject-toml.md:703
+#: ../../tutorials/pyproject-toml.md:716
 msgid "Now use hatch to publish the new version of your package to test.PyPI.org."
 msgstr "次に hatch を使って、新しいバージョンのパッケージを test.PyPI.org に公開します。"
 
-#: ../../tutorials/pyproject-toml.md:710
+#: ../../tutorials/pyproject-toml.md:723
 msgid "Next (optional) step - publishing to conda-forge"
 msgstr "次のステップ(オプション) - conda-forgeに公開します。"
 
-#: ../../tutorials/pyproject-toml.md:712
+#: ../../tutorials/pyproject-toml.md:725
 msgid ""
 "You now have all of the skills that you need to publish your package to "
 "PyPI."
 msgstr "これであなたのパッケージをPyPIに公開するために必要なスキルはすべて揃いました。"
 
-#: ../../tutorials/pyproject-toml.md:715
+#: ../../tutorials/pyproject-toml.md:728
 msgid ""
 "If you also want to publish your package on conda-forge (which is a "
 "channel within the conda ecosystem), you will learn how to do that in the"
 " next lesson."
 msgstr "あなたのパッケージを(condaエコシステム内のチャンネルである)conda-forgeで公開したい場合 、 その方法は次のレッスンで学びます。"
 
-#: ../../tutorials/pyproject-toml.md:719
+#: ../../tutorials/pyproject-toml.md:732
 msgid ""
 "Really good resources from jeremiah "
 "https://daniel.feldroy.com/posts/2023-08-pypi-project-urls-cheatsheet "
@@ -6213,7 +6614,7 @@ msgstr ""
 "jeremiah からの本当に良い情報源 https://daniel.feldroy.com/posts/2023-08-pypi-"
 "project-urls-cheatsheet が役に立ちます (リンク先のデモはなおさら)。"
 
-#: ../../tutorials/pyproject-toml.md:356
+#: ../../tutorials/pyproject-toml.md:369
 msgid ""
 "Some packaging tools will do this for you when you add a dependency using"
 " their cli interface. For example [`poetry add`](https://python-"
@@ -6227,35 +6628,38 @@ msgstr ""
 "指定子で最新バージョンを追加し、 [`pdm add`](https://pdm-"
 "project.org/latest/reference/cli/#add) は `>=` 指定子で最新バージョンを追加します。"
 
-#: ../../tutorials/setup-py-to-pyproject-toml.md:1
+#: ../../tutorials/setup-py-to-pyproject-toml.md:6
 msgid "Using Hatch to Migrate setup.py to a pyproject.toml"
 msgstr "Hatchを使ってsetup.pyをpyproject.tomlに移行する"
 
-#: ../../tutorials/setup-py-to-pyproject-toml.md:3
+#: ../../tutorials/setup-py-to-pyproject-toml.md:8
+#, fuzzy
 msgid ""
-"Hatch can be particularly useful to generate your project's "
-"`pyproject.toml` if your project already has a `setup.py`."
+"Hatch can be useful for generating your project's `pyproject.toml` file "
+"if your project already has a `setup.py` file."
 msgstr "プロジェクトに既に `setup.py` がある場合、Hatchはプロジェクトの `pyproject.toml` を生成するのに便利です。"
 
-#: ../../tutorials/setup-py-to-pyproject-toml.md:5
+#: ../../tutorials/setup-py-to-pyproject-toml.md:10
 msgid "Note"
 msgstr "注釈"
 
-#: ../../tutorials/setup-py-to-pyproject-toml.md:8
+#: ../../tutorials/setup-py-to-pyproject-toml.md:13
+#, fuzzy
 msgid ""
-"This step is not necessary and is only useful if your project already has"
-" a `setup.py` file defined."
+"This step is not necessary and is only helpful if your project already "
+"has a `setup.py` file defined."
 msgstr "このステップは必要なく、プロジェクトに既に `setup.py` ファイルが定義されている場合にのみ有用です。"
 
-#: ../../tutorials/setup-py-to-pyproject-toml.md:9
+#: ../../tutorials/setup-py-to-pyproject-toml.md:14
+#, fuzzy
 msgid ""
 "If your project does not already define a `setup.py` see [Make your "
-"Python code installable](create-python-package.md)"
+"Python code installable](create-python-package)"
 msgstr ""
 "プロジェクトで `setup.py` が定義されていない場合は、 [Python コードをインストール可能にする](installable-"
 "code.md) を参照してください。"
 
-#: ../../tutorials/setup-py-to-pyproject-toml.md:17
+#: ../../tutorials/setup-py-to-pyproject-toml.md:22
 msgid ""
 "The process of using Hatch to transition to using `pyproject.toml` for "
 "projects that already have a `setup.py` defined."
@@ -6263,11 +6667,11 @@ msgstr ""
 "すでに `setup.py` が定義されているプロジェクトで `pyproject.toml` を使用するように移行するために Hatch "
 "を使用するプロセスです。"
 
-#: ../../tutorials/setup-py-to-pyproject-toml.md:20
+#: ../../tutorials/setup-py-to-pyproject-toml.md:25
 msgid "What is Hatch?"
 msgstr "Hatchとは何か？"
 
-#: ../../tutorials/setup-py-to-pyproject-toml.md:22
+#: ../../tutorials/setup-py-to-pyproject-toml.md:27
 msgid ""
 "Hatch is a Python package manager designed to streamline the process of "
 "creating, managing, and distributing Python packages. It provides a "
@@ -6279,39 +6683,40 @@ msgstr ""
 "新しいプロジェクトの作成、依存関係の管理、ディストリビューションのビルド、PyPI "
 "のようなリポジトリへのパッケージの公開といったタスクのための便利な CLI (Command-Line Interface) を提供します。"
 
-#: ../../tutorials/setup-py-to-pyproject-toml.md:28
-msgid "See [Get to know Hatch](get-to-know-hatch.md) for more information."
+#: ../../tutorials/setup-py-to-pyproject-toml.md:33
+#, fuzzy
+msgid "See [Get to know Hatch](get-to-know-hatch) for more information."
 msgstr "詳しくは [Hatch](get-to-know-hatch.md) を知るをご覧ください。"
 
-#: ../../tutorials/setup-py-to-pyproject-toml.md:31
+#: ../../tutorials/setup-py-to-pyproject-toml.md:36
 msgid "Prerequisites"
 msgstr "前提条件"
 
-#: ../../tutorials/setup-py-to-pyproject-toml.md:33
+#: ../../tutorials/setup-py-to-pyproject-toml.md:38
 msgid ""
 "Before we begin, ensure that you have Hatch installed on your system. You"
 " can install it via pip:"
 msgstr "始める前に、システムにHatchがインストールされていることを確認してください。pipでインストールできます:"
 
-#: ../../tutorials/setup-py-to-pyproject-toml.md:39
+#: ../../tutorials/setup-py-to-pyproject-toml.md:44
 msgid "Sample Directory Tree"
 msgstr "サンプルディレクトリツリー"
 
-#: ../../tutorials/setup-py-to-pyproject-toml.md:41
+#: ../../tutorials/setup-py-to-pyproject-toml.md:46
 msgid ""
 "Let's take a look at a sample directory tree structure before and after "
 "using `hatch init`:"
 msgstr "それでは、 `hatch init` を使う前と後のディレクトリツリー構造のサンプルを見てみましょう: "
 
-#: ../../tutorials/setup-py-to-pyproject-toml.md:43
+#: ../../tutorials/setup-py-to-pyproject-toml.md:48
 msgid "Before `hatch init`"
 msgstr "`hatch init` 前"
 
-#: ../../tutorials/setup-py-to-pyproject-toml.md:59
+#: ../../tutorials/setup-py-to-pyproject-toml.md:64
 msgid "After `hatch init`"
 msgstr "`hatch init` 後"
 
-#: ../../tutorials/setup-py-to-pyproject-toml.md:77
+#: ../../tutorials/setup-py-to-pyproject-toml.md:82
 msgid ""
 "As you can see, the main change after running `hatch init` is the "
 "addition of the `pyproject.toml` file in the project directory."
@@ -6319,38 +6724,39 @@ msgstr ""
 "ご覧のように、 `hatch init` を実行した後の主な変化は、プロジェクトディレクトリに `pyproject.toml` "
 "ファイルが追加されたことです。"
 
-#: ../../tutorials/setup-py-to-pyproject-toml.md:79
+#: ../../tutorials/setup-py-to-pyproject-toml.md:84
 msgid "Step-by-Step Guide"
 msgstr "ステップバイステップガイド"
 
-#: ../../tutorials/setup-py-to-pyproject-toml.md:81
+#: ../../tutorials/setup-py-to-pyproject-toml.md:86
 msgid ""
 "Now, let's walk through the steps to use Hatch to create a "
 "`pyproject.toml` file for your project."
 msgstr "では、Hatchを使ってプロジェクトの `pyproject.toml` ファイルを作成する手順を説明しましょう。"
 
-#: ../../tutorials/setup-py-to-pyproject-toml.md:83
+#: ../../tutorials/setup-py-to-pyproject-toml.md:88
 msgid ""
 "**Navigate to Your Project Directory**: Open your terminal or command "
 "prompt and navigate to the directory where your Python project is "
 "located."
 msgstr "**プロジェクトディレクトリに移動する**: ターミナルかコマンドプロンプトを開き、Pythonプロジェクトがあるディレクトリに移動します。"
 
-#: ../../tutorials/setup-py-to-pyproject-toml.md:85
+#: ../../tutorials/setup-py-to-pyproject-toml.md:90
 msgid ""
 "**Initialize Hatch**: Run the following command to initialize Hatch in "
 "your project directory:"
 msgstr "**Hatchの初期化**: 以下のコマンドを実行し、プロジェクトディレクトリのHatchを初期化します:"
 
-#: ../../tutorials/setup-py-to-pyproject-toml.md:91
+#: ../../tutorials/setup-py-to-pyproject-toml.md:96
+#, fuzzy
 msgid ""
 "**Review and Customize**: After running the previous command, Hatch will "
 "automatically generate a `pyproject.toml` file based on your existing "
 "project configuration. Take some time to review the contents of the "
 "generated `pyproject.toml` file. You may want to customize certain "
 "settings or dependencies based on your project's requirements (see "
-"[pyproject.toml tutorial](pyproject-toml.md) for more information about "
-"the `pyproject.toml`)."
+"[pyproject.toml tutorial](pyproject-toml) for more information about the "
+"`pyproject.toml`)."
 msgstr ""
 "**レビューとカスタマイズ**: 先ほどのコマンドを実行すると、Hatchは既存のプロジェクト構成に基づいて `pyproject.toml` "
 "ファイルを自動的に生成します。 生成された `pyproject.toml` "
@@ -6358,16 +6764,17 @@ msgstr ""
 "`pyproject.toml` の詳細については [pyproject.toml](pyproject-toml.md) "
 "チュートリアルを参照してください)。"
 
-#: ../../tutorials/setup-py-to-pyproject-toml.md:93
+#: ../../tutorials/setup-py-to-pyproject-toml.md:98
+#, fuzzy
 msgid ""
 "**Verify**: Verify that the `pyproject.toml` file accurately reflects "
 "your project configuration and dependencies. You can manually edit the "
-"file if needed, but be cautious and ensure that the syntax is correct."
+"file, but be cautious and ensure that the syntax is correct."
 msgstr ""
 "**検証**: `pyproject.toml` ファイルがプロジェクト構成と依存関係を正確に反映していることを確認します。 "
 "必要であればファイルを手動で編集することもできますが、慎重を期して構文が正しいことを確認してください。"
 
-#: ../../tutorials/setup-py-to-pyproject-toml.md:95
+#: ../../tutorials/setup-py-to-pyproject-toml.md:100
 msgid ""
 "**Delete setup.py**: Since we're migrating to using `pyproject.toml` "
 "exclusively, the `setup.py` file becomes unnecessary. You can safely "
@@ -6376,7 +6783,7 @@ msgstr ""
 "**setup.py を削除する**: `pyproject.toml` のみを使用するように移行するので、 `setup.py` "
 "ファイルは不要になります。 プロジェクトディレクトリから安全に削除できます。"
 
-#: ../../tutorials/setup-py-to-pyproject-toml.md:97
+#: ../../tutorials/setup-py-to-pyproject-toml.md:102
 msgid ""
 "**Test Build**: Before proceeding further, it's essential to ensure that "
 "your project builds successfully using only the `pyproject.toml` file. "
@@ -6385,7 +6792,7 @@ msgstr ""
 "**テストビルド**: 先に進む前に、 `pyproject.toml` "
 "ファイルだけを使ってプロジェクトが正常にビルドされることを確認する必要がある。 以下のコマンドを実行してプロジェクトをビルドします:"
 
-#: ../../tutorials/setup-py-to-pyproject-toml.md:103
+#: ../../tutorials/setup-py-to-pyproject-toml.md:108
 msgid ""
 "This command will build your project based on the specifications in the "
 "`pyproject.toml` file. Make sure to check for any errors or warnings "
@@ -6394,7 +6801,7 @@ msgstr ""
 "このコマンドは `pyproject.toml` ファイルの仕様に基づいてプロジェクトをビルドします。 "
 "ビルドの過程でエラーや警告がないか、必ず確認してください。"
 
-#: ../../tutorials/setup-py-to-pyproject-toml.md:105
+#: ../../tutorials/setup-py-to-pyproject-toml.md:110
 msgid ""
 "**Test Existing Functionality**: After successfully building your project"
 " with `pyproject.toml`, it's crucial to ensure that your project's "
@@ -6403,3 +6810,300 @@ msgid ""
 msgstr ""
 "**既存機能のテスト**: `pyproject.toml` でプロジェクトのビルドに成功したら、 "
 "プロジェクトの既存の機能が損なわれないようにすることが重要です。既存のテストを実行し、すべてが期待通りに動作することを確認します。"
+
+#~ msgid "Make your Python code installable"
+#~ msgstr "Pythonコードをインストール可能にする"
+
+#~ msgid "What we previously covered"
+#~ msgstr "以前取り上げたレッスン"
+
+#~ msgid ""
+#~ "[In the previous lesson](intro), you "
+#~ "learned about what a Python package "
+#~ "is. You also learned about the "
+#~ "[benefits of creating a Python package"
+#~ "](package-benefits)."
+#~ msgstr ""
+#~ "[前のレッスンで](intro) 、Pythonパッケージとは何かについて学びました。また、 "
+#~ "[Pythonパッケージを作成する利点](package-benefits) についても学びました。"
+
+#~ msgid ""
+#~ "Your next step in our packaging "
+#~ "tutorial series is to create a "
+#~ "Python package that is installable both"
+#~ " locally and remotely from a website"
+#~ " such as GitHub (or GitLab). The "
+#~ "package that you create in this "
+#~ "lesson will have the bare minimum "
+#~ "elements needed to be installable into"
+#~ " a Python environment."
+#~ msgstr ""
+#~ "パッケージングチュートリアルシリーズの次のステップは、ローカルでも GitHub (または "
+#~ "GitLab) などのウェブサイトからリモートでもインストール可能な Python "
+#~ "パッケージを作成することです。このレッスンで作成するパッケージは、Python環境にインストールするために必要な最低限の要素しか持っていません。"
+
+#~ msgid ""
+#~ "Making your code installable is an "
+#~ "important steps towards creating a full"
+#~ " Python package that is directly "
+#~ "installable from PyPI."
+#~ msgstr "あなたのコードをインストール可能にすることは、PyPIから直接インストール可能な完全なPythonパッケージを作成するための重要なステップです。"
+
+#~ msgid "Does this lesson run as expected on windows and mac?"
+#~ msgstr "このレッスンは、windowsやmacで期待通りに動きますか？"
+
+#~ msgid ""
+#~ "A basic installable package needs a "
+#~ "few things: code, a [specific package"
+#~ " file structure](https://www.pyopensci.org/python-"
+#~ "package-guide/package-structure-code/python-"
+#~ "package-structure.html) and a `pyproject.toml`"
+#~ " containing your package's name and "
+#~ "version. Once you have these items "
+#~ "in the correct directory structure, you"
+#~ " can pip install your package into"
+#~ " any environment on your computer. "
+#~ "You will learn how to create a "
+#~ "basic installable package in this "
+#~ "lesson."
+#~ msgstr ""
+#~ "基本的なインストール可能パッケージには、以下のものが必要です: コード、 "
+#~ "[特定のパッケージファイル構造](https://www.pyopensci.org/python-package-"
+#~ "guide/package-structure-code/python-package-"
+#~ "structure.html) 、パッケージの名前とバージョンを含む `pyproject.toml` "
+#~ "が必要です。これらのアイテムが正しいディレクトリ構造になっていれば、pipであなたのコンピュータのどの環境にもパッケージをインストールすることができます。このレッスンでは、基本的なインストール可能パッケージの作成方法を学びます。"
+
+#~ msgid ""
+#~ "How to create a basic `pyproject.toml`"
+#~ " file that includes package dependencies"
+#~ " and metadata. This file is required"
+#~ " to make your package installable."
+#~ msgstr ""
+#~ "パッケージの依存関係とメタデータを含む基本的な `pyproject.toml` "
+#~ "ファイルの作成方法。このファイルは、パッケージをインストール可能にするために必要です。"
+
+#~ msgid "**What comes next**"
+#~ msgstr "**次に来るもの**"
+
+#~ msgid "In the upcoming lessons you will learn how to:"
+#~ msgstr "これからのレッスンでは、その方法を学びます:"
+
+#~ msgid "[Publish your package to PyPI](publish-pypi)"
+#~ msgstr "[PyPIへのパッケージの公開](publish-pypi)"
+
+#~ msgid "Add a README file to your package to support community use"
+#~ msgstr "コミュニティの利用をサポートするために、パッケージに README ファイルを追加してください。"
+
+#~ msgid ""
+#~ "Add additional project metadata to your"
+#~ " package to support PyPI publication"
+#~ msgstr "PyPI公開をサポートするために、パッケージにプロジェクトのメタデータを追加します"
+
+#~ msgid "Note about `setup.py`"
+#~ msgstr "`setup.py` についてのメモ"
+
+#~ msgid ""
+#~ "Now that you understand the basics "
+#~ "of the Python package directory "
+#~ "structure, and associated key files "
+#~ "(`__init__.py` and `pyproject.toml`), it's "
+#~ "time to create your Python package! "
+#~ "Below you will create a directory "
+#~ "structure similar to the structure "
+#~ "described above using Hatch."
+#~ msgstr ""
+#~ "Python パッケージのディレクトリ構造の基本を理解し、関連するキーファイル (`__init__.py` "
+#~ "と `pyproject.toml`) を理解したところで、いよいよ Python "
+#~ "パッケージを作成します！ 以下では、Hatchを使って、上で説明したようなディレクトリ構造を作成します。"
+
+#~ msgid "Hatch and project names"
+#~ msgstr "Hatchとプロジェクト名"
+
+#~ msgid ""
+#~ "Hatch makes some decisions for your "
+#~ "project's name when you run `hatch "
+#~ "new`"
+#~ msgstr "`hatch new` を実行したとき、 Hatch は、あなたのプロジェクトの名前を決定します。"
+
+#~ msgid "These include using:"
+#~ msgstr "これには以下のようなものがあります:"
+
+#~ msgid "dashes for the top level directory"
+#~ msgstr "最上位ディレクトリのダッシュ記号"
+
+#~ msgid "dashes for the project name in the pyproject.toml"
+#~ msgstr "pyproject.tomlのプロジェクト名をダッシュで囲みます"
+
+#~ msgid "underscores for the package directory name"
+#~ msgstr "パッケージディレクトリ名のアンダースコア"
+
+#~ msgid "If you use a name with underscores, Hatch will return the same thing:"
+#~ msgstr "アンダースコア付きの名前を使っても、Hatchは同じものを返します:"
+
+#~ msgid ""
+#~ "In both of the examples above the"
+#~ " project name in the pyproject.toml "
+#~ "file that hatch creates is `pyos-"
+#~ "package`."
+#~ msgstr "上記のどちらの例でも、hatchが作成するpyproject.tomlファイルのプロジェクト名は `pyos-package` です。"
+
+#~ msgid "Next run:"
+#~ msgstr "次に実行するのは:"
+
+#~ msgid ""
+#~ "If you don't have code already and"
+#~ " are just learning how to create "
+#~ "a Python package, then create an "
+#~ "empty `add_numbers.py` file. You will "
+#~ "populate the `add_numbers.py` file with "
+#~ "code provided below."
+#~ msgstr ""
+#~ "もしまだコードを持っておらず、Python パッケージの作成方法を学んでいるところなら、空の "
+#~ "`add_numbers.py` ファイルを作成してください。 この `add_numbers.py`"
+#~ " ファイルに以下に示すコードを入力します。"
+
+#~ msgid ""
+#~ "If you are following along and "
+#~ "making a Python package from scratch "
+#~ "then you can add the code below"
+#~ " to your `add_numbers.py` module. The "
+#~ "function below adds two integers "
+#~ "together and returns the result. Notice"
+#~ " that the code below has a few"
+#~ " features that we will review in "
+#~ "future tutorials:"
+#~ msgstr ""
+#~ "Python のパッケージをゼロから作るのであれば、以下のコードを `add_numbers.py` "
+#~ "モジュールに追加してください。 "
+#~ "以下の関数は2つの整数を加算して結果を返します。以下のコードには、今後のチュートリアルで確認するいくつかの機能があることに注目してください:"
+
+#~ msgid ""
+#~ "If you aren't familiar with docstrings"
+#~ " or typing yet, that is ok. You"
+#~ " can review [this page in the "
+#~ "pyOpenSci packaging guide](https://www.pyopensci.org"
+#~ "/python-package-guide/documentation/write-user-"
+#~ "documentation/document-your-code-api-"
+#~ "docstrings.html) for an overview of both"
+#~ " topics."
+#~ msgstr ""
+#~ "もしあなたがまだdocstringsやタイピングに慣れていなくても大丈夫です。 両方のトピックの概要については、 "
+#~ "[pyOpenSciパッケージングガイドのこのページ](https://www.pyopensci.org/python-"
+#~ "package-guide/documentation/write-user-documentation"
+#~ "/document-your-code-api-docstrings.html) "
+#~ "を参照してください。"
+
+#~ msgid ""
+#~ "Next, you will modify some of the"
+#~ " metadata (information) that Hatch adds "
+#~ "to your `pyproject.toml` file. You are"
+#~ " are welcome to copy the file "
+#~ "we have in our [example pyospackage "
+#~ "GitHub repository](https://github.com/pyOpenSci/pyosPackage)."
+#~ msgstr ""
+#~ "次に、Hatchが `pyproject.toml` ファイルに追加するメタデータ (情報) "
+#~ "の一部を変更します。私たちの [example pyospackage "
+#~ "GitHubリポジトリ](https://github.com/pyOpenSci/pyosPackage) "
+#~ "にあるファイルをコピーしてください。"
+
+#~ msgid "Edit the file as follows:"
+#~ msgstr "以下のようにファイルを編集します:"
+
+#~ msgid ""
+#~ "Delete `dynamic = [\"version\"]`: This "
+#~ "sets up dynamic versioning based on "
+#~ "tags stored in your git commit "
+#~ "history. We will walk through "
+#~ "implementing this in a later lesson."
+#~ msgstr ""
+#~ "`dynamic = [\"version\"]` を削除する: これは、git "
+#~ "のコミット履歴に保存されているタグに基づいて、動的なバージョン管理を設定します。後のレッスンでこの実装方法を説明します。"
+
+#~ msgid ""
+#~ "Add `version = \"0.1\"` in the "
+#~ "place of  `dynamic = [\"version\"]` "
+#~ "which you just deleted. This sets "
+#~ "up manual versioning."
+#~ msgstr ""
+#~ "先ほど削除した `dynamic = [\"version\"]` の場所に "
+#~ "`version = \"0.1\"` を追加します。これで手動バージョン管理が設定されます。"
+
+#~ msgid "Fill in the description if it doesn't already exist."
+#~ msgstr "説明文がなければ記入してください。"
+
+#~ msgid "Remove the `[tool.hatch.version]` table from the bottom of the file."
+#~ msgstr "ファイルの一番下にある `[tool.hatch.version]` テーブルを削除します。"
+
+#~ msgid "OPTIONAL: Adjust project classifiers"
+#~ msgstr "オプション: プロジェクトの分類子を調整する"
+
+#~ msgid ""
+#~ "Hatch by default provides a list "
+#~ "of classifiers that define what Python"
+#~ " versions your package supports. These "
+#~ "classifiers do not in any way "
+#~ "impact your package's build and are "
+#~ "primarily intended to be used when "
+#~ "you publish your package to PyPI."
+#~ msgstr "Hatchはデフォルトで、パッケージがサポートするPythonのバージョンを定義する分類子のリストを提供します。これらの分類子はパッケージのビルドには一切影響を与えず、主にパッケージをPyPIに公開するときに使用することを目的としています。"
+
+#~ msgid ""
+#~ "If you don't plan on publishing to"
+#~ " PyPI, you can skip this section. "
+#~ "However, if you wish, you can "
+#~ "clean it up a bit."
+#~ msgstr "PyPIに公開する予定がなければ、このセクションは飛ばして構いません。しかし、もし望むなら、少しきれいにすることもできます。"
+
+#~ msgid "To begin:"
+#~ msgstr "はじめに:"
+
+#~ msgid "Remove support for Python 3.8"
+#~ msgstr "Python 3.8のサポートを削除"
+
+#~ msgid ""
+#~ "Within the `[project]` table, update "
+#~ "`requires-python = \">3.8\"` to "
+#~ "`requires-python = \">3.9\"`"
+#~ msgstr ""
+#~ "`[project]` テーブル内で、 `requires-python = "
+#~ "\">3.8\"` を `requires-python = \">3.9\"`"
+#~ " に更新します。"
+
+#~ msgid ""
+#~ "Since you are creating a pure "
+#~ "Python package in this lesson, you "
+#~ "can remove the following classifiers:"
+#~ msgstr "このレッスンでは純粋な Python パッケージを作成するので、以下の分類子は削除してかまいません:"
+
+#~ msgid "Your new pyproject.toml file should now look something like this:"
+#~ msgstr "新しいpyproject.tomlファイルは次のようになるはずです:"
+
+#~ msgid "Let's break down `python -m pip install -e .`"
+#~ msgstr "`python -m pip install -e .` を分解してみましょう"
+
+#~ msgid "In the upcoming lessons you will:"
+#~ msgstr "これからのレッスンではあなたは:"
+
+#~ msgid ""
+#~ "Learn how to [build and publish "
+#~ "your Python package to (test) PyPI"
+#~ "](publish-pypi)"
+#~ msgstr "[Python パッケージをビルドして (test) PyPI に公開する](publish-pypi) 方法を学びましょう。"
+
+#~ msgid "Add a README file and LICENSE to your package"
+#~ msgstr "READMEファイルとLICENSEをパッケージに追加する。"
+
+#~ msgid ""
+#~ "Add more metadata to your "
+#~ "`pyproject.toml` file to support PyPI "
+#~ "publication."
+#~ msgstr "PyPI での公開をサポートするために `pyproject.toml` ファイルにメタデータを追加します。"
+
+#~ msgid "learn how to publish to **conda-forge** from **PyPI**."
+#~ msgstr "**PyPI** から **conda-forge** に公開する方法を学んでください。"
+
+#~ msgid "Make your code installable"
+#~ msgstr "コードをインストール可能にする"
+
+#~ msgid "Renaming your project before publishing"
+#~ msgstr "公開前にプロジェクト名を変更する"


### PR DESCRIPTION
Updated the Japanese translation files using `nox -s update-language -- ja` to make sure they are up to date with the current English version in preparation for the SciPy sprints.