### PR TITLE
Fix tutorial series link in package structure intro

### DIFF
--- a/package-structure-code/intro.md
+++ b/package-structure-code/intro.md
@@ -14,7 +14,7 @@ This section covers everything you need to structure your Python package, config
 - Learn by doing with guided examples
 - Perfect for your first package
 
-```{button-link} tutorials/intro
+```{button-link} ../tutorials/intro
 :color: success
 :class: sd-rounded-pill
 

--- a/package-structure-code/intro.md
+++ b/package-structure-code/intro.md
@@ -14,7 +14,7 @@ This section covers everything you need to structure your Python package, config
 - Learn by doing with guided examples
 - Perfect for your first package
 
-```{button-link} ../tutorials/intro
+```{button-link} ../tutorials/intro.html
 :color: success
 :class: sd-rounded-pill
 


### PR DESCRIPTION
## Summary

- Fix the "Start the tutorial series" button on the package structure intro page so it points from `package-structure-code/intro.html` to the tutorial intro page.
- The previous relative link resolved under the current section and caused the broken link reported in pyOpenSci/pyopensci.github.io#899.

## Validation

- Confirmed the updated relative link resolves to `https://www.pyopensci.org/python-package-guide/tutorials/intro` from `https://www.pyopensci.org/python-package-guide/package-structure-code/intro.html`.
- `git diff --check`

Closes pyOpenSci/pyopensci.github.io#899.