### PR TITLE
Revise security policy for vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Reporting Vulnerabilities
+
+**⚠️ Please do not file public GitHub issues for security
+vulnerabilities as they are open for everyone to see! ⚠️**
+
+We encourage responsible disclosure practices for security
+vulnerabilities.
+
+
+## Reporting a Vulnerability
+
+If you believe you've found a security-related bug, fill out a new
+vulnerability report via GitHub directly. To do so, follow these instructions:
+1. Click on the `Security` tab in the project repository.
+2. Click the green `Report a vulnerability` button at the top right corner.
+3. Fill in the form as accurately as you can, including as many details as
+   possible.
+4. Click the green `Submit report` button at the bottom.


### PR DESCRIPTION
Updated the security policy to focus on reporting vulnerabilities and provided detailed instructions for reporting.

I have also enabled private vulnerability reporting (see Security and quality tab above).

I've been asked by the PyPA and PSF security person to enable this on repos that publish to PyPI.