### PR TITLE
Release the PT and ES translations of the guide

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -12,11 +12,13 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('.'))
-from datetime import datetime
-import subprocess
+
+sys.path.insert(0, os.path.abspath("."))
 import os
+import subprocess
+from datetime import datetime
 from typing import TYPE_CHECKING
+
 from _ext import rss
 
 if TYPE_CHECKING:
@@ -45,7 +47,7 @@ language = language_env
 languages = ["es", "ja", "pt"]
 # the languages that will be included in a production build
 # (also excluding english)
-release_languages = ["ja"]
+release_languages = ["es", "ja", "pt"]
 
 # languages that will be included in the language dropdown
 # (ie. all that are being built in this nox build session)
@@ -146,7 +148,7 @@ html_theme_options = {
     "github_url": "https://github.com/pyopensci/python-package-guide",
     "footer_start": ["code_of_conduct", "copyright"],
     "footer_end": [],
-    "navbar_persistent": ["language-selector", "search-button"]
+    "navbar_persistent": ["language-selector", "search-button"],
 }
 
 html_context = {
@@ -182,7 +184,7 @@ exclude_patterns = [
     "venv",
     "env",
     "LICENSE.rst",
-    "SECURITY.md"
+    "SECURITY.md",
 ]
 
 # For sitemap generation
@@ -227,6 +229,7 @@ linkcheck_ignore = [
     # this discord link is correct, but unauthenticated it redirects to a sign-up page
     r"https:\/\/discord\.gg/NQtTTqtv",
 ]
+
 
 def _post_build(app: "Sphinx", exception: Exception | None) -> None:
     rss.generate_tutorials_feed(app)

--- a/conf.py
+++ b/conf.py
@@ -213,7 +213,15 @@ ogp_social_cards = {
 # Bibliographies
 bibtex_bibfiles = ["bibliography.bib"]
 # myst complains about bibtex footnotes because of render order
-suppress_warnings = ["myst.footnote"]
+suppress_warnings = [
+    "myst.footnote",
+    # Suppress false positives for translated :term: references. When a
+    # translator correctly translates a glossary term in the target language
+    # (e.g. "Code of conduct" to "código de conducta"), Sphinx still warns
+    # because it is different from the English original, despite the fact that
+    # the translated term is properly defined in the glossary.
+    "i18n.inconsistent_references",
+]
 
 # -- Options for linkcheck -------------------------------------------------
 

--- a/locales/es/LC_MESSAGES/documentation.po
+++ b/locales/es/LC_MESSAGES/documentation.po
@@ -42,7 +42,7 @@ msgstr ""
 
 #: ../../documentation/glossary.md:6
 msgid "API token"
-msgstr ""
+msgstr "token de API"
 
 #: ../../documentation/glossary.md:19
 msgid ""
@@ -108,7 +108,7 @@ msgstr ""
 
 #: ../../documentation/glossary.md:37
 msgid "Python package"
-msgstr ""
+msgstr "paquete de Python"
 
 #: ../../documentation/glossary.md:50
 msgid ""
@@ -483,9 +483,8 @@ msgid "Documentation"
 msgstr "Resumen de la Documentación"
 
 #: ../../documentation/glossary.md
-#, fuzzy
 msgid "Code of conduct"
-msgstr "Archivo de Código de Conducta"
+msgstr "código de conducta"
 
 #: ../../documentation/glossary.md:232
 msgid ""
@@ -2864,7 +2863,7 @@ msgstr ""
 
 #: ../../documentation/repository-files/readme-file-best-practices.md:157
 msgid "Your code of conduct"
-msgstr ""
+msgstr "Tu código de conducta"
 
 #: ../../documentation/repository-files/readme-file-best-practices.md:158
 msgid "Licensing information"

--- a/locales/es/LC_MESSAGES/tutorials.po
+++ b/locales/es/LC_MESSAGES/tutorials.po
@@ -1192,7 +1192,8 @@ msgstr ""
 "**Qué son estas tablas:** Estas tablas resumen los comandos de línea de comandos "
 "(por ejemplo, `pipx install hatch`, `hatch build` o `python -m build`) necesarios "
 "para completar todos los pasos del proceso de creación de un paquete, desde la "
-"instalación de Hatch hasta la publicación del paquete en PyPI y conda-forge."
+"instalación de [Hatch](get-to-know-hatch) hasta la publicación del paquete en [PyPI"
+"](publish-pypi) y conda-forge."
 
 
 #: ../../tutorials/command-line-reference.md:14
@@ -2870,7 +2871,7 @@ msgstr ""
 
 #: ../../tutorials/intro.md:53
 msgid "Add a license & code of conduct"
-msgstr ""
+msgstr "Añadir una licencia y un código de conducta"
 
 #: ../../tutorials/intro.md:53
 msgid "Update metadata in pyproject.toml"

--- a/locales/pt/LC_MESSAGES/documentation.po
+++ b/locales/pt/LC_MESSAGES/documentation.po
@@ -480,7 +480,7 @@ msgstr ""
 
 #: ../../documentation/glossary.md
 msgid "Code of conduct"
-msgstr ""
+msgstr "código de conduta"
 
 #: ../../documentation/glossary.md:232
 msgid ""
@@ -2555,7 +2555,7 @@ msgstr ""
 
 #: ../../documentation/repository-files/readme-file-best-practices.md:157
 msgid "Your code of conduct"
-msgstr ""
+msgstr "Seu código de conduta"
 
 #: ../../documentation/repository-files/readme-file-best-practices.md:158
 msgid "Licensing information"

--- a/locales/pt/LC_MESSAGES/index.po
+++ b/locales/pt/LC_MESSAGES/index.po
@@ -195,7 +195,7 @@ msgstr "[O que é um pacote Python?](/tutorials/intro)"
 
 #: ../../index.md:73
 msgid "[Create a Python package](/tutorials/create-python-package)"
-msgstr "Crie um pacote Python"
+msgstr "[Crie um pacote Python](/tutorials/create-python-package)"
 
 #: ../../index.md:74
 msgid "[Publish your package to (test) PyPI](/tutorials/publish-pypi)"
@@ -380,7 +380,7 @@ msgid ""
 "[Set norms with a Code of Conduct](/documentation/repository-files/code-"
 "of-conduct-file)"
 msgstr ""
-"[Defina normas com um Código de Conduta](/documentation/repository-files/code-of-conduct-file)"
+"[Defina normas com um Código de conduta](/documentation/repository-files/code-of-conduct-file)"
 
 #: ../../index.md:162
 msgid "[License your package](/documentation/repository-files/license-files)"

--- a/locales/pt/LC_MESSAGES/tutorials.po
+++ b/locales/pt/LC_MESSAGES/tutorials.po
@@ -349,6 +349,8 @@ msgid ""
 "A `CODE_OF_CONDUCT` file is a {term}`Code of conduct` used to establish "
 "guidelines for how people in your community interact."
 msgstr ""
+"Um arquivo CODE_OF_CONDUCT é um {term}`código de conduta` usado para estabelecer"
+"diretrizes sobre como as pessoas em sua comunidade interagem."
 
 #: ../../tutorials/add-license-coc.md:152
 msgid ""
@@ -2600,7 +2602,7 @@ msgstr ""
 
 #: ../../tutorials/intro.md:53
 msgid "Add a license & code of conduct"
-msgstr ""
+msgstr "Adicionar uma licença e um código de conduta"
 
 #: ../../tutorials/intro.md:53
 msgid "Update metadata in pyproject.toml"

--- a/noxfile.py
+++ b/noxfile.py
@@ -33,7 +33,13 @@ BUILD_PARAMETERS = ["-b", "html"]
 
 # Sphinx parameters used when checking that links work
 # ref: https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-the-linkcheck-builder
-LINKCHECK_PARAMETERS = ["-b", "linkcheck", "-Dlinkcheck_timeout=5", "-Dlinkcheck_rate_limit_timeout=30", "--fail-on-warning"]
+LINKCHECK_PARAMETERS = [
+    "-b",
+    "linkcheck",
+    "-Dlinkcheck_timeout=5",
+    "-Dlinkcheck_rate_limit_timeout=30",
+    "--fail-on-warning",
+]
 LINKCHECK_OUTPUT_DIR = pathlib.Path(BUILD_DIR, "linkcheck_output")
 
 # Sphinx parameters used to test the build of the guide
@@ -384,6 +390,18 @@ def build_all_languages(session):
         session.warn("No languages defined in LANGUAGES")
         return
     session.install("-e", ".")
+    session.log(f"Declared languages: {LANGUAGES}")
+    session.log(f"Release languages: {RELEASE_LANGUAGES}")
+    sphinx_env = _sphinx_env(session)
+    # if running from the docs or docs-test sessions, build only release languages
+    BUILD_LANGUAGES = RELEASE_LANGUAGES if sphinx_env == "production" else LANGUAGES
+    # only build languages that have a locale folder
+    BUILD_LANGUAGES = [
+        lang for lang in BUILD_LANGUAGES if (TRANSLATION_LOCALES_DIR / lang).exists()
+    ]
+    session.log(
+        f"Building languages{' for release' if sphinx_env == 'production' else ''}: {BUILD_LANGUAGES}"
+    )
     for lang in LANGUAGES:
         session.log(f"Building [{lang}] guide")
         session.run(
@@ -396,25 +414,6 @@ def build_all_languages(session):
             *session.posargs,
         )
     session.log(f"Translations built for {LANGUAGES}")
-    sphinx_env = _sphinx_env(session)
-
-    # if running from the docs or docs-test sessions, build only release languages
-    BUILD_LANGUAGES = RELEASE_LANGUAGES if sphinx_env == "production" else LANGUAGES
-    # only build languages that have a locale folder
-    BUILD_LANGUAGES = [
-        lang for lang in BUILD_LANGUAGES if (TRANSLATION_LOCALES_DIR / lang).exists()
-    ]
-    session.log(f"Declared languages: {LANGUAGES}")
-    session.log(f"Release languages: {RELEASE_LANGUAGES}")
-    session.log(
-        f"Building languages{' for release' if sphinx_env == 'production' else ''}: {BUILD_LANGUAGES}"
-    )
-    if not BUILD_LANGUAGES:
-        session.warn("No translations to build")
-    else:
-        session.notify(
-            "build-languages", [sphinx_env, BUILD_LANGUAGES, *session.posargs]
-        )
 
 
 @nox.session(name="build-all-languages-test")


### PR DESCRIPTION
After the nice translation contributions we had in the PyCon US 2026 sprints we are ready to release the guide in two additional languages!

Thanks to @KarinaS0uza and @Humanberto work, we now start a Portuguese translation of the guide! And thanks to @OlmosDeAguilera contribution, we made additional progress in the Spanish translation!

A few notes:

- During the sprint we decided to change the criteria to release a language from reaching 50% translated status, to completing the translation of the landing page.
- Building the translations is generating some `i18n.inconsistent.references` because Sphinx does not seem to find the translated terms (marked with `{term}` in the English source in the glossary, even after we translate them. In order to build cleanly and release, I added the option to suppress these warnings in `conf.py` along with a comment. See issue #670 