### PR TITLE
Improve Sphinx build by using SHA for version. Ignore SECURITY.md

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch_depth: 0
+          fetch-depth: 0
 
       - name: Restore mtimes from git history
         run: |

--- a/conf.py
+++ b/conf.py
@@ -62,9 +62,6 @@ try:
         .decode("utf-8")
         .strip()
     )
-    # Basic check: short SHA should be hex.
-    if not release_value or any(c not in "0123456789abcdef" for c in release_value.lower()):
-        raise ValueError(f"Unexpected git sha: {release_value!r}")
 except (subprocess.CalledProcessError, FileNotFoundError, ValueError):
     # Fallback when building from a source archive or without git available
     release_value = "unknown"

--- a/conf.py
+++ b/conf.py
@@ -54,18 +54,21 @@ if sphinx_env == "production":
 else:
     build_languages = ["en"] + languages
 
-# Get the latest Git tag - there might be a prettier way to do this but...
+# Use only the Git SHA for the Sphinx "release" string.
+# (Sphinx doesn't require PEP 440 here, but we keep it well-formed and stable.)
 try:
     release_value = (
-        subprocess.check_output(["git", "describe", "--tags"])
+        subprocess.check_output(["git", "rev-parse", "--short=12", "HEAD"])
         .decode("utf-8")
         .strip()
     )
-    release_value = release_value[:4]
-except subprocess.CalledProcessError:
-    release_value = "0.1"  # Default value in case there's no tag
+    # Basic check: short SHA should be hex.
+    if not release_value or any(c not in "0123456789abcdef" for c in release_value.lower()):
+        raise ValueError(f"Unexpected git sha: {release_value!r}")
+except (subprocess.CalledProcessError, FileNotFoundError, ValueError):
+    # Fallback when building from a source archive or without git available
+    release_value = "unknown"
 
-# Update the release value
 release = release_value
 
 # -- General configuration ---------------------------------------------------
@@ -181,7 +184,8 @@ exclude_patterns = [
     ".venv",
     "venv",
     "env",
-    "LICENSE.rst"
+    "LICENSE.rst",
+    "SECURITY.md"
 ]
 
 # For sitemap generation


### PR DESCRIPTION
This PR improves the Sphinx build's use of version. CI is throwing a few errors now:

```
Run nox -s docs-test
fatal: No names found, cannot describe anything.
nox > Running session docs-test
nox > Creating virtual environment (virtualenv) using python3 in .nox/docs-test
nox > python -m pip install -e .
nox > sphinx-build -b html --keep-going -E -a . _build/html
Running Sphinx v9.1.0
fatal: No names found, cannot describe anything.
loading translations [en]... done
making output directory... done
```

This fixes the `fatal: No names found...` error.