### PR TITLE
Update and pin all pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@
 repos:
   # Misc commit checks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # frozen: v6.0.0
     # ref: https://github.com/pre-commit/pre-commit-hooks#hooks-available
     hooks:
       # Autoformat: Makes sure files end in a newline and only a newline.
@@ -25,7 +25,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.2
+    rev: 2ccb47ff45ad361a21071a7eedda4c37e6ae8c5a # frozen: v2.4.2
     hooks:
       - id: codespell
         additional_dependencies:
@@ -36,12 +36,12 @@ repos:
           )$
 
   - repo: https://github.com/errata-ai/vale
-    rev: v3.14.1
+    rev: 41f3b223e8cc669d1309a2104e5b70df2ae6a5a8 # frozen: v3.14.1
     hooks:
       - id: vale
 
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.8.3
+    rev: 515f543f5718ebfd6ce22e16708bb32c68ff96e1 # frozen: v3.8.3
     hooks:
       - id: prettier
         types_or: [yaml, html, css, scss, javascript, json, toml]

--- a/examples/pure-hatch/.pre-commit-config.yaml
+++ b/examples/pure-hatch/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     hooks:
       - id: black
         language_version: python3.10
-# Tell precommit.ci bot to update codoe format tools listed in the file
+# Tell precommit.ci bot to update code format tools listed in the file
 # versions every quarter
 # The default it so update weekly which is too many new pr's for many
 # maintainers (remove these lines if you aren't using the bot!)

--- a/examples/pure-hatch/.pre-commit-config.yaml
+++ b/examples/pure-hatch/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/PyCQA/isort
-    rev: 5.11.4
+    rev: dac090ce4d9ee313d086e2e89ab1acb8c2664fa1 # frozen: 9.0.0a3
     hooks:
       - id: isort
         files: \.py$
   # Misc commit checks using built in pre-commit checks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # frozen: v6.0.0
     # ref: https://github.com/pre-commit/pre-commit-hooks#hooks-available
     hooks:
       # Autoformat: Makes sure files end in a newline and only a newline.
@@ -17,12 +17,12 @@ repos:
       - id: trailing-whitespace
   # Linting: Python code (see the file .flake8)
   - repo: https://github.com/PyCQA/flake8
-    rev: "6.0.0"
+    rev: c48217e1fc006c2dddd14df54e83b67da15de5cd # frozen: 7.3.0
     hooks:
       - id: flake8
   # Black for auto code formatting
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: c6755bb741b6481d6b3d3bb563c83fa060db96c9 # frozen: 26.3.1
     hooks:
       - id: black
         language_version: python3.8

--- a/examples/pure-hatch/.pre-commit-config.yaml
+++ b/examples/pure-hatch/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     rev: c6755bb741b6481d6b3d3bb563c83fa060db96c9 # frozen: 26.3.1
     hooks:
       - id: black
-        language_version: python3.8
+        language_version: python3.10
 # Tell precommit.ci bot to update codoe format tools listed in the file
 # versions every quarter
 # The default it so update weekly which is too many new pr's for many

--- a/examples/pure-hatch/src/examplePy/temperature.py
+++ b/examples/pure-hatch/src/examplePy/temperature.py
@@ -8,7 +8,7 @@ def celsius_to_fahrenheit(celsius):
     Returns:
         float: Temperature in Fahrenheit.
     """
-    fahrenheit = (celsius * 9/5) + 32
+    fahrenheit = (celsius * 9 / 5) + 32
     return fahrenheit
 
 
@@ -22,5 +22,5 @@ def fahrenheit_to_celsius(fahrenheit):
     Returns:
         float: Temperature in Celsius.
     """
-    celsius = (fahrenheit - 32) * 5/9
+    celsius = (fahrenheit - 32) * 5 / 9
     return celsius

--- a/examples/pure-hatch/src/examplePy/temporal-raw.py
+++ b/examples/pure-hatch/src/examplePy/temporal-raw.py
@@ -1,12 +1,15 @@
-from examplePy.temperature import fahrenheit_to_celsius
-import pandas
 from typing import Sequence
+
+import pandas
+
+from examplePy.temperature import fahrenheit_to_celsius
+
 
 def calc_annual_mean(df: pandas.DataFrame):
     """Function to calculate the mean temperature for each year and the final mean"""
     # TODO: make this a bit more robust so we can write integration test examples??
     # Calculate the mean temperature for each year
-    yearly_means = df.groupby('Year').mean()
+    yearly_means = df.groupby("Year").mean()
 
     # Calculate the final mean temperature across all years
     final_mean = yearly_means.mean()

--- a/examples/pure-hatch/src/examplePy/temporal.py
+++ b/examples/pure-hatch/src/examplePy/temporal.py
@@ -4,11 +4,12 @@ import pandas
 
 from examplePy.temperature import fahrenheit_to_celsius
 
+
 def calc_annual_mean(df: pandas.DataFrame):
     """Function to calculate the mean temperature for each year and the final mean"""
     # TODO: make this a bit more robust so we can write integration test examples??
     # Calculate the mean temperature for each year
-    yearly_means = df.groupby('Year').mean()
+    yearly_means = df.groupby("Year").mean()
 
     # Calculate the final mean temperature across all years
     final_mean = yearly_means.mean()

--- a/examples/pure-hatch/tests/examplePy/test_temperature.py
+++ b/examples/pure-hatch/tests/examplePy/test_temperature.py
@@ -1,4 +1,5 @@
 """Pytest-based unit test examples for the temperature module"""
+
 import math
 
 from examplePy import temperature

--- a/examples/pure-hatch/tests/examplePy/test_temporal.py
+++ b/examples/pure-hatch/tests/examplePy/test_temporal.py
@@ -1,4 +1,5 @@
 """Pytest-based unit test examples for the temporal module"""
+
 import pathlib
 
 import numpy
@@ -28,8 +29,7 @@ def test_calc_annual_mean(temperatures):
     df_mean, df_final = temporal.calc_annual_mean(temperatures)
 
     # Compare specific means to validate the calculations
-    assert numpy.isclose(
-        df_mean.loc[[1988], "Temperature"].iloc[0], expected_mean_1988)
+    assert numpy.isclose(df_mean.loc[[1988], "Temperature"].iloc[0], expected_mean_1988)
     assert numpy.isclose(df_final.loc["Temperature"], expected_mean_final)
 
 


### PR DESCRIPTION
This PR bumps versions for all hooks and freezes them to their SHAs (pre-commit.ci can update them and the corresponding version identifiers in the comments just fine).

Also, I fixed a few miscellaneous issues (`black` was failing to install because Python 3.8 was too old), and a typo.

I am still unsure why we have a pre-commit config file only for the `pure-hatch` example, and not for `extension-hatch` and `pure-setuptools`? Should we add one for them too?