### PR TITLE
colors for hovertext in light and dark mode

### DIFF
--- a/_ext/translation_graph.py
+++ b/_ext/translation_graph.py
@@ -143,12 +143,14 @@ class TranslationGraph(Directive):
         )
         # Create figure
         fig = go.Figure(data=heatmap)
+
+        # plotly only lets us use css variables for colors in some places,
+        # and plotly otherwise inlines a lot of CSS itself.
+        # so colors are partially specified here, and partially (forcefully)
+        # overridden in _static/pyos.css
         fig.update_layout(
             paper_bgcolor="rgba(0,0,0,0)",
             plot_bgcolor="rgba(0,0,0,0)",
-            hoverlabel_bgcolor="var(--bs-body-bg)",
-            hoverlabel_font_color="var(--bs-body-color)",
-            font_color="var(--bs-body-color)",
             margin=dict(l=40, r=40, t=40, b=40),
             xaxis_showgrid=False,
             xaxis_side="top",

--- a/_static/pyos.css
+++ b/_static/pyos.css
@@ -428,6 +428,11 @@ th {
     fill: var(--pst-color-text-base) !important;
   }
 
+  g.hovertext > path:first-child {
+    fill: var(--pst-color-background) !important;
+    stroke: var(--pst-color-border) !important;
+  }
+
   @media (max-width: 540px) {
     g.heatmap-label > text {
       display: none;


### PR DESCRIPTION
related to: https://github.com/pyOpenSci/python-package-guide/pull/539
fixes: https://github.com/pyOpenSci/python-package-guide/issues/532

sorry i couldn't help with this during the sprint - i puzzled over this for quite awhile in the initial implementation, i was just afk during those hours.

the basic problem is that plotly has a pretty messy way of handling styles. there isn't *really* a uniform way of passing style information through a complex plot object, and in particular it seems to accept full css expressions in some places, plotly-specific values other places - and probably most confusing, an undocumented subset of css in a third set of places.

font color seems to be one of those third places, where if you pass an `rgb(x,y,z)` string there, it works, but everything else is *silently* ignored (programming lesson for any newbies that may see this! fail loudly!) So while we're passing valid CSS through in the layout call, it silently strips it out, so those `var(--bs-body-color)` are just dropped and do nothing. 

second layer of the problem is that plotly then injects its own inline CSS for all the generated svg objects. in css, styles that are applied directly on an element have the highest priority, so there isn't a way for us you override them except to use the accursed `!important` flag (and i couldn't find a way to tell plotly to just *not* inject styles.

@lwasser finding the correct class for the hover text is challenging here compared to a "normal" hover effect because it's not a css hover effect, but a JS-based one where the DOM element ceases to exist once you stop hovering. the only way i found to actually figure out what selector to use there is a sort of hack, where i hovered, right clicked, inspect element, and then positioned the element inspector underneath where my mouse would be on a prior opening so that the plotly JS wouldn't detect my mouse having moved (and thus remove the hover DOM element). super janky. 

i sorta think at this point that just manually templating SVG would be easier than using plotly, but here we are.

 
<img width="282" height="236" alt="Screenshot 2025-07-16 at 6 35 18 PM" src="https://github.com/user-attachments/assets/47fe835e-7933-44b1-8fa4-2645610445a5" />
<img width="285" height="244" alt="Screenshot 2025-07-16 at 6 35 09 PM" src="https://github.com/user-attachments/assets/1f94a645-9bbd-4bd7-8fbb-8b207a10b3b6" />
