### PR TITLE
Add Spanish translations for tutorials.po

### DIFF
--- a/locales/es/LC_MESSAGES/tutorials.po
+++ b/locales/es/LC_MESSAGES/tutorials.po
@@ -156,7 +156,7 @@ msgstr ""
 msgid ""
 "Image showing the GitHub repository for SunPy an accepted pyOpenSci "
 "package."
-msgstr "Imagen que muestra el repositorio de GitHub de SunPy un paquete aceptado" 
+msgstr "Imagen que muestra el repositorio de GitHub de SunPy un paquete aceptado"
 "por pyOpenSci. "
 
 #: ../../tutorials/add-license-coc.md:52

--- a/locales/es/LC_MESSAGES/tutorials.po
+++ b/locales/es/LC_MESSAGES/tutorials.po
@@ -150,7 +150,7 @@ msgid ""
 "repository. When you add the `LICENSE` at the root, GitHub will "
 "automagically discover it and provide users with a direct link to your "
 "`LICENSE` file within your GitHub repository."
-msgstr "archivo `LICENSE` dentro de tu repositorio de GitHub."
+msgstr ""
 
 #: ../../tutorials/add-license-coc.md:50
 msgid ""

--- a/locales/es/LC_MESSAGES/tutorials.po
+++ b/locales/es/LC_MESSAGES/tutorials.po
@@ -150,13 +150,14 @@ msgid ""
 "repository. When you add the `LICENSE` at the root, GitHub will "
 "automagically discover it and provide users with a direct link to your "
 "`LICENSE` file within your GitHub repository."
-msgstr ""
+msgstr "archivo `LICENSE` dentro de tu repositorio de GitHub."
 
 #: ../../tutorials/add-license-coc.md:50
 msgid ""
 "Image showing the GitHub repository for SunPy an accepted pyOpenSci "
 "package."
-msgstr ""
+msgstr "Imagen que muestra el repositorio de GitHub de SunPy un paquete aceptado" 
+"por pyOpenSci. "
 
 #: ../../tutorials/add-license-coc.md:52
 msgid ""
@@ -165,22 +166,28 @@ msgid ""
 "the `CODE_OF_CONDUCT` file and one that specifies the license that SunPy "
 "uses. These files are discovered by GitHub because they are placed in the"
 " root of the project directory using standard naming conventions."
-msgstr ""
+msgstr "En la parte superior de la sección README de la página principal de GitHub,"
+"hay tres pestañas que enlazan directamente al archivo `README`, el cual es "
+"visible, al archivo `CODE_OF_CONDUCT` y a uno que especifica la licencia que "
+"usa SunPy. GitHub descubre estos archivos porque están ubicados en la "
+"raíz del directorio del proyecto usando convenciones de nomenclatura estándar."
 
 #: ../../tutorials/add-license-coc.md:59
 msgid "How to add a `LICENSE` file to your package directory"
-msgstr ""
+msgstr "Cómo añadir un archivo `LICENSE` al directorio de tu paquete"
 
 #: ../../tutorials/add-license-coc.md:61
 msgid "There are several ways to add a `LICENSE` file:"
-msgstr ""
+msgstr "Hay diferentes maneras de añadir al archivo `LICENSE`: "
 
 #: ../../tutorials/add-license-coc.md:63
 msgid ""
 "When you create a new repository on GitHub, it will ask you if you wish "
 "to add a `LICENSE` file at that time. If you select yes, it will create "
 "the file for you."
-msgstr ""
+msgstr "Cuando creas un nuevo repositorio en GitHub, te preguntará si deseas"
+"añadir un archivo `LICENSE` en ese momento. Si seleccionas sí, creará "
+"el archivo por ti."
 
 #: ../../tutorials/add-license-coc.md:64
 msgid ""


### PR DESCRIPTION
Contributes to #313

Added Spanish translations for a section of tutorials.po, 
including the add-license-coc.md strings. Kept all backticks 
and code terms intact as per the original English text.