### PR TITLE
Add a GitHub action to detect stale .po files and update mantainers

### DIFF
--- a/.github/workflows/track-english-changes.yml
+++ b/.github/workflows/track-english-changes.yml
@@ -1,0 +1,121 @@
+name: Track English text changes for translators
+
+# The `.po` catalogs are generated from the English pages, so changes to the guide
+# on `main` can leave every locale short of strings. This posts to the translation
+# maintenance issue to inform maintainers that updates are needed, rather than to
+# the pull request to avoid putting the burden on a beginner contributor.
+#
+# `push` rather than a pull-request trigger because that way it cannot be bypassed by
+# an admin pushing straight to `main`, or an edit made in the web editor.
+on:
+  push:
+    branches: [main]
+    # Broad on purpose: a filter that misses a source change loses the
+    # notification, one that is too wide costs a run that posts nothing.
+    paths-ignore:
+      - "locales/**"
+      - "scripts/**"
+      - ".github/**"
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  # The tracking issue is found by this label, not by number, so it can be closed
+  # and replaced without editing this file. Apply it to exactly one issue.
+  TRACKER_LABEL: po-refresh-tracker
+
+jobs:
+  track:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # The whole push, not just its last commit. This repository merges by
+      # rebasing, so one pull request lands as several commits in a single push,
+      # and `HEAD^..HEAD` would see only the last of them.
+      - name: List the files this push touched
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.event.after }}
+        run: |
+          # A branch creation or a force push reports an all-zero `before`, which
+          # the compare endpoint cannot use. There is nothing to diff against.
+          if [ -z "${BEFORE//0/}" ]; then
+            echo "No usable base for the comparison; nothing to report."
+            : > changed.txt
+          else
+            gh api "repos/${{ github.repository }}/compare/${BEFORE}...${AFTER}" \
+              --jq '.files[].filename' > changed.txt
+          fi
+          echo "Files this push touched:"
+          cat changed.txt
+
+      - name: Work out which catalogs could be affected
+        id: report
+        run: |
+          : > report.md
+          if [ -s changed.txt ]; then
+            python scripts/translation/check_source_changes.py changed.txt > report.md
+          fi
+          if [ -s report.md ]; then
+            echo "affected=true" >> "$GITHUB_OUTPUT"
+            cat report.md
+          else
+            echo "affected=false" >> "$GITHUB_OUTPUT"
+            echo "No English source that the guide translates was changed."
+          fi
+
+      - name: Tell the tracking issue
+        if: steps.report.outputs.affected == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const label = process.env.TRACKER_LABEL;
+            const { owner, repo } = context.repo;
+
+            const found = await github.paginate(github.rest.issues.listForRepo, {
+              owner, repo, labels: label, state: 'all', per_page: 100,
+            });
+            // This endpoint counts pull requests as issues, so they are dropped.
+            const issues = found.filter(i => !i.pull_request);
+
+            if (issues.length === 0) {
+              // If no issue with the correct label is found, fail.
+              core.setFailed(
+                `No issue with the \`${label}\` label, so there is nowhere to ` +
+                `report this. Create the tracking issue and apply that label.`,
+              );
+              return;
+            }
+            // If multiple issues with the correct label are found, warn and use the
+            // lowest-numbered one.
+            if (issues.length > 1) {
+              core.warning(
+                `${issues.length} issues carry \`${label}\`: ` +
+                `${issues.map(i => '#' + i.number).join(', ')}. ` +
+                `Using the lowest-numbered one.`,
+              );
+            }
+            const issue = issues.sort((a, b) => a.number - b.number)[0];
+
+            if (issue.state === 'closed') {
+              core.info(`Reopening #${issue.number}: the English text has changed again.`);
+              await github.rest.issues.update(
+                { owner, repo, issue_number: issue.number, state: 'open' },
+              );
+            }
+
+            const body = fs.readFileSync('report.md', 'utf8')
+              + `\nChanged on \`main\`: ${context.payload.compare}\n`;
+            await github.rest.issues.createComment(
+              { owner, repo, issue_number: issue.number, body },
+            );
+            core.info(`Commented on #${issue.number}.`);

--- a/conf.py
+++ b/conf.py
@@ -167,6 +167,7 @@ templates_path = ["_templates"]
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = [
+    "scripts",
     "_build",
     "Thumbs.db",
     ".DS_Store",

--- a/noxfile.py
+++ b/noxfile.py
@@ -441,8 +441,8 @@ def test_translation_scripts(session):
     """
     session.install("pytest")
     session.run("pytest", str(TRANSLATION_SCRIPTS_DIR), *session.posargs)
-    
-    
+
+
 def _clean_translation_templates(session) -> None:
     """
     Remove the gettext output directory before regenerating the templates (.pot).

--- a/noxfile.py
+++ b/noxfile.py
@@ -48,6 +48,9 @@ TEST_PARAMETERS = ["--keep-going", "-E", "-a"]
 # Sphinx parameters to generate translation templates
 TRANSLATION_TEMPLATE_PARAMETERS = ["-b", "gettext"]
 
+# Scripts that maintain the translation stats and the translation issues
+TRANSLATION_SCRIPTS_DIR = pathlib.Path("scripts", "translation")
+
 # Sphinx-autobuild ignore and include parameters
 AUTOBUILD_IGNORE = [
     "_build",
@@ -425,6 +428,17 @@ def build_all_languages_test(session):
     in the same way docs-test does for the English version.
     """
     session.notify("build-all-languages", [*TEST_PARAMETERS])
+
+
+@nox.session(name="test-translation-scripts")
+def test_translation_scripts(session):
+    """
+    Run the unit tests for the translation helper scripts.
+
+    Only pytest is installed since it's the only thing the scripts under test need.
+    """
+    session.install("pytest")
+    session.run("pytest", str(TRANSLATION_SCRIPTS_DIR), *session.posargs)
 
 
 def _sphinx_env(session) -> str:

--- a/scripts/translation/check_source_changes.py
+++ b/scripts/translation/check_source_changes.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+"""Report which `.po` files a change to the English text could affect.
+
+Run over a list of changed files by the GitHub Action ``track-english-changes.yml``,
+which posts the report itself to a tracking issue once the change is on ``main``.
+
+The tracking issue is the lowest numbered issue with the label ``po-refresh-tracker``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+LOCALES_DIR = BASE_DIR / "locales"
+
+
+MAX_ROWS = 20
+
+
+def po_stems() -> set[str]:
+    """Every ``.po`` name in the repository, without the extension."""
+    return {po_file.stem for po_file in LOCALES_DIR.rglob("*.po")}
+
+
+def english_source(stem: str) -> Path | None:
+    """The English page or section a ``.po`` file is generated from."""
+    page = BASE_DIR / f"{stem}.md"
+    if page.is_file():
+        return page
+    section = BASE_DIR / stem
+    return section if section.is_dir() else None
+
+
+def translated_sources() -> dict[str, str]:
+    """Map each repo-relative English source path to the ``.po`` stem it feeds."""
+    found = {}
+    for stem in po_stems():
+        source = english_source(stem)
+        if source is not None:
+            found[str(source.relative_to(BASE_DIR))] = stem
+    return found
+
+
+def locale_codes() -> list[str]:
+    """The locales with catalogs, in alphabetical order."""
+    return sorted(path.name for path in LOCALES_DIR.iterdir() if path.is_dir())
+
+
+def affected(
+    changed: list[str], sources: dict[str, str] | None = None
+) -> dict[str, list[str]]:
+    """Group the changed paths by the ``.po`` stem whose source they belong to.
+
+    In the current config, a source may be a single page or a whole section directory,
+    so a path counts when it is the source itself or sits anywhere below it. Paths that
+    do not belong to any known source are ignored.
+    """
+    known = translated_sources() if sources is None else sources
+    hits: dict[str, list[str]] = {}
+    for path in changed:
+        for source, stem in known.items():
+            if path == source or path.startswith(f"{source}/"):
+                hits.setdefault(stem, []).append(path)
+                break
+    return {stem: sorted(paths) for stem, paths in sorted(hits.items())}
+
+
+def render_report(hits: dict[str, list[str]], locales: list[str]) -> str:
+    """The comment left on the tracking issue, or an empty string when no hits."""
+    if not hits:
+        return ""
+    rows = sorted((path, stem) for stem, paths in hits.items() for path in paths)
+    shown, hidden = rows[:MAX_ROWS], max(0, len(rows) - MAX_ROWS)
+    table = "\n".join(f"| `{path}` | `{stem}.po` |" for path, stem in shown)
+    more = f"\n\n{hidden} more changed file(s) are not listed." if hidden else ""
+    listed = ", ".join(locales)
+    return f"""### English text changed, catalogs (.po files) may need refreshing
+
+A change on `main` touched English text of the guide so the `.po` files may need to be
+refreshed by a maintainer.
+
+| English source changed | Catalog it belongs to |
+| :--- | :--- |
+{table}{more}
+
+To refresh the catalogs, one locale at a time:
+
+```
+nox -s update-language -- <locale>    # {listed}
+```
+
+Once the catalogs are refreshed, close the issue. The GitHub Action will reopen it when
+new changes are made to the English text.
+
+If this change did not touch any translatable text (e.g., code sample, image, link, format),
+you can simply close the issue directly.
+"""
+
+
+def main(argv: list[str]) -> int:
+    """Print the report for the paths listed in the file named by ``argv[1]``.
+
+    Always succeeds (return 0). We do not fail in CI and cause a red mark on
+    a pull request for something its author very likely did not do wrong.
+    """
+    if len(argv) != 2:
+        print(f"usage: {Path(argv[0]).name} CHANGED_FILES", file=sys.stderr)
+        return 0
+    listing = Path(argv[1])
+    changed = listing.read_text(encoding="utf-8").split() if listing.is_file() else []
+    report = render_report(affected(changed), locale_codes())
+    if report:
+        print(report, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/translation/test_check_source_changes.py
+++ b/scripts/translation/test_check_source_changes.py
@@ -1,0 +1,79 @@
+"""Tests for the pull request warning about changed English text."""
+
+from __future__ import annotations
+
+import check_source_changes as check
+
+# A stand-in for the real repository layout: one page, one section.
+SOURCES = {
+    "index.md": "index",
+    "documentation": "documentation",
+    "CONTRIBUTING.md": "CONTRIBUTING",
+}
+
+
+def test_a_page_is_matched_exactly():
+    assert check.affected(["index.md"], SOURCES) == {"index": ["index.md"]}
+
+
+def test_a_section_matches_everything_below_it():
+    changed = ["documentation/index.md", "documentation/write/tutorials.md"]
+    assert check.affected(changed, SOURCES) == {"documentation": sorted(changed)}
+
+
+def test_paths_outside_any_translated_source_are_ignored():
+    changed = [
+        "scripts/translation/stats.py",
+        ".github/workflows/build-book.yml",
+        "noxfile.py",
+        "locales/es/LC_MESSAGES/index.po",
+    ]
+    assert check.affected(changed, SOURCES) == {}
+
+
+def test_a_name_that_only_starts_the_same_does_not_match():
+    """`documentation-old.md` is not part of the `documentation/` section."""
+    assert check.affected(["documentation-old.md"], SOURCES) == {}
+
+
+def test_several_sources_are_grouped_by_catalog():
+    changed = ["index.md", "documentation/a.md", "documentation/b.md"]
+    assert check.affected(changed, SOURCES) == {
+        "documentation": ["documentation/a.md", "documentation/b.md"],
+        "index": ["index.md"],
+    }
+
+
+def test_no_report_when_nothing_relevant_changed():
+    assert check.render_report({}, ["es", "pt"]) == ""
+
+
+def test_report_names_the_files_the_catalogs_and_the_command():
+    report = check.render_report(
+        {"documentation": ["documentation/a.md"]}, ["es", "pt"]
+    )
+    assert "`documentation/a.md` | `documentation.po`" in report
+    assert "nox -s update-language -- <locale>    # es, pt" in report
+    assert "may need refreshing" in report
+
+
+def test_a_long_report_says_how_much_it_left_out():
+    paths = [f"documentation/page{n}.md" for n in range(check.MAX_ROWS + 5)]
+    report = check.render_report({"documentation": paths}, ["es"])
+    assert "5 more changed file(s) are not listed." in report
+    assert report.count("| `documentation/page") == check.MAX_ROWS
+
+
+def test_catalogs_without_an_english_source_are_not_translated_any_more():
+    """`continuous-integration.po` is still on disk; its page is gone."""
+    assert check.english_source("continuous-integration") is None
+    assert "continuous-integration" not in check.translated_sources().values()
+
+
+def test_the_real_repository_resolves_to_pages_and_sections():
+    """A guard on the layout the workflow depends on."""
+    sources = check.translated_sources()
+    assert sources["index.md"] == "index"
+    assert sources["documentation"] == "documentation"
+    assert all("locales" not in path for path in sources)
+    assert "es" in check.locale_codes()


### PR DESCRIPTION
This PR sets up a simple way for translation maintainers to monitor when `.po` files (also called translation catalogs) may be stale and need to be updated.

__Wait... why don't you just update the `.po` files in the action instead of detecting?__

1) Updating .po files while contributors are working on them will cause merge conflicts when they submit a PR. While those conflicts are easy to fix (for a maintainer) they can be intimidating and scare away new contributors.

2) Also, it's easier to handle the merge of changes from the source into the `.po` file outside git because sphinx-intl uses msgmerge, which is po-format aware while the git merge driver is not.

## What was done

- Added a script to detect changes to files in the English source of the guide
- Added a GitHub action that runs this script and when changes are detected posts a comment to issue #780
- Added tests to the script logic and a nox session to execute them

## How to test

`nox -s test-translation-scripts`

## Follow up work

The final piece (still to do) is to have updates to this issue be posted in the translation channel in slack.

## AI Disclaimer

Claude code helped me with part of this, but I take full responsibility for the change. 