### PR TITLE
spanish translation documentation.po from lines 470-1180

### DIFF
--- a/locales/es/LC_MESSAGES/documentation.po
+++ b/locales/es/LC_MESSAGES/documentation.po
@@ -468,7 +468,7 @@ msgstr "Este archivo se crea con Sphinx y el tema `furo`."
 
 #: ../../documentation/hosting-tools/website-hosting-optimizing-your-docs.md:1
 msgid "Optimizing your documentation so search engines (and other users) find it"
-msgstr ""
+msgstr "Optimiza tu documentación para que los motores de búsqueda (y otros usuarios) la encuentren"
 
 #: ../../documentation/hosting-tools/website-hosting-optimizing-your-docs.md:3
 msgid ""
@@ -476,6 +476,10 @@ msgid ""
 "to add some core Sphinx extensions (and theme settings) that will help "
 "search engines such as Google find your documentation."
 msgstr ""
+"Si estás interesado en que más gente encuentre tu paquete, puede que "
+"quieras añadir algunas extensiones de Sphinx (y configuraciones de tema) "
+"que ayudarán a los motores de búsqueda como Google a encontrar tu "
+"documentación."
 
 #: ../../documentation/hosting-tools/website-hosting-optimizing-your-docs.md:7
 msgid "Google Analytics"
@@ -494,12 +498,23 @@ msgid ""
 "[Cloudflare Web Analytics](https://www.cloudflare.com/web-analytics/) and"
 " [Matomo](https://matomo.org) for web analytics."
 msgstr ""
+"Google Analytics [no cumple con el Reglamento General de Protección de "
+"Datos (RGPD) europeo](https://matomo.org/blog/2022/05/google-analytics-4-"
+"gdpr/). Aunque este reglamento tiene muchos componentes, uno de los "
+"elementos centrales es que tienes que informar a los usuarios en tu sitio"
+" que estás recopilando datos y que deben dar su consentimiento. Si bien "
+"es posible añadir infraestructura en torno a Google Analytics para que se"
+" acerque al cumplimiento de las regulaciones del RGPD, la comunidad se "
+"está alejando lentamente de Google utilizando herramientas abiertas como "
+"[Plausible](https://plausible.io/), [Cloudflare Web "
+"Analytics](https://www.cloudflare.com/web-analytics/) y [Matomo](https://matomo.org) "
+"para el análisis web."
 
 #: ../../documentation/hosting-tools/website-hosting-optimizing-your-docs.md:13
 msgid ""
 "pyOpenSci is currently looking into free options for open source "
 "developers."
-msgstr ""
+msgstr "pyOpenSci está investigando actualmente opciones gratuitas para desarrolladores de código abierto."
 
 #: ../../documentation/hosting-tools/website-hosting-optimizing-your-docs.md:16
 msgid ""
@@ -512,6 +527,13 @@ msgid ""
 "extension will add a Google Analytics site tag to each page of your "
 "documentation."
 msgstr ""
+"Algunos de los [temas de sphinx como `pydata-sphinx-theme` y sphinx-book-"
+"theme tienen soporte integrado para Google Analytics](https://pydata-"
+"sphinx-theme.readthedocs.io/en/latest/user_guide/analytics.html#google-"
+"analytics). Sin embargo, si el tema que elegiste no ofrece soporte para "
+"Google Analytics, puedes usar la extensión [`sphinxcontrib-gtagjs`](https://github.com/attakei/sphinxcontrib-gtagjs). "
+"Esta extensión añadirá una etiqueta de sitio de Google Analytics a cada "
+"página de tu documentación."
 
 #: ../../documentation/hosting-tools/website-hosting-optimizing-your-docs.md:22
 msgid ""
@@ -519,6 +541,9 @@ msgid ""
 "sitemap.readthedocs.io/en/latest/index.html) for search engine "
 "optimization"
 msgstr ""
+"[sphinx-sitemap](https://sphinx-"
+"sitemap.readthedocs.io/en/latest/index.html) para la optimización de "
+"motores de búsqueda"
 
 #: ../../documentation/hosting-tools/website-hosting-optimizing-your-docs.md:24
 msgid ""
@@ -527,6 +552,11 @@ msgid ""
 " is the most popular search engine. And if your documentation is search "
 "optimized, users are more likely to find your package!"
 msgstr ""
+"Aunque estamos tratando de alejarnos de Google Analytics debido a "
+"problemas de cumplimiento y privacidad, la optimización para motores de "
+"búsqueda sigue siendo importante. Google es el motor de búsqueda más "
+"popular. ¡Y si tu documentación está optimizada para búsquedas, es más "
+"probable que los usuarios encuentren tu paquete!"
 
 #: ../../documentation/hosting-tools/website-hosting-optimizing-your-docs.md:30
 msgid ""
@@ -535,10 +565,15 @@ msgid ""
 "sitemap to Google and it will index your entire site. This over time can "
 "make the content on your site more visible to others when they search."
 msgstr ""
+"Si estás interesado en optimizar tu documentación para motores de "
+"búsqueda como Google, querrás un archivo **sitemap.xml**. Puedes enviar "
+"este mapa del sitio a Google y este indexará todo tu sitio. Con el "
+"tiempo, esto puede hacer que el contenido de tu sitio sea más visible "
+"para otros cuando realicen búsquedas."
 
 #: ../../documentation/hosting-tools/website-hosting-optimizing-your-docs.md:36
 msgid "This extension is lightweight."
-msgstr ""
+msgstr "Esta extensión es ligera."
 
 #: ../../documentation/hosting-tools/website-hosting-optimizing-your-docs.md:38
 msgid ""
@@ -546,6 +581,10 @@ msgid ""
 "and site your documentation base url](https://sphinx-"
 "sitemap.readthedocs.io/en/latest/getting-started.html)."
 msgstr ""
+"[Requiere que lo añadas a tu lista de extensiones en `conf.py` de Sphinx "
+"y que indiques la URL base de tu "
+"documentación](https://sphinx-sitemap.readthedocs.io/en/latest/getting-"
+"started.html)."
 
 #: ../../documentation/hosting-tools/website-hosting-optimizing-your-docs.md:40
 msgid "[sphinxext.opengraph](https://github.com/wpilibsuite/sphinxext-opengraph)"
@@ -562,10 +601,18 @@ msgid ""
 "media sites like Twitter and Mastodon and even for shares on tools like "
 "Slack and Discourse."
 msgstr ""
+"OpenGraph es una extensión que te permite añadir metadatos a las páginas "
+"de contenido de tu documentación. [El protocolo OpenGraph permite que "
+"otros sitios web ofrezcan una vista previa útil del contenido de tu "
+"página cuando se comparte](https://www.freecodecamp.org/news/what-is-"
+"open-graph-and-how-can-i-use-it-for-my-website/#heading-what-is-open-"
+"graph). Esto es importante cuando las páginas de tu documentación se "
+"comparten en redes sociales como Twitter y Mastodon, e incluso para "
+"compartirlas en herramientas como Slack y Discourse."
 
 #: ../../documentation/index.md:3
 msgid "Documentation Overview"
-msgstr ""
+msgstr "Resumen de la Documentación"
 
 #: ../../documentation/index.md:3 ../../documentation/index.md:10
 #: ../../documentation/index.md:21 ../../documentation/index.md:42
@@ -574,75 +621,75 @@ msgstr "Introducción"
 
 #: ../../documentation/index.md:10
 msgid "Create Your Docs"
-msgstr ""
+msgstr "Crea Tus Documentos"
 
 #: ../../documentation/index.md:10
 msgid "Document Your Code (API)"
-msgstr ""
+msgstr "Documenta tu Código (API)"
 
 #: ../../documentation/index.md:10
 msgid "Create Package Tutorials"
-msgstr ""
+msgstr "Crear Tutoriales del Paquete"
 
 #: ../../documentation/index.md:10
 msgid "Write User Documentation"
-msgstr ""
+msgstr "Escribir Documentación para el Usuario"
 
 #: ../../documentation/index.md:21
 msgid "Contributing File"
-msgstr ""
+msgstr "Archivo de Contribución"
 
 #: ../../documentation/index.md:21
 msgid "Development Guide"
-msgstr ""
+msgstr "Guía de Desarrollo"
 
 #: ../../documentation/index.md:21
 msgid "Changelog File"
-msgstr ""
+msgstr "Archivo de Registro de Cambios"
 
 #: ../../documentation/index.md:21
 msgid "Docs for Contributors & Maintainers"
-msgstr ""
+msgstr "Documentación para Colaboradores y Mantenedores"
 
 #: ../../documentation/index.md:32
 msgid "README file"
-msgstr ""
+msgstr "Archivo README"
 
 #: ../../documentation/index.md:32
 msgid "Code of Conduct File"
-msgstr ""
+msgstr "Archivo de Código de Conducta"
 
 #: ../../documentation/index.md:32
 msgid "LICENSE files"
-msgstr ""
+msgstr "Archivos de LICENCIA"
 
 #: ../../documentation/index.md:32
 msgid "Community Docs"
-msgstr ""
+msgstr "Documentación de la Comunidad"
 
 #: ../../documentation/index.md:42
 msgid "Sphinx for Docs"
-msgstr ""
+msgstr "Sphinx para Documentación"
 
 #: ../../documentation/index.md:42
 msgid "myST vs Markdown vs rst"
-msgstr ""
+msgstr "myST vs Markdown vs rst"
 
 #: ../../documentation/index.md:42
 msgid "Publish Your Docs"
-msgstr ""
+msgstr "Publica tu Documentación"
 
 #: ../../documentation/index.md:42
 msgid "Website Hosting and Optimization"
-msgstr ""
+msgstr "Alojamiento y Optimización de Sitios Web"
 
 #: ../../documentation/index.md:42
 msgid "Publication tools for your docs"
-msgstr ""
+msgstr "Herramientas de publicación para tu documentación"
 
 #: ../../documentation/index.md:1
 msgid "Documentation for your Open Source Python Package"
-msgstr ""
+msgstr "Documentación para tu Paquete de Python de Código Abierto"
 
 #: ../../documentation/index.md:55
 msgid ""
@@ -654,16 +701,26 @@ msgid ""
 "requirements. Our requirements are focused on the documentation content "
 "of your package."
 msgstr ""
+"Ten en cuenta que las herramientas que se discuten aquí son las que vemos"
+" que se usan comúnmente en la comunidad. A medida que las herramientas "
+"evolucionen, actualizaremos esta guía. Si estás enviando un paquete para "
+"la revisión por pares de pyOpenSci y usas otras herramientas que no "
+"están en nuestra guía para construir tu paquete, ¡aún puedes enviarlo "
+"para su revisión! Las herramientas enumeradas aquí son sugerencias, no "
+"requisitos. Nuestros requisitos se centran en el contenido de la "
+"documentación de tu paquete."
 
 #: ../../documentation/index.md:65
 msgid "Documentation is critical for your Python package's success"
-msgstr ""
+msgstr "La documentación es fundamental para el éxito de tu paquete de Python"
 
 #: ../../documentation/index.md:67
 msgid ""
 "Documentation is as important to the success of your Python open source "
 "package as the code itself."
 msgstr ""
+"La documentación es tan importante para el éxito de tu paquete de Python "
+"de código abierto como el propio código."
 
 #: ../../documentation/index.md:70
 msgid ""
@@ -671,26 +728,31 @@ msgid ""
 " done. However, if users don't understand how to use your package in "
 "their workflows, then they won't use it."
 msgstr ""
+"La calidad del código es, por supuesto, valiosa, ya que es la forma en "
+"que tu paquete realiza las tareas. Sin embargo, si los usuarios no "
+"entienden cómo usar tu paquete en sus flujos de trabajo, no lo usarán."
 
 #: ../../documentation/index.md:73
 msgid ""
 "Further, explicitly documenting how to contribute is important if you "
 "wish to build a base of contributors to your package."
 msgstr ""
+"Además, documentar explícitamente cómo contribuir es importante si "
+"deseas construir una base de colaboradores para tu paquete."
 
 #: ../../documentation/index.md:76
 msgid "Two types of Python package users"
-msgstr ""
+msgstr "Dos tipos de usuarios de paquetes de Python"
 
 #: ../../documentation/index.md:78
 msgid ""
 "The documentation that you write for your package should target two types"
 " of users:"
-msgstr ""
+msgstr "La documentación que escribas para tu paquete debe dirigirse a dos tipos de usuarios:"
 
 #: ../../documentation/index.md:81
 msgid "1. Basic Tool Users"
-msgstr ""
+msgstr "1. Usuarios Básicos de la Herramienta"
 
 #: ../../documentation/index.md:83
 msgid ""
@@ -699,56 +761,72 @@ msgid ""
 " expert programmers. But they might not have a background in software "
 "development. These users need to know:"
 msgstr ""
+"Los Usuarios Básicos de la Herramienta son las personas que usarán el "
+"código de tu paquete en sus flujos de trabajo de Python. Pueden ser "
+"nuevos (o principiantes) en Python y/o en la ciencia de datos. O "
+"programadores expertos. Pero puede que no tengan experiencia en "
+"desarrollo de software. Estos usuarios necesitan saber:"
 
 #: ../../documentation/index.md:88
 msgid "How to install your package"
-msgstr ""
+msgstr "Cómo instalar tu paquete"
 
 #: ../../documentation/index.md:89
 msgid "How to install dependencies that your package requires"
-msgstr ""
+msgstr "Cómo instalar las dependencias que requiere tu paquete"
 
 #: ../../documentation/index.md:90
 msgid "How to get started using the code base"
-msgstr ""
+msgstr "Cómo empezar a usar la base de código"
 
 #: ../../documentation/index.md:91
 msgid ""
 "Information on how to cite your code / give you credit if they are using "
 "it in a research application."
 msgstr ""
+"Información sobre cómo citar tu código / darte crédito si lo están "
+"usando en una aplicación de investigación."
 
 #: ../../documentation/index.md:93
 msgid ""
 "Information on the license that your code uses so they know how they can "
 "or can't use the code in an operational setting."
 msgstr ""
+"Información sobre la licencia que utiliza tu código para que sepan cómo "
+"pueden o no pueden usar el código en un entorno operativo."
 
 #: ../../documentation/index.md:96
 msgid "2. Potential tool contributors"
-msgstr ""
+msgstr "2. Potenciales colaboradores de la herramienta"
 
 #: ../../documentation/index.md:98
 msgid ""
 "The other subset of users are more experienced and/or more engaged with "
 "your package. As such they are potential contributors. These users:"
 msgstr ""
+"El otro grupo de usuarios, lo que tienen más experiencia y/o está más "
+"involucrado con tu paquete. Ellos como tal, son colaboradores potenciales. "
+"Estos usuarios:"
 
 #: ../../documentation/index.md:102
 msgid "might have a software development background,"
-msgstr ""
+msgstr "pueden tener experiencia en desarrollo de software,"
 
 #: ../../documentation/index.md:103
 msgid ""
 "might also be able to contribute bug fixes to your package or updates to "
 "your documentation"
 msgstr ""
+"también podrían contribuir con correcciones de errores a tu paquete o "
+"actualizaciones a tu documentación"
 
 #: ../../documentation/index.md:104
 msgid ""
 "might also just be users who will find spelling errors in your "
 "documentation, or bugs in your tutorials."
 msgstr ""
+"también podrían ser simplemente usuarios que encontrarán errores de "
+"ortografía en tu documentación o errores en tus tutoriales."
 
 #: ../../documentation/index.md:106
 msgid ""
@@ -756,18 +834,25 @@ msgid ""
 "also need to understand how you'd like for them to contribute to your "
 "package. These potential contributors need:"
 msgstr ""
+"Estos usuarios necesitan todo lo que un usuario básico necesita. Pero "
+"también necesitan entender cómo te gustaría que contribuyeran a tu "
+"paquete. Estos colaboradores potenciales necesitan:"
 
 #: ../../documentation/index.md:110
 msgid ""
 "A development guide to help them understand the infrastructure used in "
 "your package repository."
 msgstr ""
+"Una guía de desarrollo para ayudarles a entender la infraestructura "
+"utilizada en el repositorio de tu paquete."
 
 #: ../../documentation/index.md:111
 msgid ""
 "Contributing guidelines that clarify the types of contributions that you "
 "welcome and how you'd prefer those contributions to be submitted."
 msgstr ""
+"Directrices de contribución que aclaren los tipos de contribuciones que "
+"aceptas y cómo prefieres que se envíen esas contribuciones."
 
 #: ../../documentation/index.md:114
 msgid ""
@@ -777,10 +862,17 @@ msgid ""
 "a code fix that includes a new test that covers an edge-case that they "
 "discovered."
 msgstr ""
+"Es importante recordar que la definición de lo que es una contribución "
+"puede ser amplia. Una contribución podría ser algo tan simple como un "
+"informe de error. O corregir un problema de ortografía en tu "
+"documentación. O podría ser una corrección de código que incluye una "
+"nueva prueba que cubre un caso límite que descubrieron."
 
 #: ../../documentation/index.md:120
 msgid "Documentation elements that pyOpenSci looks for reviewing a Python package"
 msgstr ""
+"Elementos de documentación que pyOpenSci busca al revisar un paquete de "
+"Python"
 
 #: ../../documentation/index.md:122
 msgid ""
@@ -789,6 +881,11 @@ msgid ""
 "and elements that we look for specifically can be found in our peer "
 "review check list (see link below)."
 msgstr ""
+"En la revisión abierta por pares de pyOpenSci, buscamos una estructura "
+"de documentación que apoye tanto a los usuarios de tu herramienta como a "
+"los colaboradores potenciales. Los archivos y elementos que buscamos "
+"específicamente se pueden encontrar en nuestra lista de verificación de "
+"revisión por pares (ver enlace a continuación)."
 
 #: ../../documentation/index.md:127
 msgid ""
@@ -796,10 +893,13 @@ msgid ""
 "elements that you should consider in your package's documentation in more"
 " detail."
 msgstr ""
+"En esta guía, discutimos cada elemento requerido y también discutimos "
+"otros elementos que deberías considerar en la documentación de tu paquete"
+" con más detalle."
 
 #: ../../documentation/index.md:131
 msgid "View pyOpenSci peer review check list"
-msgstr ""
+msgstr "Ver la lista de verificación de la revisión por pares de pyOpenSci"
 
 #: ../../documentation/index.md:138
 msgid ""
@@ -807,6 +907,9 @@ msgid ""
 "in the image include code of conduct.md contributing.md license.txt and "
 "readme.md."
 msgstr ""
+"Imagen que muestra los archivos en el repositorio de GitHub de "
+"MovingPandas. Los archivos en la imagen incluyen code of conduct.md, "
+"contributing.md, license.txt y readme.md."
 
 #: ../../documentation/index.md:144
 msgid ""
@@ -814,10 +917,14 @@ msgid ""
 "files in it including CONTRIBUTING.md, README.md, CODE_OF_CONDUCT.md and "
 "a LICENSE.txt file. *(screen shot taken Nov 23 2022)*"
 msgstr ""
+"Un ejemplo del repositorio de GitHub de MovingPandas con todos los "
+"archivos principales, incluyendo CONTRIBUTING.md, README.md, "
+"CODE_OF_CONDUCT.md y un archivo LICENSE.txt. *(captura de pantalla "
+"tomada el 23 de noviembre de 2022)*"
 
 #: ../../documentation/index.md:147
 msgid "What's next in this Python package documentation section?"
-msgstr ""
+msgstr "¿Qué sigue en esta sección de documentación de paquetes de Python?"
 
 #: ../../documentation/index.md:149
 msgid ""
@@ -826,10 +933,14 @@ msgid ""
 "will also suggest tools that you can use to build your user-facing "
 "documentation website."
 msgstr ""
+"En esta sección de la guía de paquetes de pyOpenSci, te guiaremos a "
+"través de las mejores prácticas para configurar la documentación de tu "
+"paquete de Python. También te sugeriremos herramientas que puedes usar "
+"para construir el sitio web de documentación orientado al usuario."
 
 #: ../../documentation/index.md:154
 msgid "Todo"
-msgstr ""
+msgstr "Tareas por Hacer"
 
 #: ../../documentation/index.md:156
 msgid ""
@@ -839,14 +950,20 @@ msgid ""
 "is that the package should support, at least, the latest three Python "
 "versions (e.g., 3.8, 3.7, 3.6)."
 msgstr ""
+"Soporte de versiones de Python. Siempre debes ser explícito sobre qué "
+"versiones de Python soporta tu paquete. Mantener la compatibilidad con "
+"versiones antiguas de Python puede ser difícil a medida que la "
+"funcionalidad cambia. Una buena regla general es que el paquete debe "
+"soportar, al menos, las últimas tres versiones de Python (por ejemplo, "
+"3.8, 3.7, 3.6)."
 
 #: ../../documentation/repository-files/changelog-file.md:1
 msgid "CHANGELOG.md Guide"
-msgstr ""
+msgstr "Guía de CHANGELOG.md"
 
 #: ../../documentation/repository-files/changelog-file.md:3
 msgid "Introduction"
-msgstr ""
+msgstr "Introducción"
 
 #: ../../documentation/repository-files/changelog-file.md:5
 msgid ""
@@ -856,10 +973,16 @@ msgid ""
 "contributors stay informed about new features, bug fixes, and other "
 "changes introduced in each release."
 msgstr ""
+"El documento `CHANGELOG.md` sirve como un recurso valioso tanto para los "
+"desarrolladores como para los usuarios para seguir la evolución de un "
+"proyecto a lo largo del tiempo. Comprender la estructura y el propósito "
+"de un registro de cambios ayuda a los usuarios y colaboradores a "
+"mantenerse informados sobre nuevas características, correcciones de "
+"errores y otros cambios introducidos en cada versión."
 
 #: ../../documentation/repository-files/changelog-file.md:7
 msgid "What is CHANGELOG.md?"
-msgstr ""
+msgstr "¿Qué es CHANGELOG.md?"
 
 #: ../../documentation/repository-files/changelog-file.md:9
 msgid ""
@@ -868,6 +991,10 @@ msgid ""
 "users understand what has been added, fixed, modified, or removed with "
 "each version of the software."
 msgstr ""
+"El propósito principal de `CHANGELOG.md` es proporcionar un registro de "
+"los cambios notables realizados en el proyecto con cada nueva versión. "
+"Este documento ayuda a los usuarios a comprender qué se ha añadido, "
+"corregido, modificado o eliminado con cada versión del software."
 
 #: ../../documentation/repository-files/changelog-file.md:11
 msgid ""
@@ -875,10 +1002,14 @@ msgid ""
 "simple resource for understanding what a changelog is and how to create a"
 " good changelog. It also includes examples of things to avoid."
 msgstr ""
+"[Mantén un CHANGELOG.md](https://keepachangelog.com/en/1.1.0/) es un "
+"recurso excelente y sencillo para entender qué es un registro de cambios "
+"y cómo crear uno bueno. También incluye ejemplos de cosas que se deben "
+"evitar."
 
 #: ../../documentation/repository-files/changelog-file.md:13
 msgid "Versioning your Python package and semantic versioning"
-msgstr ""
+msgstr "Versionado de tu paquete de Python y versionado semántico"
 
 #: ../../documentation/repository-files/changelog-file.md:16
 msgid ""
@@ -886,20 +1017,26 @@ msgid ""
 "the changelog file is a good versioning scheme. Semantic Versioning is "
 "widely used across Python packages."
 msgstr ""
+"Un componente importante de un paquete que sirve como la columna "
+"vertebral del archivo de registro de cambios es un buen esquema de "
+"versiones. El Versionado Semántico es ampliamente utilizado en los "
+"paquetes de Python."
 
 #: ../../documentation/repository-files/changelog-file.md:17
 msgid ""
 "[Creating New Versions of Your Python Package](../../package-structure-"
 "code/python-package-versions.md)"
 msgstr ""
+"[Creación de nuevas versiones de tu paquete de "
+"Python](../../package-structure-code/python-package-versions.md)"
 
 #: ../../documentation/repository-files/changelog-file.md:18
 msgid "[Semantic Versioning](https://semver.org)"
-msgstr ""
+msgstr "[Versionado Semántico](https://semver.org)"
 
 #: ../../documentation/repository-files/changelog-file.md:21
 msgid "Why is it important?"
-msgstr ""
+msgstr "¿Por qué es importante?"
 
 #: ../../documentation/repository-files/changelog-file.md:23
 msgid ""
@@ -909,10 +1046,16 @@ msgid ""
 " changelog up-to-date, project maintainers can build trust with their "
 "user base and demonstrate their commitment to improving the software."
 msgstr ""
+"Un registro de cambios bien mantenido es esencial para una comunicación "
+"transparente con los usuarios y desarrolladores. Sirve como un centro "
+"centralizado para documentar los cambios y resalta el progreso realizado"
+" en cada versión. Al mantener el registro de cambios actualizado, los "
+"mantenedores del proyecto pueden generar confianza con su base de "
+"usuarios y demostrar su compromiso con la mejora del software."
 
 #: ../../documentation/repository-files/changelog-file.md:25
 msgid "What does it include?"
-msgstr ""
+msgstr "¿Qué incluye?"
 
 #: ../../documentation/repository-files/changelog-file.md:27
 msgid ""
@@ -921,18 +1064,28 @@ msgid ""
 " may vary depending on the project's conventions, some common elements "
 "found in changelogs for Python packages include:"
 msgstr ""
+"El contenido de un archivo changelog.md suele seguir un formato "
+"estructurado, detallando los cambios introducidos en cada versión. "
+"Aunque el formato exacto puede variar según las convenciones del "
+"proyecto, algunos elementos comunes que se encuentran en los registros de"
+" cambios de los paquetes de Python incluyen:"
 
 #: ../../documentation/repository-files/changelog-file.md:29
 msgid ""
 "**Versioning**: Clear identification of each release version using "
 "semantic versioning or another versioning scheme adopted by the project."
 msgstr ""
+"**Versionado**: Identificación clara de cada versión de lanzamiento "
+"utilizando el versionado semántico u otro esquema de versionado adoptado "
+"por el proyecto."
 
 #: ../../documentation/repository-files/changelog-file.md:31
 msgid ""
 "**Release Date**: The date when each version was released to the public, "
 "providing context for the timeline of changes."
 msgstr ""
+"**Fecha de lanzamiento**: La fecha en que se lanzó cada versión al "
+"público, proporcionando contexto para la cronología de los cambios."
 
 #: ../../documentation/repository-files/changelog-file.md:33
 msgid ""
@@ -940,6 +1093,9 @@ msgid ""
 "\"Added,\" \"Changed,\" \"Fixed,\" and \"Removed\" to facilitate "
 "navigation and understanding."
 msgstr ""
+"**Categorías de los cambios**: Organizar los cambios en categorías como "
+"\"Añadido\", \"Cambiado\", \"Corregido\" y \"Eliminado\" para facilitar la "
+"navegación y la comprensión."
 
 #: ../../documentation/repository-files/changelog-file.md:35
 msgid ""
@@ -947,6 +1103,9 @@ msgid ""
 "each category, including new features, enhancements, bug fixes, and "
 "deprecated functionality."
 msgstr ""
+"**Descripción de los cambios**: Una descripción concisa de los cambios "
+"realizados en cada categoría, incluyendo nuevas características, "
+"mejoras, correcciones de errores y funcionalidades obsoletas."
 
 #: ../../documentation/repository-files/changelog-file.md:37
 msgid ""
@@ -954,6 +1113,10 @@ msgid ""
 "tracker items or pull requests associated with each change, enabling "
 "users to access more detailed information if needed."
 msgstr ""
+"**Enlaces a problemas o Pull Requests**: Referencias a "
+"elementos relevantes del seguimiento de problemas o pull "
+"requests asociados a cada cambio, lo que permite a los usuarios "
+"acceder a información más detallada si es necesario."
 
 #: ../../documentation/repository-files/changelog-file.md:39
 msgid ""
@@ -961,6 +1124,9 @@ msgid ""
 "latest version, including any breaking changes or migration steps they "
 "need to be aware of."
 msgstr ""
+"**Instrucciones de Actualización**: Guía para los usuarios sobre cómo "
+"actualizar a la última versión, incluyendo cualquier cambio que rompa la "
+"compatibilidad o los pasos de migración que deban tener en cuenta."
 
 #: ../../documentation/repository-files/changelog-file.md:41
 msgid ""
@@ -968,18 +1134,21 @@ msgid ""
 "significant contributions to the release, fostering a sense of community "
 "and appreciation for their efforts."
 msgstr ""
+"**Reconocimiento a los colaboradores**: Agradecimiento a los "
+"colaboradores que hicieron contribuciones significativas a la versión, "
+"fomentando un sentido de comunidad y aprecio por sus esfuerzos."
 
 #: ../../documentation/repository-files/changelog-file.md:43
 msgid "How do maintainers use it?"
-msgstr ""
+msgstr "¿Cómo lo usan los mantenedores?"
 
 #: ../../documentation/repository-files/changelog-file.md:45
 msgid "Often you will see a changelog that documents a few things:"
-msgstr ""
+msgstr "A menudo verás un registro de cambios que documenta algunas cosas:"
 
 #: ../../documentation/repository-files/changelog-file.md:47
 msgid "Unreleased Section"
-msgstr ""
+msgstr "Sección Sin Publicar"
 
 #: ../../documentation/repository-files/changelog-file.md:49
 msgid ""
@@ -987,26 +1156,26 @@ msgid ""
 "`Unreleased` section. This is where you can add new fixes, updates and "
 "features that have been added to the package since the last release."
 msgstr ""
+"Los commits no publicados están en la parte superior del registro de "
+"cambios, comúnmente en una sección `Sin publicar`. Aquí es donde puedes "
+"añadir nuevas correcciones, actualizaciones y características que se han "
+"añadido al paquete desde la última versión."
 
 #: ../../documentation/repository-files/changelog-file.md:51
 msgid "This section might look something like this:"
-msgstr ""
+msgstr "Esta sección podría tener un aspecto similar a este:"
 
 #: ../../documentation/repository-files/changelog-file.md:59
 msgid "Release Sections"
-msgstr ""
+msgstr "Secciones de Publicación"
 
 #: ../../documentation/repository-files/changelog-file.md:61
 msgid ""
 "When you are ready to make a new release, you can move the elements into "
 "a section that is specific to that new release number."
 msgstr ""
-
-#: ../../documentation/repository-files/changelog-file.md:63
-msgid ""
-"This specific release section will sit below the unreleased section and "
-"can include any updates, additions, deprecations and contributors."
-msgstr ""
+"Cuando estés listo para publicar una nueva versión, puedes mover los "
+"elementos a una sección específica para ese nuevo número de versión."
 
 #: ../../documentation/repository-files/changelog-file.md:65
 msgid ""

--- a/locales/es/LC_MESSAGES/index.po
+++ b/locales/es/LC_MESSAGES/index.po
@@ -26,7 +26,7 @@ msgstr "Tutoriales"
 
 #: ../../index.md:299
 msgid "Packaging"
-msgstr "Enpaquetado"
+msgstr "Empaquetado"
 
 #: ../../index.md:148 ../../index.md:307
 msgid "Documentation"


### PR DESCRIPTION
I used a combination of manual translation and ai translation. then I manually reviewed and edited each line. this is just lines 470 to 1180 that i manually reviewed and corrected.

built and tested locally. 

noticed that markdown level 3 headings are not being translated by sphinx. maybe a conf.py tweak needed.