### PR TITLE
Update GitHub commit instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,19 +85,20 @@ An image showing how to preview changes in GitHub. The file content is displayed
 
 ### How to commit your changes
 
-When you are done editing the file, scroll down to the bottom of the page. You will see a section called "Commit changes".
-Here you can write a title and a description for your changes. Make sure to write a clear and concise title that describes the changes you made.
+When you are done editing the file, click the green "Commit changes..." button in the top-right corner of the editor.
+GitHub will open a "Propose changes" dialog where you can write a commit message and an optional extended description.
+Make sure the commit message clearly and concisely describes the changes you made.
 
 ```{figure} images/contributing/commit-changes.png
 ---
 name: commit-changes in GitHub
 width: 80%
-alt: Commit changes in GitHub
+alt: Propose changes dialog in GitHub
 ---
-An image showing how to commit changes in GitHub. The commit message is displayed in a text editor. The commit changes section is highlighted with a red rectangle.
+The GitHub "Propose changes" dialog with the commit message field highlighted.
 ```
 
-After writing your commit message, click the "Commit changes" button to save your changes.
+After writing your commit message, click the "Propose changes" button to save the commit to your fork.
 
 ## Contributing locally on your computer
 


### PR DESCRIPTION
Closes #734

Updates `CONTRIBUTING.md` to match the current GitHub web editor:

- points contributors to the top-right **Commit changes...** button
- describes the **Propose changes** dialog
- updates the final button label and image text

Testing: `nox -s docs-test --reuse-existing-virtualenvs` (English docs and release-language builds passed).