### PR TITLE
Fix link to code style (it was pointing to CONTRIBUTING)

### DIFF
--- a/index.md
+++ b/index.md
@@ -231,8 +231,6 @@ Learn about best practices for:
 ::::{grid-item}
 :::{card} ✨ Code style & Format ✨
 :class-card: left-aligned
-:link: CONTRIBUTING
-:link-type: doc
 
 * [Code style](package-structure-code/code-style-linting-format.md)
 :::


### PR DESCRIPTION
See "✨ Code style & Format ✨" here: https://www.pyopensci.org/python-package-guide/#contributing