### PR TITLE
docs: add Turing Way links for CITATION.cff and software citation

### DIFF
--- a/documentation/repository-files/license-files.md
+++ b/documentation/repository-files/license-files.md
@@ -132,6 +132,13 @@ This would not be true with a GPL licensed package. `GPL-3` packages can include
 
 While many permissive licenses do not require citation, we strongly encourage that you cite all software that you use in papers, blogs, and other publications. You tell your users how to cite your package by using a [citation.cff file](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files).
 
+:::{tip} Additional resources on software citation
+The Turing Way has excellent guides on this topic:
+
+- [CITATION.cff files](https://book.the-turing-way.org/communication/citable/citable-cff) — detailed guide on creating and maintaining citation files
+- [Software citation pathways](https://book.the-turing-way.org/pathways/pathways-software-citation) — overview of how software citation works in practice
+:::
+
 ### Citation.cff files: Making your software citable
 
 A `CITATION.cff` file is a machine-readable file that provides citation information for your software package. The "cff" stands for "Citation File Format," which is a standardized format for software citation metadata.


### PR DESCRIPTION
Adds links to The Turing Way guides on CITATION.cff files and software citation pathways in the license/citation section. Closes #562
