### PR TITLE
Remove references and links to the obsolete PyOS Discourse

### DIFF
--- a/documentation/hosting-tools/website-hosting-optimizing-your-docs.md
+++ b/documentation/hosting-tools/website-hosting-optimizing-your-docs.md
@@ -43,5 +43,4 @@ OpenGraph is an extension that allows you to add metadata to your documentation
 content pages. [The OpenGraph protocol allows other websites to provide a
 useful preview of the content on your page when shared](https://www.freecodecamp.org/news/what-is-open-graph-and-how-can-i-use-it-for-my-website/#heading-what-is-open-graph). This is important
 for when the pages in your documentation are shared on social
-media sites like Twitter and Mastodon and even for shares on
-tools like Slack and Discourse.
+media and even for shares on collaboration platforms like Slack and Discourse.

--- a/documentation/repository-files/contributing-file.md
+++ b/documentation/repository-files/contributing-file.md
@@ -51,7 +51,7 @@ The CONTRIBUTING.md file should include information about:
 If you have a [development guide](development-guide), link to it. This guide should provide clear instructions on how to set up your development environment locally. It also should overview CI tools that you have that could simplify the contribution process (for example, pre-[commit.ci bot](https://www.pyopensci.org/python-package-guide/package-structure-code/code-style-linting-format.html#pre-commit-ci), and so on), [linters, code formatters](https://www.pyopensci.org/python-package-guide/package-structure-code/code-style-linting-format.html#code-linting-formatting-and-styling-tools), and so on.
 
 This guide should also include information for someone
-interested in asking questions. Some projects accept questions as GitHub or GitLab issues. Others use GitHub discussions, Discourse, or even a Discord server.
+interested in asking questions. Some projects accept questions as GitHub or GitLab issues. Others use GitHub Discussions, Discourse, or even a Discord server.
 
 The contributing file should also include:
 

--- a/index.md
+++ b/index.md
@@ -250,7 +250,7 @@ This guidebook is for anyone interested in learning more about Python packaging.
 If you have ideas of things you'd like
 to see here clarified in this guide, [we invite you to open an issue on GitHub.](https://github.com/pyOpenSci/python-package-guide/issues).
 
-If you have questions about our peer review process or packaging in general, you are welcome to use our [pyOpenSci Discourse forum](https://pyopensci.discourse.group/).
+If you have questions about our peer review process or packaging in general, you are welcome to use our [GitHub Discussions](https://github.com/orgs/pyOpenSci/discussions).
 
 This living Python packaging guide is updated as tools and best practices evolve in the Python packaging ecosystem. We will be adding new content over the next year.
 


### PR DESCRIPTION
Remove references and links to the obsolete PyOS Discourse.
Minor edits in related content.