### PR TITLE
Remove stray characters at end of tutorial

### DIFF
--- a/tutorials/publish-pypi.md
+++ b/tutorials/publish-pypi.md
@@ -394,10 +394,6 @@ Once you publish on PyPI, you can then easily add your package to the conda-forg
 
 You will learn how to do that in the next lesson.
 
-
-
-
 ## Footnotes
 
 [^venv]: https://docs.python.org/3/library/venv.html
-```


### PR DESCRIPTION
The `publish-pypi.md` file ends with the start of code block (https://github.com/pyOpenSci/python-package-guide/blob/01de29ee6f6a08f4d1bd433ad6ea1824788c1396/tutorials/publish-pypi.md?plain=1#L403) and this causes issues when rendering the page, as per the attached screenshot:

<img width="1197" height="922" alt="8F3JL4LMRzdgT9p" src="https://github.com/user-attachments/assets/027d4cd2-867a-4e10-a253-806c3141eb84" />

This is a tiny fix while working on the trusted publishing tutorial (#253).